### PR TITLE
Add mise work:connect:redoc task for opening service Redoc pages

### DIFF
--- a/tasks/_common.sh
+++ b/tasks/_common.sh
@@ -583,6 +583,53 @@ get_webui_url_for_universe() {
     fi
 }
 
+get_service_url_for_universe() {
+    local universe=$1
+    local environment=$2
+    local instance=$3
+    local service=$4
+
+    if [[ "$universe" == "dev" ]]; then
+        if [[ "$environment" != "local" ]]; then
+            log error "Environment $environment is not supported for dev universe"
+            exit 1
+        fi
+        get_dev_service_url "$instance" "$service"
+        return 0
+    elif [[ "$universe" == "thrive-sh-test" ]]; then
+        if [[ "$environment" != "staging" ]]; then
+            log error "Environment $environment is not supported for thrive-sh-test universe"
+            exit 1
+        fi
+        if [[ "$service" == "webapi" ]]; then
+            echo "http://${instance}${THRIVE_SH_TEST_DOMAIN}:${WEBAPI_TESTING_PORT}"
+        else
+            log error "Service $service is not supported for thrive-sh-test universe"
+            exit 1
+        fi
+        return 0
+    elif [[ "$universe" == "thrive" ]]; then
+        if [[ "$environment" == "production" ]]; then
+            if [[ "$service" == "api" ]]; then
+                echo "$HOSTED_GLOBAL_API_URL"
+            else
+                log error "Service $service does not have a public production URL"
+                exit 1
+            fi
+            return 0
+        elif [[ "$environment" == "staging" ]]; then
+            echo "https://jupiter-${service}-${instance}.${GLOBAL_HOSTED_INFRA_ROOT}"
+            return 0
+        else
+            log error "Environment $environment is not supported for thrive universe"
+            exit 1
+        fi
+    else
+        log error "Unknown universe: $universe"
+        exit 1
+    fi
+}
+
 get_instance() {
     uvx codename -s '-'
 }

--- a/tasks/work/connect/redoc.sh
+++ b/tasks/work/connect/redoc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the Redoc page for a service"
+#USAGE flag "--universe <universe>" default="dev" help="Jupiter universe"
+#USAGE flag "--environment <environment>" default="local" help="Jupiter environment" {
+#USAGE   choices "production" "staging" "local"
+#USAGE }
+#USAGE flag "--instance <instance>" default="dev" help="Jupiter instance"
+#USAGE complete "instance" run="./tasks/run/instance/_list-fast.sh"
+#USAGE flag "--service <service>" default="webapi" help="The service whose Redoc page to open" {
+#USAGE   choices "webapi" "api"
+#USAGE }
+#USAGE flag "--log <log>" default="info" help="Log output" {
+#USAGE   choices "info" "debug" "trace"
+#USAGE }
+
+: "${usage_universe:=}"
+: "${usage_environment:=}"
+: "${usage_instance:=}"
+: "${usage_service:=}"
+
+set -e -o pipefail
+
+source tasks/_common.sh
+
+log info "Opening Redoc page for service $usage_service (universe: $usage_universe, environment: $usage_environment, instance: $usage_instance)"
+
+if [[ "$usage_universe" == "dev" ]]; then
+    if ! check_service_is_running pm2 "$usage_instance" "$usage_service"; then
+        log error "Service $usage_service is not running for instance: $usage_instance"
+        log error "Please start the service first with: mise run:srv"
+        exit 1
+    fi
+fi
+
+service_url=$(get_service_url_for_universe "$usage_universe" "$usage_environment" "$usage_instance" "$usage_service")
+
+open "${service_url}/redoc"


### PR DESCRIPTION
Adds tasks/work/connect/redoc.sh with --universe, --environment,
--instance, and --service flags, mirroring the run:web pattern.
Also adds get_service_url_for_universe() to _common.sh to resolve
service URLs across dev/thrive-sh-test/thrive universes.

https://claude.ai/code/session_01WTbZCMkDG5ND17phxKNXYY