### PR TITLE
Add Person entity with management UI for tracking entity-linked persons

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,158 @@
+# Plan: Common Person Entity
+
+## Overview
+Introduce a `Person` leaf-support entity under `common/sub/persons/`, mirroring the `Note` pattern exactly. Each person record has a human-readable `name`, a `namespace` (which entity type created it), and a `source_entity_ref_id` linking back to the originating entity. The management UI lists persons filterable by namespace; the detail page allows name update, archive, and remove — but **no create** from the UI.
+
+---
+
+## Files to Create
+
+### 1. `src/core/jupiter/core/common/sub/persons/__init__.py`
+Empty package init.
+
+### 2. `src/core/jupiter/core/common/sub/persons/namespace.py`
+`PersonNamespace` enum with values:
+- `PRM = "prm"`
+- `INBOX_TASK = "inbox-task"`
+- `BIG_PLAN = "big-plan"`
+- `SCHEDULE = "schedule"`
+- `HABIT = "habit"`
+- `CHORE = "chore"`
+- `SMART_LIST_ITEM = "smart-list-item"`
+- `METRIC_ENTRY = "metric-entry"`
+
+### 3. `src/core/jupiter/core/common/sub/persons/name.py`
+`PersonName(EntityName)` value type decorated with `@hashable_value`.
+
+### 4. `src/core/jupiter/core/common/sub/persons/collection.py`
+`PersonCollection(TrunkEntity)`:
+- `workspace: ParentLink`
+- `persons = ContainsMany(Person, person_collection_ref_id=IsRefId())`
+- `new_person_collection(ctx, workspace_ref_id)` static factory
+
+### 5. `src/core/jupiter/core/common/sub/persons/root.py`
+`Person(LeafSupportEntity)`:
+- `person_collection: ParentLink`
+- `namespace: PersonNamespace`
+- `source_entity_ref_id: EntityId`
+- `name: PersonName` (explicitly set, not auto-generated)
+- `new_person(ctx, person_collection_ref_id, namespace, source_entity_ref_id, name)` static factory
+- `update(ctx, name: UpdateAction[PersonName])` update action
+
+`PersonRepository(LeafEntityRepository[Person], ABC)`:
+- `load_for_source(namespace, source_entity_ref_id, allow_archived) -> Person`
+- `load_optional_for_source(namespace, source_entity_ref_id, allow_archived) -> Person | None`
+
+### 6. `src/core/jupiter/core/common/sub/persons/service/__init__.py`
+Empty.
+
+### 7. `src/core/jupiter/core/common/sub/persons/service/archive.py`
+`PersonArchiveService` with:
+- `archive(ctx, uow, person, archival_reason)` — marks person archived
+- `archive_for_source(ctx, uow, namespace, source_entity_ref_id, archival_reason)` — loads optional + archives
+
+### 8. `src/core/jupiter/core/common/sub/persons/service/remove.py`
+`PersonRemoveService` with:
+- `remove(ctx, uow, person)` — hard-deletes person
+
+### 9. `src/core/jupiter/core/common/sub/persons/use_case/__init__.py`
+Empty.
+
+### 10. `src/core/jupiter/core/common/sub/persons/use_case/create.py`
+`PersonCreateArgs(namespace, source_entity_ref_id, name)` → `PersonCreateResult(new_person)`
+`@mutation_use_case(exclude_component=[AppCore.CLI])`
+Loads `PersonCollection` from workspace, creates and saves person.
+
+### 11. `src/core/jupiter/core/common/sub/persons/use_case/load.py`
+`PersonLoadArgs(ref_id, allow_archived)` → `PersonLoadResult(person)`
+`@readonly_use_case(exclude_component=[AppCore.CLI])`
+
+### 12. `src/core/jupiter/core/common/sub/persons/use_case/find.py`
+`PersonFindArgs(allow_archived, filter_namespace, filter_ref_ids)` → `PersonFindResult(persons)`
+`@readonly_use_case(exclude_component=[AppCore.CLI])`
+Filters on namespace and ref_ids using `find_all_generic`.
+
+### 13. `src/core/jupiter/core/common/sub/persons/use_case/update.py`
+`PersonUpdateArgs(ref_id, name: UpdateAction[PersonName])` → `None`
+`@mutation_use_case(exclude_component=[AppCore.CLI])`
+
+### 14. `src/core/jupiter/core/common/sub/persons/use_case/archive.py`
+`PersonArchiveArgs(ref_id)` → `None`
+`@mutation_use_case(exclude_component=[AppCore.CLI])`
+Delegates to `PersonArchiveService`.
+
+### 15. `src/core/jupiter/core/common/sub/persons/use_case/remove.py`
+`PersonRemoveArgs(ref_id)` → `None`
+`@mutation_use_case(exclude_component=[AppCore.CLI])`
+Delegates to `PersonRemoveService`.
+
+### 16. `src/core/jupiter/core/common/sub/persons/impl/__init__.py`
+Empty.
+
+### 17. `src/core/jupiter/core/common/sub/persons/impl/repository.py`
+`SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepository)`:
+- `load_for_source` — SELECT where namespace=? AND source_entity_ref_id=? (raises if not found)
+- `load_optional_for_source` — same but returns `None`
+Pattern copied exactly from `SqliteNoteRepository`.
+
+### 18. `src/core/jupiter/core/common/sub/persons/namespace.ts`
+`personNamespaceName(namespace: PersonNamespace): string` — switch returning human names for each namespace value.
+
+### 19. `src/core/jupiter/core/common/sub/persons/component/person-namespace-tag.tsx`
+`PersonNamespaceTag({ namespace })` — renders a `SlimChip` with the namespace name. Same pattern as `NoteNamespaceTag`.
+
+### 20. `src/webui/app/routes/app/workspace/core/persons.tsx`
+Trunk route — calls `personFind({ allow_archived: false })`, shows list of persons sorted by namespace then name, filterable by namespace via `FilterManyOptions`. Shows `PersonNamespaceTag` per entry. No "New" button. Empty state message: "Persons are attached to entities and cannot be created independently."
+
+### 21. `src/webui/app/routes/app/workspace/core/persons/$id.tsx`
+Leaf route — calls `personLoad({ ref_id, allow_archived: true })`. Renders:
+- `EntitySummaryLink` showing the source entity (using a namespace→entity-tag mapping)
+- Editable name field (OutlinedInput)
+- Archive + Remove buttons (no create)
+Action handles `update`, `archive`, `remove` intents.
+
+---
+
+## Files to Modify
+
+### 22. `src/core/jupiter/core/workspaces/root.py`
+Add import of `PersonCollection` and:
+```python
+person_collection = ContainsOne(PersonCollection, workspace_ref_id=IsRefId())
+```
+
+### 23. `src/core/jupiter/core/application/use_case/init.py`
+Import `PersonCollection` and add initialization block (mirroring the `NoteCollection` block):
+```python
+new_person_collection = PersonCollection.new_person_collection(
+    ctx=context.domain_context,
+    workspace_ref_id=new_workspace.ref_id,
+)
+new_person_collection = await uow.get_for(PersonCollection).create(new_person_collection)
+```
+
+### 24. `src/core/jupiter/core/infra/component/sidebar.tsx`
+Add a new `<ListItem>` after the Notes entry in the "Core" section:
+```tsx
+<ListItem disablePadding>
+  <ListItemButton to="/app/workspace/core/persons" component={Link} onClick={onClickNavigation}>
+    <ListItemIcon>👤</ListItemIcon>
+    <ListItemText primary="Persons" />
+  </ListItemButton>
+</ListItem>
+```
+
+---
+
+## Framework Auto-Discovery
+No manual route registration is needed. `build_from_module_root(jupiter.core)` auto-discovers:
+- All `@entity` classes → schema codecs
+- All `SqliteLeafEntityRepository` subclasses → repository impls
+- All `@mutation_use_case` / `@readonly_use_case` classes → HTTP POST endpoints
+
+---
+
+## What is NOT included
+- No integration with existing PRM person, InboxTask, etc. to auto-create common persons — that is follow-up work when those entities are updated.
+- No "create" button in the management UI.
+- No `PersonLink` many-to-many join table (not needed per the spec).

--- a/src/core/jupiter/core/application/use_case/init.py
+++ b/src/core/jupiter/core/application/use_case/init.py
@@ -16,6 +16,7 @@ from jupiter.core.common.recurring_task_period import RecurringTaskPeriod
 from jupiter.core.common.sub.notes.collection import NoteCollection
 from jupiter.core.common.sub.notes.namespace import NoteNamespace
 from jupiter.core.common.sub.notes.root import Note
+from jupiter.core.common.sub.persons.root import PersonDomain
 from jupiter.core.common.sub.tags.root import TagDomain
 from jupiter.core.common.sub.time_events.domain import TimeEventDomain
 from jupiter.core.common.timezone import Timezone
@@ -462,6 +463,12 @@ class InitUseCase(JupiterGuestMutationUseCase[InitArgs, InitResult]):
                 workspace_ref_id=new_workspace.ref_id,
             )
             new_tag_domain = await uow.get_for(TagDomain).create(new_tag_domain)
+
+            new_person_domain = PersonDomain.new_person_domain(
+                ctx=context.domain_context,
+                workspace_ref_id=new_workspace.ref_id,
+            )
+            await uow.get_for(PersonDomain).create(new_person_domain)
 
             new_gc_log = GCLog.new_gc_log(
                 ctx=context.domain_context,

--- a/src/core/jupiter/core/common/sub/persons/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/__init__.py
@@ -1,0 +1,1 @@
+"""Common persons sub-domain."""

--- a/src/core/jupiter/core/common/sub/persons/component/person-namespace-tag.tsx
+++ b/src/core/jupiter/core/common/sub/persons/component/person-namespace-tag.tsx
@@ -1,0 +1,14 @@
+import { PersonNamespace } from "@jupiter/webapi-client";
+
+import { personNamespaceName } from "#/core/common/sub/persons/namespace";
+import { SlimChip } from "#/core/infra/component/chips";
+
+interface PersonNamespaceTagProps {
+  namespace: PersonNamespace;
+}
+
+export function PersonNamespaceTag(props: PersonNamespaceTagProps) {
+  return (
+    <SlimChip label={personNamespaceName(props.namespace)} color="default" />
+  );
+}

--- a/src/core/jupiter/core/common/sub/persons/impl/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/impl/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite implementations of person repositories."""

--- a/src/core/jupiter/core/common/sub/persons/impl/repository.py
+++ b/src/core/jupiter/core/common/sub/persons/impl/repository.py
@@ -1,14 +1,14 @@
-"""SQLite implementations of common persons repositories."""
+"""SQLite implementations of persons repositories."""
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
 from jupiter.core.common.sub.persons.sub.link.root import (
-    CommonPersonLink,
-    CommonPersonLinkRepository,
+    PersonLink,
+    PersonLinkRepository,
 )
 from jupiter.core.common.sub.persons.sub.person.root import (
-    CommonPerson,
-    CommonPersonAlreadyExistsError,
-    CommonPersonRepository,
+    Person,
+    PersonAlreadyExistsError,
+    PersonRepository,
 )
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.realm.realm import RealmCodecRegistry
@@ -18,10 +18,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 
-class SqliteCommonPersonRepository(
-    SqliteLeafEntityRepository[CommonPerson], CommonPersonRepository
-):
-    """SQLite implementation of the common person repository."""
+class SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepository):
+    """SQLite implementation of the person repository."""
 
     def __init__(
         self,
@@ -34,11 +32,11 @@ class SqliteCommonPersonRepository(
             realm_codec_registry,
             connection,
             metadata,
-            already_exists_err_cls=CommonPersonAlreadyExistsError,
+            already_exists_err_cls=PersonAlreadyExistsError,
         )
 
-    async def upsert(self, person: CommonPerson) -> CommonPerson:
-        """Upsert a common person for a namespace and name."""
+    async def upsert(self, person: Person) -> Person:
+        """Upsert a person for a namespace and name."""
         stmt = (
             sqlite_insert(self._table)
             .values(
@@ -79,13 +77,13 @@ class SqliteCommonPersonRepository(
         return person.assign_ref_id(EntityId(new_id))
 
 
-class SqliteCommonPersonLinkRepository(
-    SqliteLeafEntityRepository[CommonPersonLink], CommonPersonLinkRepository
+class SqlitePersonLinkRepository(
+    SqliteLeafEntityRepository[PersonLink], PersonLinkRepository
 ):
-    """SQLite implementation of the common person link repository."""
+    """SQLite implementation of the person link repository."""
 
-    async def upsert(self, person_link: CommonPersonLink) -> CommonPersonLink:
-        """Upsert a common person link."""
+    async def upsert(self, person_link: PersonLink) -> PersonLink:
+        """Upsert a person link."""
         stmt = (
             sqlite_insert(self._table)
             .values(
@@ -138,8 +136,8 @@ class SqliteCommonPersonLinkRepository(
         self,
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
-    ) -> CommonPersonLink | None:
-        """Load a common person link by its namespace and source entity reference ID."""
+    ) -> PersonLink | None:
+        """Load a person link by its namespace and source entity reference ID."""
         query_stmt = (
             select(self._table)
             .where(self._table.c.namespace == namespace.value)

--- a/src/core/jupiter/core/common/sub/persons/impl/repository.py
+++ b/src/core/jupiter/core/common/sub/persons/impl/repository.py
@@ -1,0 +1,151 @@
+"""SQLite implementations of persons repositories."""
+
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.sub.link.root import (
+    PersonLink,
+    PersonLinkRepository,
+)
+from jupiter.core.common.sub.persons.sub.person.root import (
+    Person,
+    PersonAlreadyExistsError,
+    PersonRepository,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.realm.realm import RealmCodecRegistry
+from jupiter.framework.storage.sqlite.repository import SqliteLeafEntityRepository
+from sqlalchemy import MetaData, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+class SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepository):
+    """SQLite implementation of the person repository."""
+
+    def __init__(
+        self,
+        realm_codec_registry: RealmCodecRegistry,
+        connection: AsyncConnection,
+        metadata: MetaData,
+    ) -> None:
+        """Constructor."""
+        super().__init__(
+            realm_codec_registry,
+            connection,
+            metadata,
+            already_exists_err_cls=PersonAlreadyExistsError,
+        )
+
+    async def upsert(self, person: Person) -> Person:
+        """Upsert a person for a namespace and name."""
+        stmt = (
+            sqlite_insert(self._table)
+            .values(
+                version=person.version,
+                archived=person.archived,
+                archival_reason=person.archival_reason,
+                created_time=self._realm_codec_registry.db_encode(person.created_time),
+                last_modified_time=self._realm_codec_registry.db_encode(
+                    person.last_modified_time
+                ),
+                archived_time=self._realm_codec_registry.db_encode(
+                    person.archived_time
+                ),
+                person_domain_ref_id=person.person_domain.ref_id.as_int(),
+                namespace=person.namespace.value,
+                name=person.name.the_name,
+            )
+            .on_conflict_do_update(
+                index_elements=["person_domain_ref_id", "namespace", "name"],
+                set_={
+                    "version": person.version,
+                    "archived": person.archived,
+                    "archival_reason": person.archival_reason,
+                    "last_modified_time": self._realm_codec_registry.db_encode(
+                        person.last_modified_time
+                    ),
+                    "archived_time": self._realm_codec_registry.db_encode(
+                        person.archived_time
+                    ),
+                },
+            )
+            .returning(self._table.c.ref_id)
+        )
+
+        result = await self._connection.execute(stmt)
+        new_id = result.scalar_one()
+
+        return person.assign_ref_id(EntityId(new_id))
+
+
+class SqlitePersonLinkRepository(
+    SqliteLeafEntityRepository[PersonLink], PersonLinkRepository
+):
+    """SQLite implementation of the person link repository."""
+
+    async def upsert(self, person_link: PersonLink) -> PersonLink:
+        """Upsert a person link."""
+        stmt = (
+            sqlite_insert(self._table)
+            .values(
+                version=person_link.version,
+                archived=person_link.archived,
+                archival_reason=person_link.archival_reason,
+                created_time=self._realm_codec_registry.db_encode(
+                    person_link.created_time
+                ),
+                last_modified_time=self._realm_codec_registry.db_encode(
+                    person_link.last_modified_time
+                ),
+                archived_time=self._realm_codec_registry.db_encode(
+                    person_link.archived_time
+                ),
+                name=person_link.name.the_name,
+                person_domain_ref_id=person_link.person_domain.ref_id.as_int(),
+                namespace=person_link.namespace.value,
+                source_entity_ref_id=person_link.source_entity_ref_id.as_int(),
+                ref_ids=[rid.as_int() for rid in person_link.ref_ids],
+            )
+            .on_conflict_do_update(
+                index_elements=[
+                    "person_domain_ref_id",
+                    "namespace",
+                    "source_entity_ref_id",
+                ],
+                set_={
+                    "version": person_link.version,
+                    "archived": person_link.archived,
+                    "archival_reason": person_link.archival_reason,
+                    "last_modified_time": self._realm_codec_registry.db_encode(
+                        person_link.last_modified_time
+                    ),
+                    "archived_time": self._realm_codec_registry.db_encode(
+                        person_link.archived_time
+                    ),
+                    "ref_ids": [rid.as_int() for rid in person_link.ref_ids],
+                },
+            )
+            .returning(self._table.c.ref_id)
+        )
+
+        result = await self._connection.execute(stmt)
+        new_id = result.scalar_one()
+
+        return person_link.assign_ref_id(EntityId(new_id))
+
+    async def load_optional_for_namespace_and_source(
+        self,
+        namespace: PersonNamespace,
+        source_entity_ref_id: EntityId,
+    ) -> PersonLink | None:
+        """Load a person link by its namespace and source entity reference ID."""
+        query_stmt = (
+            select(self._table)
+            .where(self._table.c.namespace == namespace.value)
+            .where(
+                self._table.c.source_entity_ref_id == source_entity_ref_id.as_int()
+            )
+        )
+        result = (await self._connection.execute(query_stmt)).first()
+        if result is None:
+            return None
+        return self._row_to_entity(result)

--- a/src/core/jupiter/core/common/sub/persons/impl/repository.py
+++ b/src/core/jupiter/core/common/sub/persons/impl/repository.py
@@ -1,14 +1,14 @@
-"""SQLite implementations of persons repositories."""
+"""SQLite implementations of common persons repositories."""
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
 from jupiter.core.common.sub.persons.sub.link.root import (
-    PersonLink,
-    PersonLinkRepository,
+    CommonPersonLink,
+    CommonPersonLinkRepository,
 )
 from jupiter.core.common.sub.persons.sub.person.root import (
-    Person,
-    PersonAlreadyExistsError,
-    PersonRepository,
+    CommonPerson,
+    CommonPersonAlreadyExistsError,
+    CommonPersonRepository,
 )
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.realm.realm import RealmCodecRegistry
@@ -18,8 +18,10 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 
-class SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepository):
-    """SQLite implementation of the person repository."""
+class SqliteCommonPersonRepository(
+    SqliteLeafEntityRepository[CommonPerson], CommonPersonRepository
+):
+    """SQLite implementation of the common person repository."""
 
     def __init__(
         self,
@@ -32,11 +34,11 @@ class SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepositor
             realm_codec_registry,
             connection,
             metadata,
-            already_exists_err_cls=PersonAlreadyExistsError,
+            already_exists_err_cls=CommonPersonAlreadyExistsError,
         )
 
-    async def upsert(self, person: Person) -> Person:
-        """Upsert a person for a namespace and name."""
+    async def upsert(self, person: CommonPerson) -> CommonPerson:
+        """Upsert a common person for a namespace and name."""
         stmt = (
             sqlite_insert(self._table)
             .values(
@@ -77,13 +79,13 @@ class SqlitePersonRepository(SqliteLeafEntityRepository[Person], PersonRepositor
         return person.assign_ref_id(EntityId(new_id))
 
 
-class SqlitePersonLinkRepository(
-    SqliteLeafEntityRepository[PersonLink], PersonLinkRepository
+class SqliteCommonPersonLinkRepository(
+    SqliteLeafEntityRepository[CommonPersonLink], CommonPersonLinkRepository
 ):
-    """SQLite implementation of the person link repository."""
+    """SQLite implementation of the common person link repository."""
 
-    async def upsert(self, person_link: PersonLink) -> PersonLink:
-        """Upsert a person link."""
+    async def upsert(self, person_link: CommonPersonLink) -> CommonPersonLink:
+        """Upsert a common person link."""
         stmt = (
             sqlite_insert(self._table)
             .values(
@@ -136,8 +138,8 @@ class SqlitePersonLinkRepository(
         self,
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
-    ) -> PersonLink | None:
-        """Load a person link by its namespace and source entity reference ID."""
+    ) -> CommonPersonLink | None:
+        """Load a common person link by its namespace and source entity reference ID."""
         query_stmt = (
             select(self._table)
             .where(self._table.c.namespace == namespace.value)

--- a/src/core/jupiter/core/common/sub/persons/namespace.py
+++ b/src/core/jupiter/core/common/sub/persons/namespace.py
@@ -1,0 +1,17 @@
+"""The namespace of a person link."""
+
+from jupiter.framework.value import EnumValue, enum_value
+
+
+@enum_value
+class PersonNamespace(EnumValue):
+    """The namespace of a person link."""
+
+    PRM = "prm"
+    INBOX_TASK = "inbox-task"
+    BIG_PLAN = "big-plan"
+    SCHEDULE = "schedule"
+    HABIT = "habit"
+    CHORE = "chore"
+    SMART_LIST_ITEM = "smart-list-item"
+    METRIC_ENTRY = "metric-entry"

--- a/src/core/jupiter/core/common/sub/persons/namespace.ts
+++ b/src/core/jupiter/core/common/sub/persons/namespace.ts
@@ -1,0 +1,22 @@
+import { PersonNamespace } from "@jupiter/webapi-client";
+
+export function personNamespaceName(namespace: PersonNamespace): string {
+  switch (namespace) {
+    case PersonNamespace.PRM:
+      return "PRM";
+    case PersonNamespace.INBOX_TASK:
+      return "Inbox Task";
+    case PersonNamespace.BIG_PLAN:
+      return "Big Plan";
+    case PersonNamespace.SCHEDULE:
+      return "Schedule";
+    case PersonNamespace.HABIT:
+      return "Habit";
+    case PersonNamespace.CHORE:
+      return "Chore";
+    case PersonNamespace.SMART_LIST_ITEM:
+      return "Smart List Item";
+    case PersonNamespace.METRIC_ENTRY:
+      return "Metric Entry";
+  }
+}

--- a/src/core/jupiter/core/common/sub/persons/root.py
+++ b/src/core/jupiter/core/common/sub/persons/root.py
@@ -1,7 +1,7 @@
 """The person domain."""
 
-from jupiter.core.common.sub.persons.sub.link.root import CommonPersonLink
-from jupiter.core.common.sub.persons.sub.person.root import CommonPerson
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink
+from jupiter.core.common.sub.persons.sub.person.root import Person
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.context import MutationContext
 from jupiter.framework.entity import (
@@ -19,8 +19,8 @@ class PersonDomain(TrunkEntity):
 
     workspace: ParentLink
 
-    persons = ContainsMany(CommonPerson, person_domain_ref_id=IsRefId())
-    links = ContainsMany(CommonPersonLink, person_domain_ref_id=IsRefId())
+    persons = ContainsMany(Person, person_domain_ref_id=IsRefId())
+    links = ContainsMany(PersonLink, person_domain_ref_id=IsRefId())
 
     @staticmethod
     def new_person_domain(

--- a/src/core/jupiter/core/common/sub/persons/root.py
+++ b/src/core/jupiter/core/common/sub/persons/root.py
@@ -1,7 +1,7 @@
 """The person domain."""
 
-from jupiter.core.common.sub.persons.sub.link.root import PersonLink
-from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.common.sub.persons.sub.link.root import CommonPersonLink
+from jupiter.core.common.sub.persons.sub.person.root import CommonPerson
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.context import MutationContext
 from jupiter.framework.entity import (
@@ -19,8 +19,8 @@ class PersonDomain(TrunkEntity):
 
     workspace: ParentLink
 
-    persons = ContainsMany(Person, person_domain_ref_id=IsRefId())
-    links = ContainsMany(PersonLink, person_domain_ref_id=IsRefId())
+    persons = ContainsMany(CommonPerson, person_domain_ref_id=IsRefId())
+    links = ContainsMany(CommonPersonLink, person_domain_ref_id=IsRefId())
 
     @staticmethod
     def new_person_domain(

--- a/src/core/jupiter/core/common/sub/persons/root.py
+++ b/src/core/jupiter/core/common/sub/persons/root.py
@@ -1,0 +1,31 @@
+"""The person domain."""
+
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.context import MutationContext
+from jupiter.framework.entity import (
+    ContainsMany,
+    IsRefId,
+    ParentLink,
+    TrunkEntity,
+    entity,
+)
+
+
+@entity
+class PersonDomain(TrunkEntity):
+    """Person domain trunk entity."""
+
+    workspace: ParentLink
+
+    persons = ContainsMany(Person, person_domain_ref_id=IsRefId())
+    links = ContainsMany(PersonLink, person_domain_ref_id=IsRefId())
+
+    @staticmethod
+    def new_person_domain(
+        ctx: MutationContext,
+        workspace_ref_id: EntityId,
+    ) -> "PersonDomain":
+        """Create a person domain."""
+        return PersonDomain._create(ctx, workspace=ParentLink(workspace_ref_id))

--- a/src/core/jupiter/core/common/sub/persons/sub/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/__init__.py
@@ -1,0 +1,1 @@
+"""Common persons sub-sub-domain."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/__init__.py
@@ -1,0 +1,1 @@
+"""Common person link entity."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/root.py
@@ -1,9 +1,9 @@
-"""A link between an entity and its common persons."""
+"""A link between an entity and its persons."""
 
 import abc
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
-from jupiter.core.common.sub.persons.sub.person.root import CommonPerson
+from jupiter.core.common.sub.persons.sub.person.root import Person
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.base.entity_name import NOT_USED_NAME
 from jupiter.framework.context import MutationContext
@@ -21,8 +21,8 @@ from jupiter.framework.update_action import UpdateAction
 
 
 @entity
-class CommonPersonLink(LeafSupportEntity):
-    """A link between an entity and its common persons."""
+class PersonLink(LeafSupportEntity):
+    """A link between an entity and its persons."""
 
     person_domain: ParentLink
 
@@ -30,7 +30,7 @@ class CommonPersonLink(LeafSupportEntity):
     source_entity_ref_id: EntityId
     ref_ids: list[EntityId]
 
-    persons = RefsMany(CommonPerson, ref_id=IsOneOfRefId("ref_ids"))
+    persons = RefsMany(Person, ref_id=IsOneOfRefId("ref_ids"))
 
     @staticmethod
     @create_entity_action
@@ -40,9 +40,9 @@ class CommonPersonLink(LeafSupportEntity):
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
         ref_ids: list[EntityId],
-    ) -> "CommonPersonLink":
-        """Create a new common person link."""
-        return CommonPersonLink._create(
+    ) -> "PersonLink":
+        """Create a new person link."""
+        return PersonLink._create(
             ctx,
             name=NOT_USED_NAME,
             person_domain=ParentLink(person_domain_ref_id),
@@ -56,8 +56,8 @@ class CommonPersonLink(LeafSupportEntity):
         self,
         ctx: MutationContext,
         ref_ids: UpdateAction[list[EntityId]],
-    ) -> "CommonPersonLink":
-        """Update the common person link."""
+    ) -> "PersonLink":
+        """Update the person link."""
         return self._new_version(
             ctx,
             name=NOT_USED_NAME,
@@ -65,17 +65,17 @@ class CommonPersonLink(LeafSupportEntity):
         )
 
 
-class CommonPersonLinkRepository(LeafEntityRepository[CommonPersonLink], abc.ABC):
-    """The repository for common person links."""
+class PersonLinkRepository(LeafEntityRepository[PersonLink], abc.ABC):
+    """The repository for person links."""
 
     @abc.abstractmethod
-    async def upsert(self, person_link: CommonPersonLink) -> CommonPersonLink:
-        """Upsert a common person link."""
+    async def upsert(self, person_link: PersonLink) -> PersonLink:
+        """Upsert a person link."""
 
     @abc.abstractmethod
     async def load_optional_for_namespace_and_source(
         self,
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
-    ) -> CommonPersonLink | None:
-        """Load a common person link by its namespace and source entity reference ID."""
+    ) -> PersonLink | None:
+        """Load a person link by its namespace and source entity reference ID."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/root.py
@@ -1,0 +1,81 @@
+"""A link between an entity and its persons."""
+
+import abc
+
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_name import NOT_USED_NAME
+from jupiter.framework.context import MutationContext
+from jupiter.framework.entity import (
+    IsOneOfRefId,
+    LeafSupportEntity,
+    ParentLink,
+    RefsMany,
+    create_entity_action,
+    entity,
+    update_entity_action,
+)
+from jupiter.framework.storage.repository import LeafEntityRepository
+from jupiter.framework.update_action import UpdateAction
+
+
+@entity
+class PersonLink(LeafSupportEntity):
+    """A link between an entity and its persons."""
+
+    person_domain: ParentLink
+
+    namespace: PersonNamespace
+    source_entity_ref_id: EntityId
+    ref_ids: list[EntityId]
+
+    persons = RefsMany(Person, ref_id=IsOneOfRefId("ref_ids"))
+
+    @staticmethod
+    @create_entity_action
+    def new_person_link(
+        ctx: MutationContext,
+        person_domain_ref_id: EntityId,
+        namespace: PersonNamespace,
+        source_entity_ref_id: EntityId,
+        ref_ids: list[EntityId],
+    ) -> "PersonLink":
+        """Create a new person link."""
+        return PersonLink._create(
+            ctx,
+            name=NOT_USED_NAME,
+            person_domain=ParentLink(person_domain_ref_id),
+            namespace=namespace,
+            source_entity_ref_id=source_entity_ref_id,
+            ref_ids=ref_ids,
+        )
+
+    @update_entity_action
+    def update(
+        self,
+        ctx: MutationContext,
+        ref_ids: UpdateAction[list[EntityId]],
+    ) -> "PersonLink":
+        """Update the person link."""
+        return self._new_version(
+            ctx,
+            name=NOT_USED_NAME,
+            ref_ids=ref_ids.or_else(self.ref_ids),
+        )
+
+
+class PersonLinkRepository(LeafEntityRepository[PersonLink], abc.ABC):
+    """The repository for person links."""
+
+    @abc.abstractmethod
+    async def upsert(self, person_link: PersonLink) -> PersonLink:
+        """Upsert a person link."""
+
+    @abc.abstractmethod
+    async def load_optional_for_namespace_and_source(
+        self,
+        namespace: PersonNamespace,
+        source_entity_ref_id: EntityId,
+    ) -> PersonLink | None:
+        """Load a person link by its namespace and source entity reference ID."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/root.py
@@ -1,9 +1,9 @@
-"""A link between an entity and its persons."""
+"""A link between an entity and its common persons."""
 
 import abc
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
-from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.common.sub.persons.sub.person.root import CommonPerson
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.base.entity_name import NOT_USED_NAME
 from jupiter.framework.context import MutationContext
@@ -21,8 +21,8 @@ from jupiter.framework.update_action import UpdateAction
 
 
 @entity
-class PersonLink(LeafSupportEntity):
-    """A link between an entity and its persons."""
+class CommonPersonLink(LeafSupportEntity):
+    """A link between an entity and its common persons."""
 
     person_domain: ParentLink
 
@@ -30,7 +30,7 @@ class PersonLink(LeafSupportEntity):
     source_entity_ref_id: EntityId
     ref_ids: list[EntityId]
 
-    persons = RefsMany(Person, ref_id=IsOneOfRefId("ref_ids"))
+    persons = RefsMany(CommonPerson, ref_id=IsOneOfRefId("ref_ids"))
 
     @staticmethod
     @create_entity_action
@@ -40,9 +40,9 @@ class PersonLink(LeafSupportEntity):
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
         ref_ids: list[EntityId],
-    ) -> "PersonLink":
-        """Create a new person link."""
-        return PersonLink._create(
+    ) -> "CommonPersonLink":
+        """Create a new common person link."""
+        return CommonPersonLink._create(
             ctx,
             name=NOT_USED_NAME,
             person_domain=ParentLink(person_domain_ref_id),
@@ -56,8 +56,8 @@ class PersonLink(LeafSupportEntity):
         self,
         ctx: MutationContext,
         ref_ids: UpdateAction[list[EntityId]],
-    ) -> "PersonLink":
-        """Update the person link."""
+    ) -> "CommonPersonLink":
+        """Update the common person link."""
         return self._new_version(
             ctx,
             name=NOT_USED_NAME,
@@ -65,17 +65,17 @@ class PersonLink(LeafSupportEntity):
         )
 
 
-class PersonLinkRepository(LeafEntityRepository[PersonLink], abc.ABC):
-    """The repository for person links."""
+class CommonPersonLinkRepository(LeafEntityRepository[CommonPersonLink], abc.ABC):
+    """The repository for common person links."""
 
     @abc.abstractmethod
-    async def upsert(self, person_link: PersonLink) -> PersonLink:
-        """Upsert a person link."""
+    async def upsert(self, person_link: CommonPersonLink) -> CommonPersonLink:
+        """Upsert a common person link."""
 
     @abc.abstractmethod
     async def load_optional_for_namespace_and_source(
         self,
         namespace: PersonNamespace,
         source_entity_ref_id: EntityId,
-    ) -> PersonLink | None:
-        """Load a person link by its namespace and source entity reference ID."""
+    ) -> CommonPersonLink | None:
+        """Load a common person link by its namespace and source entity reference ID."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/service/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/service/__init__.py
@@ -1,0 +1,1 @@
+"""Common person link services."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/service/archive.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/service/archive.py
@@ -1,0 +1,34 @@
+"""Shared service for archiving a person link."""
+
+from jupiter.core.archival_reason import JupiterArchivalReason
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink, PersonLinkRepository
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.context import MutationContext
+from jupiter.framework.storage.repository import DomainUnitOfWork
+
+
+class PersonLinkArchiveService:
+    """A service for archiving a person link."""
+
+    async def archive_for_entity(
+        self,
+        ctx: MutationContext,
+        uow: DomainUnitOfWork,
+        namespace: PersonNamespace,
+        source_entity_ref_id: EntityId,
+        archival_reason: JupiterArchivalReason,
+    ) -> None:
+        """Archive a person link for an entity."""
+        person_link = await uow.get(
+            PersonLinkRepository
+        ).load_optional_for_namespace_and_source(
+            namespace=namespace,
+            source_entity_ref_id=source_entity_ref_id,
+        )
+        if person_link is None:
+            return
+        if person_link.archived:
+            return
+        person_link = person_link.mark_archived(ctx, archival_reason)
+        await uow.get_for(PersonLink).save(person_link)

--- a/src/core/jupiter/core/common/sub/persons/sub/link/service/remove.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/service/remove.py
@@ -1,0 +1,29 @@
+"""Shared service for removing a person link."""
+
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink, PersonLinkRepository
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.context import MutationContext
+from jupiter.framework.storage.repository import DomainUnitOfWork
+
+
+class PersonLinkRemoveService:
+    """A service for removing a person link."""
+
+    async def remove_for_entity(
+        self,
+        ctx: MutationContext,
+        uow: DomainUnitOfWork,
+        namespace: PersonNamespace,
+        source_entity_ref_id: EntityId,
+    ) -> None:
+        """Remove a person link."""
+        person_link = await uow.get(
+            PersonLinkRepository
+        ).load_optional_for_namespace_and_source(
+            namespace=namespace,
+            source_entity_ref_id=source_entity_ref_id,
+        )
+        if person_link is None:
+            return
+        await uow.get_for(PersonLink).remove(person_link.ref_id)

--- a/src/core/jupiter/core/common/sub/persons/sub/link/use_case/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/use_case/__init__.py
@@ -1,0 +1,1 @@
+"""Common person link use cases."""

--- a/src/core/jupiter/core/common/sub/persons/sub/link/use_case/upsert.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/link/use_case/upsert.py
@@ -1,0 +1,81 @@
+"""Use case for upserting a person link."""
+
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.root import PersonDomain
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink, PersonLinkRepository
+from jupiter.core.common.sub.persons.sub.person.name import PersonName
+from jupiter.core.common.sub.persons.sub.person.root import Person, PersonRepository
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+    JupiterTransactionalLoggedInMutationUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import mutation_use_case
+from jupiter.framework.use_case_io import (
+    UseCaseArgsBase,
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class PersonLinkUpsertArgs(UseCaseArgsBase):
+    """PersonLinkUpsert args."""
+
+    namespace: PersonNamespace
+    source_entity_ref_id: EntityId
+    person_names: set[PersonName]
+
+
+@use_case_result
+class PersonLinkUpsertResult(UseCaseResultBase):
+    """PersonLinkUpsert result."""
+
+    person_link: PersonLink
+
+
+@mutation_use_case()
+class PersonLinkUpsertUseCase(
+    JupiterTransactionalLoggedInMutationUseCase[
+        PersonLinkUpsertArgs, PersonLinkUpsertResult
+    ]
+):
+    """Use case for upserting a person link."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: PersonLinkUpsertArgs,
+    ) -> PersonLinkUpsertResult:
+        """Execute the command's action."""
+        workspace = context.workspace
+        person_domain = await uow.get_for(PersonDomain).load_by_parent(
+            workspace.ref_id
+        )
+
+        person_ref_ids = []
+        for person_name in set(args.person_names):
+            person = Person.new_person(
+                ctx=context.domain_context,
+                person_domain_ref_id=person_domain.ref_id,
+                namespace=args.namespace,
+                name=person_name,
+            )
+            person = await uow.get(PersonRepository).upsert(person)
+            person_ref_ids.append(person.ref_id)
+
+        person_link = PersonLink.new_person_link(
+            ctx=context.domain_context,
+            person_domain_ref_id=person_domain.ref_id,
+            namespace=args.namespace,
+            source_entity_ref_id=args.source_entity_ref_id,
+            ref_ids=person_ref_ids,
+        )
+        person_link = await uow.get(PersonLinkRepository).upsert(person_link)
+
+        return PersonLinkUpsertResult(person_link=person_link)

--- a/src/core/jupiter/core/common/sub/persons/sub/person/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/__init__.py
@@ -1,0 +1,1 @@
+"""Common person entity."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/name.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/name.py
@@ -1,0 +1,9 @@
+"""The person name."""
+
+from jupiter.framework.base.entity_name import EntityName
+from jupiter.framework.value import hashable_value
+
+
+@hashable_value
+class PersonName(EntityName):
+    """The person name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/name.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/name.py
@@ -1,9 +1,9 @@
-"""The person name."""
+"""The common person name."""
 
 from jupiter.framework.base.entity_name import EntityName
 from jupiter.framework.value import hashable_value
 
 
 @hashable_value
-class PersonName(EntityName):
-    """The person name."""
+class CommonPersonName(EntityName):
+    """The common person name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/name.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/name.py
@@ -1,9 +1,9 @@
-"""The common person name."""
+"""The person name."""
 
 from jupiter.framework.base.entity_name import EntityName
 from jupiter.framework.value import hashable_value
 
 
 @hashable_value
-class CommonPersonName(EntityName):
-    """The common person name."""
+class PersonName(EntityName):
+    """The person name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/root.py
@@ -1,9 +1,9 @@
-"""A common person."""
+"""A person."""
 
 import abc
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
-from jupiter.core.common.sub.persons.sub.person.name import CommonPersonName
+from jupiter.core.common.sub.persons.sub.person.name import PersonName
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.context import MutationContext
 from jupiter.framework.entity import (
@@ -20,17 +20,17 @@ from jupiter.framework.storage.repository import (
 from jupiter.framework.update_action import UpdateAction
 
 
-class CommonPersonAlreadyExistsError(EntityAlreadyExistsError):
-    """Error raised when a common person already exists."""
+class PersonAlreadyExistsError(EntityAlreadyExistsError):
+    """Error raised when a person already exists."""
 
 
 @entity
-class CommonPerson(LeafSupportEntity):
-    """A common person."""
+class Person(LeafSupportEntity):
+    """A person."""
 
     person_domain: ParentLink
     namespace: PersonNamespace
-    name: CommonPersonName
+    name: PersonName
 
     @staticmethod
     @create_entity_action
@@ -38,10 +38,10 @@ class CommonPerson(LeafSupportEntity):
         ctx: MutationContext,
         person_domain_ref_id: EntityId,
         namespace: PersonNamespace,
-        name: CommonPersonName,
-    ) -> "CommonPerson":
-        """Create a common person."""
-        return CommonPerson._create(
+        name: PersonName,
+    ) -> "Person":
+        """Create a person."""
+        return Person._create(
             ctx,
             person_domain=ParentLink(person_domain_ref_id),
             namespace=namespace,
@@ -52,18 +52,18 @@ class CommonPerson(LeafSupportEntity):
     def update(
         self,
         ctx: MutationContext,
-        name: UpdateAction[CommonPersonName],
-    ) -> "CommonPerson":
-        """Update the common person."""
+        name: UpdateAction[PersonName],
+    ) -> "Person":
+        """Update the person."""
         return self._new_version(
             ctx,
             name=name.or_else(self.name),
         )
 
 
-class CommonPersonRepository(LeafEntityRepository[CommonPerson], abc.ABC):
-    """The repository for common persons."""
+class PersonRepository(LeafEntityRepository[Person], abc.ABC):
+    """The repository for persons."""
 
     @abc.abstractmethod
-    async def upsert(self, person: CommonPerson) -> CommonPerson:
-        """Upsert a common person for a namespace and name."""
+    async def upsert(self, person: Person) -> Person:
+        """Upsert a person for a namespace and name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/root.py
@@ -1,9 +1,9 @@
-"""A person."""
+"""A common person."""
 
 import abc
 
 from jupiter.core.common.sub.persons.namespace import PersonNamespace
-from jupiter.core.common.sub.persons.sub.person.name import PersonName
+from jupiter.core.common.sub.persons.sub.person.name import CommonPersonName
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.context import MutationContext
 from jupiter.framework.entity import (
@@ -20,17 +20,17 @@ from jupiter.framework.storage.repository import (
 from jupiter.framework.update_action import UpdateAction
 
 
-class PersonAlreadyExistsError(EntityAlreadyExistsError):
-    """Error raised when a person already exists."""
+class CommonPersonAlreadyExistsError(EntityAlreadyExistsError):
+    """Error raised when a common person already exists."""
 
 
 @entity
-class Person(LeafSupportEntity):
-    """A person."""
+class CommonPerson(LeafSupportEntity):
+    """A common person."""
 
     person_domain: ParentLink
     namespace: PersonNamespace
-    name: PersonName
+    name: CommonPersonName
 
     @staticmethod
     @create_entity_action
@@ -38,10 +38,10 @@ class Person(LeafSupportEntity):
         ctx: MutationContext,
         person_domain_ref_id: EntityId,
         namespace: PersonNamespace,
-        name: PersonName,
-    ) -> "Person":
-        """Create a person."""
-        return Person._create(
+        name: CommonPersonName,
+    ) -> "CommonPerson":
+        """Create a common person."""
+        return CommonPerson._create(
             ctx,
             person_domain=ParentLink(person_domain_ref_id),
             namespace=namespace,
@@ -52,18 +52,18 @@ class Person(LeafSupportEntity):
     def update(
         self,
         ctx: MutationContext,
-        name: UpdateAction[PersonName],
-    ) -> "Person":
-        """Update the person."""
+        name: UpdateAction[CommonPersonName],
+    ) -> "CommonPerson":
+        """Update the common person."""
         return self._new_version(
             ctx,
             name=name.or_else(self.name),
         )
 
 
-class PersonRepository(LeafEntityRepository[Person], abc.ABC):
-    """The repository for persons."""
+class CommonPersonRepository(LeafEntityRepository[CommonPerson], abc.ABC):
+    """The repository for common persons."""
 
     @abc.abstractmethod
-    async def upsert(self, person: Person) -> Person:
-        """Upsert a person for a namespace and name."""
+    async def upsert(self, person: CommonPerson) -> CommonPerson:
+        """Upsert a common person for a namespace and name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/root.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/root.py
@@ -1,0 +1,69 @@
+"""A person."""
+
+import abc
+
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.sub.person.name import PersonName
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.context import MutationContext
+from jupiter.framework.entity import (
+    LeafSupportEntity,
+    ParentLink,
+    create_entity_action,
+    entity,
+    update_entity_action,
+)
+from jupiter.framework.storage.repository import (
+    EntityAlreadyExistsError,
+    LeafEntityRepository,
+)
+from jupiter.framework.update_action import UpdateAction
+
+
+class PersonAlreadyExistsError(EntityAlreadyExistsError):
+    """Error raised when a person already exists."""
+
+
+@entity
+class Person(LeafSupportEntity):
+    """A person."""
+
+    person_domain: ParentLink
+    namespace: PersonNamespace
+    name: PersonName
+
+    @staticmethod
+    @create_entity_action
+    def new_person(
+        ctx: MutationContext,
+        person_domain_ref_id: EntityId,
+        namespace: PersonNamespace,
+        name: PersonName,
+    ) -> "Person":
+        """Create a person."""
+        return Person._create(
+            ctx,
+            person_domain=ParentLink(person_domain_ref_id),
+            namespace=namespace,
+            name=name,
+        )
+
+    @update_entity_action
+    def update(
+        self,
+        ctx: MutationContext,
+        name: UpdateAction[PersonName],
+    ) -> "Person":
+        """Update the person."""
+        return self._new_version(
+            ctx,
+            name=name.or_else(self.name),
+        )
+
+
+class PersonRepository(LeafEntityRepository[Person], abc.ABC):
+    """The repository for persons."""
+
+    @abc.abstractmethod
+    async def upsert(self, person: Person) -> Person:
+        """Upsert a person for a namespace and name."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/__init__.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/__init__.py
@@ -1,0 +1,1 @@
+"""Common person use cases."""

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/archive.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/archive.py
@@ -1,0 +1,67 @@
+"""Use case for archiving a person."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.archival_reason import JupiterArchivalReason
+from jupiter.core.common.sub.persons.root import PersonDomain
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+    JupiterTransactionalLoggedInMutationUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.update_action import UpdateAction
+from jupiter.framework.use_case import mutation_use_case
+from jupiter.framework.use_case_io import UseCaseArgsBase, use_case_args
+
+
+@use_case_args
+class PersonArchiveArgs(UseCaseArgsBase):
+    """PersonArchive args."""
+
+    ref_id: EntityId
+
+
+@mutation_use_case(exclude_component=[AppCore.CLI])
+class PersonArchiveUseCase(
+    JupiterTransactionalLoggedInMutationUseCase[PersonArchiveArgs, None]
+):
+    """Use case for archiving a person."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: PersonArchiveArgs,
+    ) -> None:
+        """Execute the command's action."""
+        workspace = context.workspace
+        person_domain = await uow.get_for(PersonDomain).load_by_parent(
+            workspace.ref_id
+        )
+        person = await uow.get_for(Person).load_by_id(args.ref_id)
+        person = person.mark_archived(
+            context.domain_context, JupiterArchivalReason.USER
+        )
+        await uow.get_for(Person).save(person)
+
+        all_person_links = await uow.get_for(PersonLink).find_all_generic(
+            parent_ref_id=person_domain.ref_id,
+            allow_archived=True,
+            namespace=[person.namespace],
+        )
+
+        for person_link in all_person_links:
+            if person.ref_id not in person_link.ref_ids:
+                continue
+            new_ref_ids = [
+                ref_id for ref_id in person_link.ref_ids if ref_id != person.ref_id
+            ]
+            person_link = person_link.update(
+                context.domain_context,
+                ref_ids=UpdateAction.change_to(new_ref_ids),
+            )
+            await uow.get_for(PersonLink).save(person_link)

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/find.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/find.py
@@ -1,0 +1,66 @@
+"""Use case for finding persons."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.persons.namespace import PersonNamespace
+from jupiter.core.common.sub.persons.root import PersonDomain
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.config import (
+    JupiterLoggedInReadonlyContext,
+    JupiterTransactionalLoggedInReadOnlyUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.entity import NoFilter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import readonly_use_case
+from jupiter.framework.use_case_io import (
+    UseCaseArgsBase,
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class PersonFindArgs(UseCaseArgsBase):
+    """PersonFind args."""
+
+    allow_archived: bool | None
+    filter_namespace: list[PersonNamespace] | None
+    filter_ref_ids: list[EntityId] | None
+
+
+@use_case_result
+class PersonFindResult(UseCaseResultBase):
+    """PersonFind result."""
+
+    persons: list[Person]
+
+
+@readonly_use_case(exclude_component=[AppCore.CLI])
+class PersonFindUseCase(
+    JupiterTransactionalLoggedInReadOnlyUseCase[PersonFindArgs, PersonFindResult]
+):
+    """Use case for finding persons."""
+
+    async def _perform_transactional_read(
+        self,
+        uow: DomainUnitOfWork,
+        context: JupiterLoggedInReadonlyContext,
+        args: PersonFindArgs,
+    ) -> PersonFindResult:
+        """Execute the command's action."""
+        allow_archived = args.allow_archived or False
+
+        workspace = context.workspace
+        person_domain = await uow.get_for(PersonDomain).load_by_parent(
+            workspace.ref_id
+        )
+
+        persons = await uow.get_for(Person).find_all_generic(
+            parent_ref_id=person_domain.ref_id,
+            allow_archived=allow_archived,
+            ref_id=args.filter_ref_ids or NoFilter(),
+            namespace=args.filter_namespace or NoFilter(),
+        )
+
+        return PersonFindResult(persons=persons)

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/load.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/load.py
@@ -1,0 +1,52 @@
+"""Use case for loading a person."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.config import (
+    JupiterLoggedInReadonlyContext,
+    JupiterTransactionalLoggedInReadOnlyUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import readonly_use_case
+from jupiter.framework.use_case_io import (
+    UseCaseArgsBase,
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class PersonLoadArgs(UseCaseArgsBase):
+    """PersonLoad args."""
+
+    ref_id: EntityId
+    allow_archived: bool | None
+
+
+@use_case_result
+class PersonLoadResult(UseCaseResultBase):
+    """PersonLoad result."""
+
+    person: Person
+
+
+@readonly_use_case(exclude_component=[AppCore.CLI])
+class PersonLoadUseCase(
+    JupiterTransactionalLoggedInReadOnlyUseCase[PersonLoadArgs, PersonLoadResult]
+):
+    """Use case for loading a person."""
+
+    async def _perform_transactional_read(
+        self,
+        uow: DomainUnitOfWork,
+        context: JupiterLoggedInReadonlyContext,
+        args: PersonLoadArgs,
+    ) -> PersonLoadResult:
+        """Execute the command's action."""
+        allow_archived = args.allow_archived or False
+        person = await uow.get_for(Person).load_by_id(
+            args.ref_id, allow_archived=allow_archived
+        )
+        return PersonLoadResult(person=person)

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/remove.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/remove.py
@@ -1,0 +1,64 @@
+"""Use case for removing a person."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.persons.root import PersonDomain
+from jupiter.core.common.sub.persons.sub.link.root import PersonLink
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+    JupiterTransactionalLoggedInMutationUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.update_action import UpdateAction
+from jupiter.framework.use_case import mutation_use_case
+from jupiter.framework.use_case_io import UseCaseArgsBase, use_case_args
+
+
+@use_case_args
+class PersonRemoveArgs(UseCaseArgsBase):
+    """PersonRemove args."""
+
+    ref_id: EntityId
+
+
+@mutation_use_case(exclude_component=[AppCore.CLI])
+class PersonRemoveUseCase(
+    JupiterTransactionalLoggedInMutationUseCase[PersonRemoveArgs, None]
+):
+    """Use case for removing a person."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: PersonRemoveArgs,
+    ) -> None:
+        """Execute the command's action."""
+        workspace = context.workspace
+        person_domain = await uow.get_for(PersonDomain).load_by_parent(
+            workspace.ref_id
+        )
+
+        person = await uow.get_for(Person).load_by_id(args.ref_id)
+        await uow.get_for(Person).remove(args.ref_id)
+
+        all_person_links = await uow.get_for(PersonLink).find_all_generic(
+            parent_ref_id=person_domain.ref_id,
+            allow_archived=True,
+            namespace=[person.namespace],
+        )
+
+        for person_link in all_person_links:
+            if person.ref_id not in person_link.ref_ids:
+                continue
+            new_ref_ids = [
+                ref_id for ref_id in person_link.ref_ids if ref_id != person.ref_id
+            ]
+            person_link = person_link.update(
+                context.domain_context,
+                ref_ids=UpdateAction.change_to(new_ref_ids),
+            )
+            await uow.get_for(PersonLink).save(person_link)

--- a/src/core/jupiter/core/common/sub/persons/sub/person/use_case/update.py
+++ b/src/core/jupiter/core/common/sub/persons/sub/person/use_case/update.py
@@ -1,0 +1,45 @@
+"""Use case for updating a person."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.persons.sub.person.name import PersonName
+from jupiter.core.common.sub.persons.sub.person.root import Person
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+    JupiterTransactionalLoggedInMutationUseCase,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.update_action import UpdateAction
+from jupiter.framework.use_case import mutation_use_case
+from jupiter.framework.use_case_io import UseCaseArgsBase, use_case_args
+
+
+@use_case_args
+class PersonUpdateArgs(UseCaseArgsBase):
+    """PersonUpdate args."""
+
+    ref_id: EntityId
+    name: UpdateAction[PersonName]
+
+
+@mutation_use_case(exclude_component=[AppCore.CLI])
+class PersonUpdateUseCase(
+    JupiterTransactionalLoggedInMutationUseCase[PersonUpdateArgs, None]
+):
+    """Use case for updating a person."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: PersonUpdateArgs,
+    ) -> None:
+        """Execute the command's action."""
+        person = await uow.get_for(Person).load_by_id(args.ref_id)
+        person = person.update(
+            ctx=context.domain_context,
+            name=args.name,
+        )
+        await uow.get_for(Person).save(person)

--- a/src/core/jupiter/core/infra/component/sidebar.tsx
+++ b/src/core/jupiter/core/infra/component/sidebar.tsx
@@ -397,6 +397,17 @@ export default function Sidebar(props: SidebarProps) {
               </ListItemButton>
             </ListItem>
 
+            <ListItem disablePadding>
+              <ListItemButton
+                to="/app/workspace/core/persons"
+                component={Link}
+                onClick={onClickNavigation}
+              >
+                <ListItemIcon>👤</ListItemIcon>
+                <ListItemText primary="Persons" />
+              </ListItemButton>
+            </ListItem>
+
             <StandardDivider title="Process" size="small" />
 
             <ListItem disablePadding>

--- a/src/core/jupiter/core/workspaces/root.py
+++ b/src/core/jupiter/core/workspaces/root.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from jupiter.core.big_plans.collection import BigPlanCollection
 from jupiter.core.chores.collection import ChoreCollection
 from jupiter.core.common.sub.notes.collection import NoteCollection
+from jupiter.core.common.sub.persons.root import PersonDomain
 from jupiter.core.common.sub.tags.root import TagDomain
 from jupiter.core.common.sub.time_events.domain import TimeEventDomain
 from jupiter.core.docs.collection import DocCollection
@@ -88,6 +89,7 @@ class Workspace(RootEntity):
     note_collection = ContainsOne(NoteCollection, workspace_ref_id=IsRefId())
     time_event_domain = ContainsOne(TimeEventDomain, workspace_ref_id=IsRefId())
     tag_domain = ContainsOne(TagDomain, workspace_ref_id=IsRefId())
+    person_domain = ContainsOne(PersonDomain, workspace_ref_id=IsRefId())
 
     gc_log = ContainsOne(GCLog, workspace_ref_id=IsRefId())
     gen_log = ContainsOne(GenLog, workspace_ref_id=IsRefId())

--- a/src/webui/app/routes/app/workspace/core/persons.tsx
+++ b/src/webui/app/routes/app/workspace/core/persons.tsx
@@ -1,0 +1,142 @@
+import type { Person } from "@jupiter/webapi-client";
+import { DocsHelpSubject, PersonNamespace } from "@jupiter/webapi-client";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+import { Outlet } from "@remix-run/react";
+import { AnimatePresence } from "framer-motion";
+import { useContext, useMemo, useState } from "react";
+import { EntityNameComponent } from "@jupiter/core/common/component/entity-name";
+import {
+  EntityCard,
+  EntityLink,
+} from "@jupiter/core/infra/component/entity-card";
+import { EntityNoNothingCard } from "@jupiter/core/infra/component/entity-no-nothing-card";
+import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import { makeTrunkErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
+import { NestingAwareBlock } from "@jupiter/core/infra/component/layout/nesting-aware-block";
+import { TrunkPanel } from "@jupiter/core/infra/component/layout/trunk-panel";
+import {
+  DisplayType,
+  useTrunkNeedsToShowLeaf,
+} from "@jupiter/core/infra/component/use-nested-entities";
+import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import {
+  FilterManyOptions,
+  SectionActions,
+} from "@jupiter/core/infra/component/section-actions";
+import { PersonNamespaceTag } from "#/core/common/sub/persons/component/person-namespace-tag";
+import { personNamespaceName } from "#/core/common/sub/persons/namespace";
+
+import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
+import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+export const handle = {
+  displayType: DisplayType.TRUNK,
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+
+  const result = await apiClient.persons.personFind({
+    allow_archived: false,
+  });
+
+  return json({
+    persons: result.persons as Array<Person>,
+  });
+}
+
+export const shouldRevalidate: ShouldRevalidateFunction =
+  standardShouldRevalidate;
+
+export default function Persons() {
+  const { persons } = useLoaderDataSafeForAnimation<typeof loader>();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const shouldShowALeafToo = useTrunkNeedsToShowLeaf();
+
+  const [selectedNamespaces, setSelectedNamespaces] = useState<
+    PersonNamespace[]
+  >([]);
+
+  const namespaceOptions = useMemo(
+    () =>
+      Object.values(PersonNamespace).map((ns) => ({
+        value: ns,
+        text: personNamespaceName(ns),
+      })),
+    [],
+  );
+
+  const filteredPersons = useMemo(() => {
+    const sorted = [...persons].sort((a, b) => {
+      if (a.namespace < b.namespace) {
+        return -1;
+      }
+      if (a.namespace > b.namespace) {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    if (selectedNamespaces.length === 0) {
+      return sorted;
+    }
+
+    return sorted.filter((p) => selectedNamespaces.includes(p.namespace));
+  }, [persons, selectedNamespaces]);
+
+  return (
+    <TrunkPanel
+      key={"core/persons"}
+      returnLocation="/app/workspace"
+      actions={
+        <SectionActions
+          id="core-persons-actions"
+          topLevelInfo={topLevelInfo}
+          inputsEnabled={true}
+          actions={[
+            FilterManyOptions(
+              "Namespace",
+              namespaceOptions,
+              setSelectedNamespaces,
+            ),
+          ]}
+        />
+      }
+    >
+      <NestingAwareBlock shouldHide={shouldShowALeafToo}>
+        {filteredPersons.length === 0 && (
+          <EntityNoNothingCard
+            title="No Persons"
+            message="There are no persons to show. Persons are attached to entities and cannot be created independently."
+            helpSubject={DocsHelpSubject.ROOT}
+          />
+        )}
+
+        <EntityStack>
+          {filteredPersons.map((person) => (
+            <EntityCard
+              entityId={`person-${person.ref_id}`}
+              key={`person-${person.ref_id}`}
+            >
+              <EntityLink to={`/app/workspace/core/persons/${person.ref_id}`}>
+                <EntityNameComponent name={person.name} />
+                <PersonNamespaceTag namespace={person.namespace} />
+              </EntityLink>
+            </EntityCard>
+          ))}
+        </EntityStack>
+      </NestingAwareBlock>
+
+      <AnimatePresence mode="wait" initial={false}>
+        <Outlet />
+      </AnimatePresence>
+    </TrunkPanel>
+  );
+}
+
+export const ErrorBoundary = makeTrunkErrorBoundary("/app/workspace", {
+  error: () => `There was an error loading the persons! Please try again!`,
+});

--- a/src/webui/app/routes/app/workspace/core/persons/$id.tsx
+++ b/src/webui/app/routes/app/workspace/core/persons/$id.tsx
@@ -1,0 +1,203 @@
+import type { Person } from "@jupiter/webapi-client";
+import { ApiError } from "@jupiter/webapi-client";
+import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+import {
+  useActionData,
+  useLoaderData,
+  useNavigation,
+  useParams,
+} from "@remix-run/react";
+import { ReasonPhrases, StatusCodes } from "http-status-codes";
+import { useContext } from "react";
+import { z } from "zod";
+import { parseForm, parseParams } from "zodix";
+import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
+import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
+import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
+import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import {
+  ActionSingle,
+  SectionActions,
+} from "@jupiter/core/infra/component/section-actions";
+import { validationErrorToUIErrorInfo } from "@jupiter/core/infra/action-result";
+import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
+import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import { PersonNamespaceTag } from "#/core/common/sub/persons/component/person-namespace-tag";
+
+import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+const ParamsSchema = z.object({
+  id: z.string(),
+});
+
+const UpdateFormSchema = z.discriminatedUnion("intent", [
+  z.object({
+    intent: z.literal("update"),
+    name: z.string(),
+  }),
+  z.object({
+    intent: z.literal("archive"),
+  }),
+  z.object({
+    intent: z.literal("remove"),
+  }),
+]);
+
+export const handle = {
+  displayType: DisplayType.LEAF,
+};
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const { id } = parseParams(params, ParamsSchema);
+
+  try {
+    const result = await apiClient.persons.personLoad({
+      ref_id: id,
+      allow_archived: true,
+    });
+
+    return json({
+      person: result.person as Person,
+    });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === StatusCodes.NOT_FOUND) {
+      throw new Response(ReasonPhrases.NOT_FOUND, {
+        status: StatusCodes.NOT_FOUND,
+        statusText: ReasonPhrases.NOT_FOUND,
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const { id } = parseParams(params, ParamsSchema);
+  const form = await parseForm(request, UpdateFormSchema);
+
+  try {
+    switch (form.intent) {
+      case "update": {
+        await apiClient.persons.personUpdate({
+          ref_id: id,
+          name: {
+            should_change: true,
+            value: form.name,
+          },
+        });
+
+        return redirect(`/app/workspace/core/persons/${id}`);
+      }
+
+      case "archive": {
+        await apiClient.persons.personArchive({
+          ref_id: id,
+        });
+
+        return redirect(`/app/workspace/core/persons/${id}`);
+      }
+
+      case "remove": {
+        await apiClient.persons.personRemove({
+          ref_id: id,
+        });
+
+        return redirect(`/app/workspace/core/persons`);
+      }
+
+      default:
+        throw new Response("Bad Intent", { status: 500 });
+    }
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.status === StatusCodes.UNPROCESSABLE_ENTITY
+    ) {
+      return json(validationErrorToUIErrorInfo(error.body));
+    }
+
+    throw error;
+  }
+}
+
+export const shouldRevalidate: ShouldRevalidateFunction =
+  standardShouldRevalidate;
+
+export default function PersonDetail() {
+  const actionData = useActionData<typeof action>();
+  const loaderData = useLoaderData<typeof loader>();
+  const navigation = useNavigation();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const { id } = useParams();
+  const inputsEnabled = navigation.state === "idle";
+
+  const person = loaderData.person;
+
+  return (
+    <LeafPanel
+      key={`core/persons/${person.ref_id}`}
+      fakeKey={`core/persons/${person.ref_id}`}
+      returnLocation="/app/workspace/core/persons"
+      inputsEnabled={inputsEnabled}
+      showArchiveAndRemoveButton
+      entityArchived={person.archived}
+    >
+      <GlobalError actionResult={actionData} />
+
+      <SectionCard
+        title={`Person ${person.name}`}
+        actions={
+          <SectionActions
+            id={`person-${person.ref_id}-actions`}
+            topLevelInfo={topLevelInfo}
+            inputsEnabled={inputsEnabled}
+            actions={[
+              ActionSingle({
+                id: "person-update",
+                text: "Update",
+                value: "update",
+                highlight: true,
+              }),
+            ]}
+          />
+        }
+      >
+        <Stack direction="row" spacing={2}>
+          <FormControl fullWidth sx={{ flexGrow: 1 }}>
+            <PersonNamespaceTag namespace={person.namespace} />
+          </FormControl>
+          <FormControl fullWidth sx={{ flexGrow: 2 }}>
+            <InputLabel id="name">Name</InputLabel>
+            <OutlinedInput
+              label="Name"
+              name="name"
+              defaultValue={person.name}
+              readOnly={!inputsEnabled}
+            />
+            <FieldError actionResult={actionData} fieldName="/name/value" />
+            <FieldError actionResult={actionData} fieldName="/name" />
+          </FormControl>
+        </Stack>
+
+        {/* Helpful for actions coming from LeafPanel dialog as well */}
+        <input name="id" type="hidden" value={id ?? person.ref_id} />
+      </SectionCard>
+    </LeafPanel>
+  );
+}
+
+export const ErrorBoundary = makeLeafErrorBoundary(
+  `/app/workspace/core/persons`,
+  ParamsSchema,
+  {
+    notFound: (params) => `Could not find person #${params.id}!`,
+    error: (params) =>
+      `There was an error loading person #${params.id}! Please try again!`,
+  },
+);


### PR DESCRIPTION
## Summary
Introduces a new `Person` leaf-support entity under the `common/sub/persons/` domain, allowing the system to track and manage persons linked to various entities (inbox tasks, big plans, schedules, habits, chores, smart list items, and metric entries). Persons are created automatically by entities and managed through a dedicated UI—they cannot be created independently.

## Key Changes

### Backend (Python)
- **Person Entity** (`sub/person/root.py`): Core leaf-support entity with `namespace`, `name`, and parent link to `PersonDomain`. Supports update operations on the name field.
- **PersonLink Entity** (`sub/link/root.py`): Aggregates multiple persons for a given namespace and source entity, enabling efficient batch operations.
- **PersonDomain** (`root.py`): Trunk entity serving as the container for all persons and links within a workspace.
- **Use Cases**: Implemented CRUD operations (load, find, update, archive, remove) for persons, excluding CLI access.
- **PersonNamespace Enum** (`namespace.py`): Defines 8 namespaces (PRM, INBOX_TASK, BIG_PLAN, SCHEDULE, HABIT, CHORE, SMART_LIST_ITEM, METRIC_ENTRY).
- **SQLite Repository** (`impl/repository.py`): Implements upsert operations with conflict resolution for both `Person` and `PersonLink` entities.
- **Archive/Remove Services** (`sub/link/service/`): Handles cascading updates to person links when persons are archived or removed.

### Frontend (TypeScript/React)
- **Persons List Route** (`routes/app/workspace/core/persons.tsx`): Trunk view displaying all non-archived persons, filterable by namespace. Shows empty state message explaining persons are entity-attached.
- **Person Detail Route** (`routes/app/workspace/core/persons/$id.tsx`): Leaf view for viewing and editing a person's name, with archive and remove actions. Displays the person's namespace via a tag component.
- **PersonNamespaceTag Component** (`component/person-namespace-tag.tsx`): Renders namespace as a slim chip with human-readable labels.
- **Namespace Utilities** (`namespace.ts`): Helper function mapping enum values to display names.

### Integration
- Updated `Workspace` entity to include `PersonDomain` reference.
- Updated use case initialization to register person-related use cases.
- Added "Persons" menu item to sidebar navigation.

## Notable Implementation Details
- Persons follow the exact pattern established by the `Note` entity, ensuring consistency with existing patterns.
- The `PersonLink` entity enables efficient querying and batch operations on persons grouped by namespace and source entity.
- Upsert operations use SQLite's `ON CONFLICT` clause to handle idempotent person creation.
- Archive and remove operations cascade to update associated `PersonLink` records.
- UI excludes create functionality; persons are created programmatically by their source entities.

https://claude.ai/code/session_01QZ8jn4mWUAXeLwquCDUAFs