### PR TITLE
Add delay by 1 day/week/month buttons to inbox task editor

### DIFF
--- a/src/core/jupiter/core/inbox_tasks/component/properties-editor.tsx
+++ b/src/core/jupiter/core/inbox_tasks/component/properties-editor.tsx
@@ -631,6 +631,41 @@ export function InboxTaskPropertiesEditor(
               </Button>
             </ButtonGroup>
           )}
+
+          {corePropertyEditable && (
+            <ButtonGroup fullWidth>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={!props.inputsEnabled}
+                type="submit"
+                name="intent"
+                value={constructIntentName(props.intentPrefix, "delay-1-day")}
+              >
+                Delay by 1 Day
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={!props.inputsEnabled}
+                type="submit"
+                name="intent"
+                value={constructIntentName(props.intentPrefix, "delay-1-week")}
+              >
+                Delay by 1 Week
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={!props.inputsEnabled}
+                type="submit"
+                name="intent"
+                value={constructIntentName(props.intentPrefix, "delay-1-month")}
+              >
+                Delay by 1 Month
+              </Button>
+            </ButtonGroup>
+          )}
         </Stack>
       </CardActions>
     </SectionCard>

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
@@ -8,6 +8,7 @@ import type {
   Tag,
   Contact,
 } from "@jupiter/webapi-client";
+import { DateTime } from "luxon";
 import {
   ApiError,
   BigPlanStatus,
@@ -146,6 +147,18 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
   }),
   z.object({
     intent: z.literal("inbox-task-update"),
+    ...UpdateFormInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("inbox-task-delay-1-day"),
+    ...UpdateFormInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("inbox-task-delay-1-week"),
+    ...UpdateFormInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("inbox-task-delay-1-month"),
     ...UpdateFormInboxTaskSchema,
   }),
   z.object({
@@ -420,6 +433,64 @@ export async function action({ request, params }: ActionFunctionArgs) {
             },
           });
         }
+
+        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+      }
+
+      case "inbox-task-delay-1-day":
+      case "inbox-task-delay-1-week":
+      case "inbox-task-delay-1-month": {
+        const today = DateTime.now().startOf("day");
+        const delay =
+          form.intent === "inbox-task-delay-1-day"
+            ? { days: 1 }
+            : form.intent === "inbox-task-delay-1-week"
+              ? { weeks: 1 }
+              : { months: 1 };
+        const newActionableDate = today.plus(delay);
+
+        let newDueDate: DateTime | undefined;
+        if (
+          form.inboxTaskDueDate !== undefined &&
+          form.inboxTaskDueDate !== ""
+        ) {
+          const oldDueDate = DateTime.fromISO(form.inboxTaskDueDate);
+          if (
+            form.inboxTaskActionableDate !== undefined &&
+            form.inboxTaskActionableDate !== ""
+          ) {
+            const oldActionableDate = DateTime.fromISO(
+              form.inboxTaskActionableDate,
+            );
+            const gapDays = oldDueDate.diff(oldActionableDate, "days").days;
+            newDueDate = newActionableDate.plus({ days: gapDays });
+          } else {
+            newDueDate = newActionableDate;
+          }
+        }
+
+        await apiClient.inboxTasks.inboxTaskUpdate({
+          ref_id: form.inboxTaskRefId,
+          name: { should_change: false },
+          status: { should_change: false },
+          project_ref_id: { should_change: false },
+          chapter_ref_id: { should_change: false },
+          goal_ref_id: { should_change: false },
+          big_plan_ref_id: { should_change: false },
+          is_key: { should_change: false },
+          eisen: { should_change: false },
+          difficulty: { should_change: false },
+          actionable_date: {
+            should_change: true,
+            value: newActionableDate.toISODate() ?? undefined,
+          },
+          due_date: {
+            should_change: true,
+            value: newDueDate
+              ? (newDueDate.toISODate() ?? undefined)
+              : undefined,
+          },
+        });
 
         return redirect(`/app/workspace/calendar?${url.searchParams}`);
       }

--- a/src/webui/app/routes/app/workspace/inbox-tasks/$id.tsx
+++ b/src/webui/app/routes/app/workspace/inbox-tasks/$id.tsx
@@ -9,6 +9,7 @@ import type {
   Contact,
   Workspace,
 } from "@jupiter/webapi-client";
+import { DateTime } from "luxon";
 import {
   ApiError,
   Difficulty,
@@ -111,6 +112,18 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
   }),
   z.object({
     intent: z.literal("update"),
+    ...CommonParamsSchema,
+  }),
+  z.object({
+    intent: z.literal("delay-1-day"),
+    ...CommonParamsSchema,
+  }),
+  z.object({
+    intent: z.literal("delay-1-week"),
+    ...CommonParamsSchema,
+  }),
+  z.object({
+    intent: z.literal("delay-1-month"),
     ...CommonParamsSchema,
   }),
   z.object({
@@ -311,6 +324,54 @@ export async function action({ request, params }: ActionFunctionArgs) {
             },
           });
         }
+
+        return redirect(`/app/workspace/inbox-tasks`);
+      }
+
+      case "delay-1-day":
+      case "delay-1-week":
+      case "delay-1-month": {
+        const today = DateTime.now().startOf("day");
+        const delay =
+          form.intent === "delay-1-day"
+            ? { days: 1 }
+            : form.intent === "delay-1-week"
+              ? { weeks: 1 }
+              : { months: 1 };
+        const newActionableDate = today.plus(delay);
+
+        let newDueDate: DateTime | undefined;
+        if (form.dueDate !== undefined && form.dueDate !== "") {
+          const oldDueDate = DateTime.fromISO(form.dueDate);
+          if (form.actionableDate !== undefined && form.actionableDate !== "") {
+            const oldActionableDate = DateTime.fromISO(form.actionableDate);
+            const gapDays = oldDueDate.diff(oldActionableDate, "days").days;
+            newDueDate = newActionableDate.plus({ days: gapDays });
+          } else {
+            newDueDate = newActionableDate;
+          }
+        }
+
+        await apiClient.inboxTasks.inboxTaskUpdate({
+          ref_id: id,
+          name: { should_change: false },
+          status: { should_change: false },
+          project_ref_id: { should_change: false },
+          chapter_ref_id: { should_change: false },
+          goal_ref_id: { should_change: false },
+          big_plan_ref_id: { should_change: false },
+          is_key: { should_change: false },
+          eisen: { should_change: false },
+          difficulty: { should_change: false },
+          actionable_date: {
+            should_change: true,
+            value: newActionableDate.toISODate() ?? undefined,
+          },
+          due_date: {
+            should_change: true,
+            value: newDueDate ? (newDueDate.toISODate() ?? undefined) : undefined,
+          },
+        });
 
         return redirect(`/app/workspace/inbox-tasks`);
       }

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -6,6 +6,7 @@ import type {
   Tag,
   Contact,
 } from "@jupiter/webapi-client";
+import { DateTime } from "luxon";
 import {
   ApiError,
   BigPlanStatus,
@@ -150,6 +151,18 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
   }),
   z.object({
     intent: z.literal("target-inbox-task-update"),
+    ...UpdateFormTargetInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("target-inbox-task-delay-1-day"),
+    ...UpdateFormTargetInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("target-inbox-task-delay-1-week"),
+    ...UpdateFormTargetInboxTaskSchema,
+  }),
+  z.object({
+    intent: z.literal("target-inbox-task-delay-1-month"),
     ...UpdateFormTargetInboxTaskSchema,
   }),
   z.object({
@@ -446,6 +459,64 @@ export async function action({ request, params }: ActionFunctionArgs) {
             },
           });
         }
+
+        return redirect(`/app/workspace/time-plans/${id}`);
+      }
+
+      case "target-inbox-task-delay-1-day":
+      case "target-inbox-task-delay-1-week":
+      case "target-inbox-task-delay-1-month": {
+        const today = DateTime.now().startOf("day");
+        const delay =
+          form.intent === "target-inbox-task-delay-1-day"
+            ? { days: 1 }
+            : form.intent === "target-inbox-task-delay-1-week"
+              ? { weeks: 1 }
+              : { months: 1 };
+        const newActionableDate = today.plus(delay);
+
+        let newDueDate: DateTime | undefined;
+        if (
+          form.targetInboxTaskDueDate !== undefined &&
+          form.targetInboxTaskDueDate !== ""
+        ) {
+          const oldDueDate = DateTime.fromISO(form.targetInboxTaskDueDate);
+          if (
+            form.targetInboxTaskActionableDate !== undefined &&
+            form.targetInboxTaskActionableDate !== ""
+          ) {
+            const oldActionableDate = DateTime.fromISO(
+              form.targetInboxTaskActionableDate,
+            );
+            const gapDays = oldDueDate.diff(oldActionableDate, "days").days;
+            newDueDate = newActionableDate.plus({ days: gapDays });
+          } else {
+            newDueDate = newActionableDate;
+          }
+        }
+
+        await apiClient.inboxTasks.inboxTaskUpdate({
+          ref_id: form.targetInboxTaskRefId,
+          name: { should_change: false },
+          status: { should_change: false },
+          project_ref_id: { should_change: false },
+          chapter_ref_id: { should_change: false },
+          goal_ref_id: { should_change: false },
+          big_plan_ref_id: { should_change: false },
+          is_key: { should_change: false },
+          eisen: { should_change: false },
+          difficulty: { should_change: false },
+          actionable_date: {
+            should_change: true,
+            value: newActionableDate.toISODate() ?? undefined,
+          },
+          due_date: {
+            should_change: true,
+            value: newDueDate
+              ? (newDueDate.toISODate() ?? undefined)
+              : undefined,
+          },
+        });
 
         return redirect(`/app/workspace/time-plans/${id}`);
       }


### PR DESCRIPTION
Adds three delay buttons (Delay by 1 Day, Delay by 1 Week, Delay by 1 Month)
to the inbox task properties editor. These buttons are only shown for core-editable
tasks (source USER or BIG_PLAN) and move the actionable date to today + delay,
preserving the gap between actionable and due dates.

Handles the new intents in all three WebUI routes that embed the
InboxTaskPropertiesEditor: inbox-tasks/$id, time-plans/$id/$activityId,
and calendar/time-event/in-day-block/$id.

https://claude.ai/code/session_01DQ5HwYA3qbcPUZS5kFn3ZJ