### PR TITLE
Add upcoming celebrations and catch-up widgets sidebar to PRM persons page

### DIFF
--- a/src/core/jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget.tsx
+++ b/src/core/jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget.tsx
@@ -1,0 +1,66 @@
+import { InboxTaskSource, InboxTaskStatus } from "@jupiter/webapi-client";
+
+import { aDateToDate } from "#/core/common/adate";
+import {
+  filterInboxTasksForDisplay,
+  sortInboxTasksByEisenAndDifficulty,
+} from "#/core/inbox_tasks/root";
+import { InboxTaskStack } from "#/core/inbox_tasks/component/stack";
+import { InboxTasksNoTasksCard } from "#/core/inbox_tasks/component/no-tasks-card";
+import { WidgetProps } from "#/core/home/component/common";
+
+export function UpcomingCatchUpsWidget(props: WidgetProps) {
+  const personTasks = props.personTasks!;
+  const today = aDateToDate(props.topLevelInfo.today).endOf("day");
+  const oneMonthFromNow = today.plus({ months: 1 }).endOf("day");
+
+  const sortedInboxTasks = sortInboxTasksByEisenAndDifficulty(
+    personTasks.personInboxTasks,
+  );
+
+  const upcomingCatchUps = filterInboxTasksForDisplay(
+    sortedInboxTasks,
+    personTasks.personEntriesByRefId,
+    personTasks.optimisticUpdates,
+    {
+      allowSources: [InboxTaskSource.PERSON_CATCH_UP],
+      allowStatuses: [
+        InboxTaskStatus.NOT_STARTED,
+        InboxTaskStatus.NOT_STARTED_GEN,
+        InboxTaskStatus.IN_PROGRESS,
+        InboxTaskStatus.BLOCKED,
+      ],
+      includeIfNoActionableDate: true,
+      dueDateEnd: oneMonthFromNow,
+    },
+  );
+
+  if (upcomingCatchUps.length === 0) {
+    return (
+      <InboxTasksNoTasksCard
+        parent="person"
+        parentLabel="New Person"
+        parentNewLocations="/app/workspace/prm/persons/new"
+      />
+    );
+  }
+
+  return (
+    <InboxTaskStack
+      key="upcoming-catch-ups"
+      topLevelInfo={props.topLevelInfo}
+      showOptions={{
+        showStatus: true,
+        showDueDate: true,
+        showHandleMarkDone: true,
+        showHandleMarkNotDone: true,
+      }}
+      label="Upcoming Catch Ups"
+      inboxTasks={upcomingCatchUps}
+      optimisticUpdates={personTasks.optimisticUpdates}
+      moreInfoByRefId={personTasks.personEntriesByRefId}
+      onCardMarkDone={personTasks.onCardMarkDone}
+      onCardMarkNotDone={personTasks.onCardMarkNotDone}
+    />
+  );
+}

--- a/src/core/jupiter/core/prm/sub/person/sub/occasion/components/kind-select.tsx
+++ b/src/core/jupiter/core/prm/sub/person/sub/occasion/components/kind-select.tsx
@@ -3,6 +3,7 @@ import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { useEffect, useState } from "react";
 
 import { occasionKindName } from "#/core/prm/sub/person/sub/occasion/kind";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
 
 interface OccasionKindSelectProps {
   name: string;
@@ -11,6 +12,7 @@ interface OccasionKindSelectProps {
 }
 
 export function OccasionKindSelect(props: OccasionKindSelectProps) {
+  const isBigScreen = useBigScreen();
   const [kind, setKind] = useState<OccasionKind>(props.defaultValue);
 
   useEffect(() => {
@@ -31,7 +33,7 @@ export function OccasionKindSelect(props: OccasionKindSelectProps) {
           disabled={!props.inputsEnabled}
           value={OccasionKind.BIRTHDAY}
         >
-          {occasionKindName(OccasionKind.BIRTHDAY)}
+          {occasionKindName(OccasionKind.BIRTHDAY, isBigScreen)}
         </ToggleButton>
         <ToggleButton
           size="small"
@@ -39,7 +41,7 @@ export function OccasionKindSelect(props: OccasionKindSelectProps) {
           disabled={!props.inputsEnabled}
           value={OccasionKind.ANNIVERSARY}
         >
-          {occasionKindName(OccasionKind.ANNIVERSARY)}
+          {occasionKindName(OccasionKind.ANNIVERSARY, isBigScreen)}
         </ToggleButton>
         <ToggleButton
           size="small"
@@ -47,7 +49,7 @@ export function OccasionKindSelect(props: OccasionKindSelectProps) {
           disabled={!props.inputsEnabled}
           value={OccasionKind.HOLIDAY}
         >
-          {occasionKindName(OccasionKind.HOLIDAY)}
+          {occasionKindName(OccasionKind.HOLIDAY, isBigScreen)}
         </ToggleButton>
         <ToggleButton
           size="small"
@@ -55,7 +57,7 @@ export function OccasionKindSelect(props: OccasionKindSelectProps) {
           disabled={!props.inputsEnabled}
           value={OccasionKind.OTHER}
         >
-          {occasionKindName(OccasionKind.OTHER)}
+          {occasionKindName(OccasionKind.OTHER, isBigScreen)}
         </ToggleButton>
       </ToggleButtonGroup>
       <input name={props.name} type="hidden" value={kind} />

--- a/src/core/jupiter/core/prm/sub/person/sub/occasion/kind.ts
+++ b/src/core/jupiter/core/prm/sub/person/sub/occasion/kind.ts
@@ -1,13 +1,16 @@
 import { OccasionKind } from "@jupiter/webapi-client";
 
-export function occasionKindName(kind: OccasionKind): string {
+export function occasionKindName(
+  kind: OccasionKind,
+  isBigScreen: boolean = true,
+): string {
   switch (kind) {
     case OccasionKind.BIRTHDAY:
-      return "Birthday";
+      return isBigScreen ? "Birthday" : "Bday";
     case OccasionKind.ANNIVERSARY:
-      return "Anniversary";
+      return isBigScreen ? "Anniversary" : "Anniv";
     case OccasionKind.HOLIDAY:
-      return "Holiday";
+      return isBigScreen ? "Holiday" : "Holi";
     case OccasionKind.OTHER:
       return "Other";
   }

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -14,7 +14,11 @@ import {
   TagNamespace,
   WidgetDimension,
 } from "@jupiter/webapi-client";
-import type { PersonFindResultEntry, Tag } from "@jupiter/webapi-client";
+import type {
+  Circle,
+  PersonFindResultEntry,
+  Tag,
+} from "@jupiter/webapi-client";
 import { DifficultyTag } from "@jupiter/core/common/component/difficulty-tag";
 import { EisenTag } from "@jupiter/core/common/component/eisen-tag";
 import { EntityNameComponent } from "@jupiter/core/common/component/entity-name";
@@ -157,7 +161,9 @@ export default function Persons() {
       )
     : undefined;
 
-  const personEntriesByRefId: { [key: string]: ReturnType<typeof inboxTaskFindEntryToParent> } = {};
+  const personEntriesByRefId: {
+    [key: string]: ReturnType<typeof inboxTaskFindEntryToParent>;
+  } = {};
   if (loaderData.personInboxTasks) {
     for (const entry of loaderData.personInboxTasks) {
       personEntriesByRefId[entry.inbox_task.ref_id] =
@@ -303,23 +309,43 @@ export default function Persons() {
                   gap: 2,
                 }}
               >
-                <WidgetContainer geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}>
+                <WidgetContainer
+                  geometry={{
+                    row: 0,
+                    col: 0,
+                    dimension: WidgetDimension.DIM_KX1,
+                  }}
+                >
                   <UpcomingBirthdaysWidget
                     rightNow={rightNow}
                     timezone={topLevelInfo.user.timezone}
                     topLevelInfo={topLevelInfo}
                     personTasks={personTasks}
-                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                    geometry={{
+                      row: 0,
+                      col: 0,
+                      dimension: WidgetDimension.DIM_KX1,
+                    }}
                   />
                 </WidgetContainer>
 
-                <WidgetContainer geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}>
+                <WidgetContainer
+                  geometry={{
+                    row: 0,
+                    col: 0,
+                    dimension: WidgetDimension.DIM_KX1,
+                  }}
+                >
                   <UpcomingCatchUpsWidget
                     rightNow={rightNow}
                     timezone={topLevelInfo.user.timezone}
                     topLevelInfo={topLevelInfo}
                     personTasks={personTasks}
-                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                    geometry={{
+                      row: 0,
+                      col: 0,
+                      dimension: WidgetDimension.DIM_KX1,
+                    }}
                   />
                 </WidgetContainer>
               </Box>
@@ -336,8 +362,7 @@ export default function Persons() {
               onChange={(_, newValue) => setSmallScreenTab(newValue)}
             >
               <Tab label="People" />
-              <Tab label="Occasions" />
-              <Tab label="Catch Ups" />
+              <Tab label="Tasks" />
             </Tabs>
 
             <TabPanel value={smallScreenTab} index={0}>
@@ -362,36 +387,34 @@ export default function Persons() {
 
             <TabPanel value={smallScreenTab} index={1}>
               {personTasks ? (
-                <UpcomingBirthdaysWidget
-                  rightNow={rightNow}
-                  timezone={topLevelInfo.user.timezone}
-                  topLevelInfo={topLevelInfo}
-                  personTasks={personTasks}
-                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                />
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  <UpcomingBirthdaysWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{
+                      row: 0,
+                      col: 0,
+                      dimension: WidgetDimension.DIM_KX1,
+                    }}
+                  />
+                  <UpcomingCatchUpsWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{
+                      row: 0,
+                      col: 0,
+                      dimension: WidgetDimension.DIM_KX1,
+                    }}
+                  />
+                </Box>
               ) : (
                 <EntityNoNothingCard
                   title="You Have To Start Somewhere"
-                  message="There are no upcoming celebrations."
-                  newEntityLocations="/app/workspace/prm/persons/new"
-                  helpSubject={DocsHelpSubject.PRM}
-                />
-              )}
-            </TabPanel>
-
-            <TabPanel value={smallScreenTab} index={2}>
-              {personTasks ? (
-                <UpcomingCatchUpsWidget
-                  rightNow={rightNow}
-                  timezone={topLevelInfo.user.timezone}
-                  topLevelInfo={topLevelInfo}
-                  personTasks={personTasks}
-                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                />
-              ) : (
-                <EntityNoNothingCard
-                  title="You Have To Start Somewhere"
-                  message="There are no upcoming catch ups."
+                  message="There are no upcoming tasks."
                   newEntityLocations="/app/workspace/prm/persons/new"
                   helpSubject={DocsHelpSubject.PRM}
                 />
@@ -409,7 +432,7 @@ export default function Persons() {
 
 interface PersonCardProps {
   entry: PersonFindResultEntry;
-  circlesByRefId: Map<string, { ref_id: string; name: unknown }>;
+  circlesByRefId: Map<string, Circle>;
 }
 
 function PersonCard({ entry, circlesByRefId }: PersonCardProps) {

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -309,7 +309,7 @@ export default function Persons() {
               >
                 <Box>
                   <Typography variant="h6" sx={{ mb: 1 }}>
-                    Upcoming Celebrations
+                    Upcoming Occasions
                   </Typography>
                   <UpcomingBirthdaysWidget
                     rightNow={rightNow}

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -13,7 +13,6 @@ import {
   InboxTaskStatus,
   TagNamespace,
   WidgetDimension,
-  WorkspaceFeature,
 } from "@jupiter/webapi-client";
 import type { PersonFindResultEntry, Tag } from "@jupiter/webapi-client";
 import { DifficultyTag } from "@jupiter/core/common/component/difficulty-tag";
@@ -48,7 +47,6 @@ import {
   InboxTaskOptimisticState,
   sortInboxTasksNaturally,
 } from "@jupiter/core/inbox_tasks/root";
-import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
 import { UpcomingBirthdaysWidget } from "@jupiter/core/prm/sub/person/component/upcoming-birthdays-widget";
 import { UpcomingCatchUpsWidget } from "@jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget";
@@ -93,25 +91,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
     filter_namespace: [TagNamespace.PERSON],
   });
 
-  let personInboxTasksResponse = undefined;
-  if (isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.PRM)) {
-    personInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
-      allow_archived: false,
-      include_tags: true,
-      include_notes: false,
-      include_time_event_blocks: false,
-      filter_sources: [
-        InboxTaskSource.PERSON_OCCASION,
-        InboxTaskSource.PERSON_CATCH_UP,
-      ],
-    });
-  }
+  const personInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
+    allow_archived: false,
+    include_tags: true,
+    include_notes: false,
+    include_time_event_blocks: false,
+    filter_sources: [
+      InboxTaskSource.PERSON_OCCASION,
+      InboxTaskSource.PERSON_CATCH_UP,
+    ],
+  });
 
   return json({
     entries: body.entries,
     allCircles: circlesResult.circles,
     allTags: allTags.tags,
-    personInboxTasks: personInboxTasksResponse?.entries,
+    personInboxTasks: personInboxTasksResponse.entries,
   });
 }
 

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -48,6 +48,7 @@ import {
   sortInboxTasksNaturally,
 } from "@jupiter/core/inbox_tasks/root";
 import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
+import { WidgetContainer } from "@jupiter/core/home/component/common";
 import { UpcomingBirthdaysWidget } from "@jupiter/core/prm/sub/person/component/upcoming-birthdays-widget";
 import { UpcomingCatchUpsWidget } from "@jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget";
 import { TabPanel } from "@jupiter/core/infra/component/tab-panel";
@@ -302,21 +303,25 @@ export default function Persons() {
                   gap: 2,
                 }}
               >
-                <UpcomingBirthdaysWidget
-                  rightNow={rightNow}
-                  timezone={topLevelInfo.user.timezone}
-                  topLevelInfo={topLevelInfo}
-                  personTasks={personTasks}
-                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                />
+                <WidgetContainer geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}>
+                  <UpcomingBirthdaysWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                  />
+                </WidgetContainer>
 
-                <UpcomingCatchUpsWidget
-                  rightNow={rightNow}
-                  timezone={topLevelInfo.user.timezone}
-                  topLevelInfo={topLevelInfo}
-                  personTasks={personTasks}
-                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                />
+                <WidgetContainer geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}>
+                  <UpcomingCatchUpsWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                  />
+                </WidgetContainer>
               </Box>
             )}
           </Box>

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -53,7 +53,7 @@ import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
 import { UpcomingBirthdaysWidget } from "@jupiter/core/prm/sub/person/component/upcoming-birthdays-widget";
 import { UpcomingCatchUpsWidget } from "@jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget";
 import { TabPanel } from "@jupiter/core/infra/component/tab-panel";
-import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
+import { Box, Tab, Tabs } from "@mui/material";
 import { DateTime } from "luxon";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
@@ -307,33 +307,21 @@ export default function Persons() {
                   gap: 2,
                 }}
               >
-                <Box>
-                  <Typography variant="h6" sx={{ mb: 1 }}>
-                    Upcoming Occasions
-                  </Typography>
-                  <UpcomingBirthdaysWidget
-                    rightNow={rightNow}
-                    timezone={topLevelInfo.user.timezone}
-                    topLevelInfo={topLevelInfo}
-                    personTasks={personTasks}
-                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                  />
-                </Box>
+                <UpcomingBirthdaysWidget
+                  rightNow={rightNow}
+                  timezone={topLevelInfo.user.timezone}
+                  topLevelInfo={topLevelInfo}
+                  personTasks={personTasks}
+                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                />
 
-                <Divider />
-
-                <Box>
-                  <Typography variant="h6" sx={{ mb: 1 }}>
-                    Upcoming Catch Ups
-                  </Typography>
-                  <UpcomingCatchUpsWidget
-                    rightNow={rightNow}
-                    timezone={topLevelInfo.user.timezone}
-                    topLevelInfo={topLevelInfo}
-                    personTasks={personTasks}
-                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-                  />
-                </Box>
+                <UpcomingCatchUpsWidget
+                  rightNow={rightNow}
+                  timezone={topLevelInfo.user.timezone}
+                  topLevelInfo={topLevelInfo}
+                  personTasks={personTasks}
+                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                />
               </Box>
             )}
           </Box>

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -52,7 +52,8 @@ import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
 import { UpcomingBirthdaysWidget } from "@jupiter/core/prm/sub/person/component/upcoming-birthdays-widget";
 import { UpcomingCatchUpsWidget } from "@jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget";
-import { Box, Divider, Typography } from "@mui/material";
+import { TabPanel } from "@jupiter/core/infra/component/tab-panel";
+import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
 import { DateTime } from "luxon";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
@@ -221,8 +222,9 @@ export default function Persons() {
         }
       : undefined;
 
-  const showSidebar =
-    isBigScreen && personTasks !== undefined;
+  const showSidebar = isBigScreen && personTasks !== undefined;
+
+  const [smallScreenTab, setSmallScreenTab] = useState(0);
 
   const shouldShowALeaf = useTrunkNeedsToShowLeaf();
   const shouldShowALeaflet = useLeafNeedsToShowLeaflet();
@@ -271,116 +273,190 @@ export default function Persons() {
         />
       }
     >
-      <Box
-        sx={
-          showSidebar
-            ? { display: "flex", alignItems: "flex-start", gap: 2 }
-            : {}
-        }
-      >
-        <Box sx={showSidebar ? { flex: 1, minWidth: 0 } : {}}>
-          <NestingAwareBlock shouldHide={shouldShowALeaf || shouldShowALeaflet}>
-            {filteredEntries.length === 0 && (
-              <EntityNoNothingCard
-                title="You Have To Start Somewhere"
-                message="There are no persons to show with the current filters. You can create a new person."
-                newEntityLocations="/app/workspace/prm/persons/new"
-                helpSubject={DocsHelpSubject.PRM}
-              />
+      <NestingAwareBlock shouldHide={shouldShowALeaf || shouldShowALeaflet}>
+        {/* Big screen: two-column layout with sidebar */}
+        {isBigScreen && (
+          <Box sx={{ display: "flex", alignItems: "flex-start", gap: 2 }}>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              {filteredEntries.length === 0 && (
+                <EntityNoNothingCard
+                  title="You Have To Start Somewhere"
+                  message="There are no persons to show with the current filters. You can create a new person."
+                  newEntityLocations="/app/workspace/prm/persons/new"
+                  helpSubject={DocsHelpSubject.PRM}
+                />
+              )}
+              <EntityStack>
+                {filteredEntries.map((entry) => (
+                  <PersonCard
+                    key={entry.person.ref_id}
+                    entry={entry}
+                    circlesByRefId={circlesByRefId}
+                  />
+                ))}
+              </EntityStack>
+            </Box>
+
+            {showSidebar && (
+              <Box
+                sx={{
+                  width: "320px",
+                  flexShrink: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 2,
+                }}
+              >
+                <Box>
+                  <Typography variant="h6" sx={{ mb: 1 }}>
+                    Upcoming Celebrations
+                  </Typography>
+                  <UpcomingBirthdaysWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                  />
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="h6" sx={{ mb: 1 }}>
+                    Upcoming Catch Ups
+                  </Typography>
+                  <UpcomingCatchUpsWidget
+                    rightNow={rightNow}
+                    timezone={topLevelInfo.user.timezone}
+                    topLevelInfo={topLevelInfo}
+                    personTasks={personTasks}
+                    geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                  />
+                </Box>
+              </Box>
             )}
-
-            <EntityStack>
-              {filteredEntries.map((entry) => (
-                <EntityCard
-                  entityId={`person-${entry.person.ref_id}`}
-                  key={`person-${entry.person.ref_id}`}
-                >
-                  <EntityLink
-                    to={`/app/workspace/prm/persons/${entry.person.ref_id}`}
-                  >
-                    <EntityNameComponent name={entry.contact.name} />
-                    {entry.circle_ref_ids.length > 0 && (
-                      <>
-                        {entry.circle_ref_ids
-                          .map((circleRefId) => circlesByRefId.get(circleRefId))
-                          .filter((c): c is NonNullable<typeof c> => Boolean(c))
-                          .map((circle) => (
-                            <CircleTag
-                              key={`circle-${circle.ref_id}`}
-                              circle={circle}
-                            />
-                          ))}
-                      </>
-                    )}
-
-                    {entry.person.catch_up_params && (
-                      <>
-                        <PeriodTag period={entry.person.catch_up_params.period} />
-                        {entry.person.catch_up_params.eisen && (
-                          <EisenTag eisen={entry.person.catch_up_params.eisen} />
-                        )}
-                        {entry.person.catch_up_params.difficulty && (
-                          <DifficultyTag
-                            difficulty={entry.person.catch_up_params.difficulty}
-                          />
-                        )}
-                      </>
-                    )}
-
-                    {entry.tags?.map((tag: Tag) => (
-                      <TagTag key={tag.ref_id} tag={tag} />
-                    ))}
-                  </EntityLink>
-                </EntityCard>
-              ))}
-            </EntityStack>
-          </NestingAwareBlock>
-        </Box>
-
-        {showSidebar && !shouldShowALeaf && !shouldShowALeaflet && (
-          <Box
-            sx={{
-              width: "320px",
-              flexShrink: 0,
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-            }}
-          >
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Upcoming Celebrations
-              </Typography>
-              <UpcomingBirthdaysWidget
-                rightNow={rightNow}
-                timezone={topLevelInfo.user.timezone}
-                topLevelInfo={topLevelInfo}
-                personTasks={personTasks}
-                geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-              />
-            </Box>
-
-            <Divider />
-
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Upcoming Catch Ups
-              </Typography>
-              <UpcomingCatchUpsWidget
-                rightNow={rightNow}
-                timezone={topLevelInfo.user.timezone}
-                topLevelInfo={topLevelInfo}
-                personTasks={personTasks}
-                geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
-              />
-            </Box>
           </Box>
         )}
-      </Box>
+
+        {/* Small screen: tab view */}
+        {!isBigScreen && (
+          <>
+            <Tabs
+              value={smallScreenTab}
+              variant="fullWidth"
+              onChange={(_, newValue) => setSmallScreenTab(newValue)}
+            >
+              <Tab label="People" />
+              <Tab label="Celebrations" />
+              <Tab label="Catch Ups" />
+            </Tabs>
+
+            <TabPanel value={smallScreenTab} index={0}>
+              {filteredEntries.length === 0 && (
+                <EntityNoNothingCard
+                  title="You Have To Start Somewhere"
+                  message="There are no persons to show with the current filters. You can create a new person."
+                  newEntityLocations="/app/workspace/prm/persons/new"
+                  helpSubject={DocsHelpSubject.PRM}
+                />
+              )}
+              <EntityStack>
+                {filteredEntries.map((entry) => (
+                  <PersonCard
+                    key={entry.person.ref_id}
+                    entry={entry}
+                    circlesByRefId={circlesByRefId}
+                  />
+                ))}
+              </EntityStack>
+            </TabPanel>
+
+            <TabPanel value={smallScreenTab} index={1}>
+              {personTasks ? (
+                <UpcomingBirthdaysWidget
+                  rightNow={rightNow}
+                  timezone={topLevelInfo.user.timezone}
+                  topLevelInfo={topLevelInfo}
+                  personTasks={personTasks}
+                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                />
+              ) : (
+                <EntityNoNothingCard
+                  title="You Have To Start Somewhere"
+                  message="There are no upcoming celebrations."
+                  newEntityLocations="/app/workspace/prm/persons/new"
+                  helpSubject={DocsHelpSubject.PRM}
+                />
+              )}
+            </TabPanel>
+
+            <TabPanel value={smallScreenTab} index={2}>
+              {personTasks ? (
+                <UpcomingCatchUpsWidget
+                  rightNow={rightNow}
+                  timezone={topLevelInfo.user.timezone}
+                  topLevelInfo={topLevelInfo}
+                  personTasks={personTasks}
+                  geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+                />
+              ) : (
+                <EntityNoNothingCard
+                  title="You Have To Start Somewhere"
+                  message="There are no upcoming catch ups."
+                  newEntityLocations="/app/workspace/prm/persons/new"
+                  helpSubject={DocsHelpSubject.PRM}
+                />
+              )}
+            </TabPanel>
+          </>
+        )}
+      </NestingAwareBlock>
       <AnimatePresence mode="wait" initial={false}>
         <Outlet />
       </AnimatePresence>
     </TrunkPanel>
+  );
+}
+
+interface PersonCardProps {
+  entry: PersonFindResultEntry;
+  circlesByRefId: Map<string, { ref_id: string; name: unknown }>;
+}
+
+function PersonCard({ entry, circlesByRefId }: PersonCardProps) {
+  return (
+    <EntityCard entityId={`person-${entry.person.ref_id}`}>
+      <EntityLink to={`/app/workspace/prm/persons/${entry.person.ref_id}`}>
+        <EntityNameComponent name={entry.contact.name} />
+        {entry.circle_ref_ids.length > 0 && (
+          <>
+            {entry.circle_ref_ids
+              .map((circleRefId) => circlesByRefId.get(circleRefId))
+              .filter((c): c is NonNullable<typeof c> => Boolean(c))
+              .map((circle) => (
+                <CircleTag key={`circle-${circle.ref_id}`} circle={circle} />
+              ))}
+          </>
+        )}
+        {entry.person.catch_up_params && (
+          <>
+            <PeriodTag period={entry.person.catch_up_params.period} />
+            {entry.person.catch_up_params.eisen && (
+              <EisenTag eisen={entry.person.catch_up_params.eisen} />
+            )}
+            {entry.person.catch_up_params.difficulty && (
+              <DifficultyTag
+                difficulty={entry.person.catch_up_params.difficulty}
+              />
+            )}
+          </>
+        )}
+        {entry.tags?.map((tag: Tag) => (
+          <TagTag key={tag.ref_id} tag={tag} />
+        ))}
+      </EntityLink>
+    </EntityCard>
   );
 }
 

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -348,7 +348,7 @@ export default function Persons() {
               onChange={(_, newValue) => setSmallScreenTab(newValue)}
             >
               <Tab label="People" />
-              <Tab label="Celebrations" />
+              <Tab label="Occasions" />
               <Tab label="Catch Ups" />
             </Tabs>
 

--- a/src/webui/app/routes/app/workspace/prm/persons.tsx
+++ b/src/webui/app/routes/app/workspace/prm/persons.tsx
@@ -3,10 +3,18 @@ import GroupWorkIcon from "@mui/icons-material/GroupWork";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { Outlet } from "@remix-run/react";
+import { Outlet, useFetcher } from "@remix-run/react";
 import { AnimatePresence } from "framer-motion";
 import { useContext, useState } from "react";
-import { DocsHelpSubject, TagNamespace } from "@jupiter/webapi-client";
+import {
+  DocsHelpSubject,
+  InboxTask,
+  InboxTaskSource,
+  InboxTaskStatus,
+  TagNamespace,
+  WidgetDimension,
+  WorkspaceFeature,
+} from "@jupiter/webapi-client";
 import type { PersonFindResultEntry, Tag } from "@jupiter/webapi-client";
 import { DifficultyTag } from "@jupiter/core/common/component/difficulty-tag";
 import { EisenTag } from "@jupiter/core/common/component/eisen-tag";
@@ -35,6 +43,17 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { TagTag } from "#/core/common/sub/tags/component/tag-tag";
+import {
+  inboxTaskFindEntryToParent,
+  InboxTaskOptimisticState,
+  sortInboxTasksNaturally,
+} from "@jupiter/core/inbox_tasks/root";
+import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
+import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
+import { UpcomingBirthdaysWidget } from "@jupiter/core/prm/sub/person/component/upcoming-birthdays-widget";
+import { UpcomingCatchUpsWidget } from "@jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget";
+import { Box, Divider, Typography } from "@mui/material";
+import { DateTime } from "luxon";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
@@ -46,6 +65,12 @@ export const handle = {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
+
+  const summaryResponse = await apiClient.application.getSummaries({
+    include_workspace: true,
+  });
+  const workspace = summaryResponse.workspace!;
+
   const body = await apiClient.prm.personFind({
     allow_archived: false,
     include_occasions: false,
@@ -67,10 +92,25 @@ export async function loader({ request }: LoaderFunctionArgs) {
     filter_namespace: [TagNamespace.PERSON],
   });
 
+  let personInboxTasksResponse = undefined;
+  if (isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.PRM)) {
+    personInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
+      allow_archived: false,
+      include_tags: true,
+      include_notes: false,
+      include_time_event_blocks: false,
+      filter_sources: [
+        InboxTaskSource.PERSON_OCCASION,
+        InboxTaskSource.PERSON_CATCH_UP,
+      ],
+    });
+  }
+
   return json({
     entries: body.entries,
     allCircles: circlesResult.circles,
     allTags: allTags.tags,
+    personInboxTasks: personInboxTasksResponse?.entries,
   });
 }
 
@@ -80,6 +120,7 @@ export const shouldRevalidate: ShouldRevalidateFunction =
 export default function Persons() {
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const topLevelInfo = useContext(TopLevelInfoContext);
+  const isBigScreen = useBigScreen();
 
   const entries = loaderData.entries as Array<PersonFindResultEntry>;
 
@@ -87,6 +128,9 @@ export default function Persons() {
     [],
   );
   const [selectedTagsRefId, setSelectedTagsRefId] = useState<string[]>([]);
+  const [optimisticUpdates, setOptimisticUpdates] = useState<{
+    [key: string]: InboxTaskOptimisticState;
+  }>({});
 
   const circlesByRefId = new Map(
     loaderData.allCircles.map((c) => [c.ref_id, c]),
@@ -109,6 +153,76 @@ export default function Persons() {
       selectedTagsRefId.includes(tag.ref_id),
     );
   });
+
+  const sortedPersonInboxTasks = loaderData.personInboxTasks
+    ? sortInboxTasksNaturally(
+        loaderData.personInboxTasks.map((e) => e.inbox_task),
+      )
+    : undefined;
+
+  const personEntriesByRefId: { [key: string]: ReturnType<typeof inboxTaskFindEntryToParent> } = {};
+  if (loaderData.personInboxTasks) {
+    for (const entry of loaderData.personInboxTasks) {
+      personEntriesByRefId[entry.inbox_task.ref_id] =
+        inboxTaskFindEntryToParent(entry);
+    }
+  }
+
+  const cardActionFetcher = useFetcher();
+
+  function handleCardMarkDone(it: InboxTask) {
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [it.ref_id]: {
+        status: InboxTaskStatus.DONE,
+        eisen: prev[it.ref_id]?.eisen ?? it.eisen,
+      },
+    }));
+    setTimeout(() => {
+      cardActionFetcher.submit(
+        { id: it.ref_id, status: InboxTaskStatus.DONE },
+        {
+          method: "post",
+          action: "/app/workspace/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    }, 0);
+  }
+
+  function handleCardMarkNotDone(it: InboxTask) {
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [it.ref_id]: {
+        status: InboxTaskStatus.NOT_DONE,
+        eisen: prev[it.ref_id]?.eisen ?? it.eisen,
+      },
+    }));
+    setTimeout(() => {
+      cardActionFetcher.submit(
+        { id: it.ref_id, status: InboxTaskStatus.NOT_DONE },
+        {
+          method: "post",
+          action: "/app/workspace/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    }, 0);
+  }
+
+  const rightNow = DateTime.local({ zone: topLevelInfo.user.timezone });
+
+  const personTasks =
+    sortedPersonInboxTasks !== undefined
+      ? {
+          personInboxTasks: sortedPersonInboxTasks,
+          personEntriesByRefId,
+          optimisticUpdates,
+          onCardMarkDone: handleCardMarkDone,
+          onCardMarkNotDone: handleCardMarkNotDone,
+        }
+      : undefined;
+
+  const showSidebar =
+    isBigScreen && personTasks !== undefined;
 
   const shouldShowALeaf = useTrunkNeedsToShowLeaf();
   const shouldShowALeaflet = useLeafNeedsToShowLeaflet();
@@ -157,62 +271,112 @@ export default function Persons() {
         />
       }
     >
-      <NestingAwareBlock shouldHide={shouldShowALeaf || shouldShowALeaflet}>
-        {filteredEntries.length === 0 && (
-          <EntityNoNothingCard
-            title="You Have To Start Somewhere"
-            message="There are no persons to show with the current filters. You can create a new person."
-            newEntityLocations="/app/workspace/prm/persons/new"
-            helpSubject={DocsHelpSubject.PRM}
-          />
+      <Box
+        sx={
+          showSidebar
+            ? { display: "flex", alignItems: "flex-start", gap: 2 }
+            : {}
+        }
+      >
+        <Box sx={showSidebar ? { flex: 1, minWidth: 0 } : {}}>
+          <NestingAwareBlock shouldHide={shouldShowALeaf || shouldShowALeaflet}>
+            {filteredEntries.length === 0 && (
+              <EntityNoNothingCard
+                title="You Have To Start Somewhere"
+                message="There are no persons to show with the current filters. You can create a new person."
+                newEntityLocations="/app/workspace/prm/persons/new"
+                helpSubject={DocsHelpSubject.PRM}
+              />
+            )}
+
+            <EntityStack>
+              {filteredEntries.map((entry) => (
+                <EntityCard
+                  entityId={`person-${entry.person.ref_id}`}
+                  key={`person-${entry.person.ref_id}`}
+                >
+                  <EntityLink
+                    to={`/app/workspace/prm/persons/${entry.person.ref_id}`}
+                  >
+                    <EntityNameComponent name={entry.contact.name} />
+                    {entry.circle_ref_ids.length > 0 && (
+                      <>
+                        {entry.circle_ref_ids
+                          .map((circleRefId) => circlesByRefId.get(circleRefId))
+                          .filter((c): c is NonNullable<typeof c> => Boolean(c))
+                          .map((circle) => (
+                            <CircleTag
+                              key={`circle-${circle.ref_id}`}
+                              circle={circle}
+                            />
+                          ))}
+                      </>
+                    )}
+
+                    {entry.person.catch_up_params && (
+                      <>
+                        <PeriodTag period={entry.person.catch_up_params.period} />
+                        {entry.person.catch_up_params.eisen && (
+                          <EisenTag eisen={entry.person.catch_up_params.eisen} />
+                        )}
+                        {entry.person.catch_up_params.difficulty && (
+                          <DifficultyTag
+                            difficulty={entry.person.catch_up_params.difficulty}
+                          />
+                        )}
+                      </>
+                    )}
+
+                    {entry.tags?.map((tag: Tag) => (
+                      <TagTag key={tag.ref_id} tag={tag} />
+                    ))}
+                  </EntityLink>
+                </EntityCard>
+              ))}
+            </EntityStack>
+          </NestingAwareBlock>
+        </Box>
+
+        {showSidebar && !shouldShowALeaf && !shouldShowALeaflet && (
+          <Box
+            sx={{
+              width: "320px",
+              flexShrink: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
+            <Box>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Upcoming Celebrations
+              </Typography>
+              <UpcomingBirthdaysWidget
+                rightNow={rightNow}
+                timezone={topLevelInfo.user.timezone}
+                topLevelInfo={topLevelInfo}
+                personTasks={personTasks}
+                geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+              />
+            </Box>
+
+            <Divider />
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Upcoming Catch Ups
+              </Typography>
+              <UpcomingCatchUpsWidget
+                rightNow={rightNow}
+                timezone={topLevelInfo.user.timezone}
+                topLevelInfo={topLevelInfo}
+                personTasks={personTasks}
+                geometry={{ row: 0, col: 0, dimension: WidgetDimension.DIM_KX1 }}
+              />
+            </Box>
+          </Box>
         )}
-
-        <EntityStack>
-          {filteredEntries.map((entry) => (
-            <EntityCard
-              entityId={`person-${entry.person.ref_id}`}
-              key={`person-${entry.person.ref_id}`}
-            >
-              <EntityLink
-                to={`/app/workspace/prm/persons/${entry.person.ref_id}`}
-              >
-                <EntityNameComponent name={entry.contact.name} />
-                {entry.circle_ref_ids.length > 0 && (
-                  <>
-                    {entry.circle_ref_ids
-                      .map((circleRefId) => circlesByRefId.get(circleRefId))
-                      .filter((c): c is NonNullable<typeof c> => Boolean(c))
-                      .map((circle) => (
-                        <CircleTag
-                          key={`circle-${circle.ref_id}`}
-                          circle={circle}
-                        />
-                      ))}
-                  </>
-                )}
-
-                {entry.person.catch_up_params && (
-                  <>
-                    <PeriodTag period={entry.person.catch_up_params.period} />
-                    {entry.person.catch_up_params.eisen && (
-                      <EisenTag eisen={entry.person.catch_up_params.eisen} />
-                    )}
-                    {entry.person.catch_up_params.difficulty && (
-                      <DifficultyTag
-                        difficulty={entry.person.catch_up_params.difficulty}
-                      />
-                    )}
-                  </>
-                )}
-
-                {entry.tags?.map((tag: Tag) => (
-                  <TagTag key={tag.ref_id} tag={tag} />
-                ))}
-              </EntityLink>
-            </EntityCard>
-          ))}
-        </EntityStack>
-      </NestingAwareBlock>
+      </Box>
       <AnimatePresence mode="wait" initial={false}>
         <Outlet />
       </AnimatePresence>


### PR DESCRIPTION
On big screens, shows a right-side column with two widgets:
- Upcoming Celebrations: reuses UpcomingBirthdaysWidget to show person
  occasion tasks due within 3 months
- Upcoming Catch Ups: new UpcomingCatchUpsWidget showing catch-up tasks
  due within 1 month

Also loads person inbox tasks (occasion + catch-up sources) in the
persons page loader to power the sidebar widgets.

https://claude.ai/code/session_01RiC8HZeTsZdioUPkdhqEhB