### PR TITLE
Add build script for API service client packages

### DIFF
--- a/tasks/build/api-clients.sh
+++ b/tasks/build/api-clients.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#MISE description="Build TypeScript and Python client packages from the API service's OpenAPI spec"
+#USAGE flag "--log <log>" default="info" help="Log output" {
+#USAGE   choices "info" "debug" "trace"
+#USAGE }
+
+set -e -o pipefail
+
+source tasks/_common.sh
+
+log info "Building API client packages from OpenAPI spec (version: ${VERSION})"
+
+webapi_port=$(get_free_port)
+api_port=$(get_free_port)
+webui_port=$(get_free_port)
+docs_port=$(get_free_port)
+api_url=http://0.0.0.0:${api_port}
+
+log info "Starting Jupiter for API client build with api port $api_port"
+
+run_jupiter_webapp dev apigen "$webapi_port" "$api_port" "$webui_port" "$docs_port" wait:api no-monit ci local latest pm2
+
+log info "Extracting OpenAPI spec from API service"
+
+mkdir -p .build-cache/apigen
+rm -f .build-cache/apigen/api-openapi.json
+http --timeout 2 get "$api_url/openapi.json" > .build-cache/apigen/api-openapi.json
+
+log info "Stopping Jupiter for API client build"
+
+stop_jupiter_webapp apigen
+
+PACKAGE_NAME=api-client
+
+log info "Building TypeScript client package"
+
+mkdir -p ".build-cache/clients/${VERSION}/ts/${PACKAGE_NAME}/gen"
+
+npx openapi \
+    --input .build-cache/apigen/api-openapi.json \
+    --output ".build-cache/clients/${VERSION}/ts/${PACKAGE_NAME}/gen" \
+    --client fetch \
+    --name ApiClient
+
+log info "Building Python client package"
+
+python_generation_config=$(cat <<'EOF'
+project_name_override: jupiter_api_client
+package_name_override: jupiter_api_client
+EOF
+)
+
+echo "$python_generation_config" > config.yaml
+
+trap "rm -rf jupiter_api_client config.yaml" EXIT
+rm -rf ".build-cache/clients/${VERSION}/py/${PACKAGE_NAME}"
+uvx openapi-python-client generate --config config.yaml --path .build-cache/apigen/api-openapi.json --meta uv
+mv jupiter_api_client ".build-cache/clients/${VERSION}/py/${PACKAGE_NAME}"


### PR DESCRIPTION
## Summary
Adds a new build script (`tasks/build/api-clients.sh`) that generates TypeScript and Python client packages from the API service's OpenAPI specification.

## Changes
- New executable script that:
  - Starts Jupiter webapp in development mode for API generation
  - Extracts OpenAPI spec from the running API service
  - Generates TypeScript client using openapi CLI with fetch client
  - Generates Python client using openapi-python-client with uv package manager
  - Organizes built packages by version and language in `.build-cache/clients/`

## Usage
Script supports a `--log` flag with options: `info` (default), `debug`, `trace`