### PR TITLE
Fix broken entity summary links causing 404 errors in search results

### DIFF
--- a/src/core/jupiter/core/common/component/entity-summary-link.tsx
+++ b/src/core/jupiter/core/common/component/entity-summary-link.tsx
@@ -73,7 +73,7 @@ export function EntitySummaryLink({
       );
     case NamedEntityTag.WORKING_MEM:
       return (
-        <EntityLink to={`/app/workspace/working-mem/archive/${summary.ref_id}`}>
+        <EntityLink to={`/app/workspace/working-mem`}>
           <SlimChip label={"Working Mem"} color={"primary"} />
           {commonSequence}
         </EntityLink>
@@ -220,7 +220,7 @@ export function EntitySummaryLink({
       );
     case NamedEntityTag.METRIC:
       return (
-        <EntityLink to={`/app/workspace/metrics/${summary.ref_id}/entries`}>
+        <EntityLink to={`/app/workspace/metrics/${summary.ref_id}`}>
           <SlimChip label={"Metric"} color={"primary"} />
           {commonSequence}
         </EntityLink>
@@ -248,14 +248,14 @@ export function EntitySummaryLink({
       );
     case NamedEntityTag.SLACK_TASK:
       return (
-        <EntityLink to={`/app/workspace/slack-tasks/${summary.ref_id}`}>
+        <EntityLink to={`/app/workspace/push-integrations/slack-tasks/${summary.ref_id}`}>
           <SlimChip label={"Slack Tasks"} color={"primary"} />
           {commonSequence}
         </EntityLink>
       );
     case NamedEntityTag.EMAIL_TASK:
       return (
-        <EntityLink to={`/app/workspace/email-tasks/${summary.ref_id}`}>
+        <EntityLink to={`/app/workspace/push-integrations/email-tasks/${summary.ref_id}`}>
           <SlimChip label={"Email Tasks"} color={"primary"} />
           {commonSequence}
         </EntityLink>


### PR DESCRIPTION
Four entity types had incorrect URLs in EntitySummaryLink:
- WORKING_MEM: pointed to /working-mem/archive/:id which was removed in the
  single-working-mem refactor; now links to /working-mem
- METRIC: pointed to /metrics/:id/entries which has no route; now links to /metrics/:id
- SLACK_TASK: was missing the push-integrations/ prefix in the path
- EMAIL_TASK: was missing the push-integrations/ prefix in the path

https://claude.ai/code/session_01CGzuevgWiMUWk4PGZRynm3