### PR TITLE
Make mobile loading/error pages and Android background respect device theme

### DIFF
--- a/src/mobile/android/app/src/main/res/values-night/styles.xml
+++ b/src/mobile/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:background">@null</item>
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+
+</resources>

--- a/src/mobile/android/app/src/main/res/values/styles.xml
+++ b/src/mobile/android/app/src/main/res/values/styles.xml
@@ -13,6 +13,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:windowBackground">@android:color/white</item>
     </style>
 
 

--- a/src/mobile/src/error.html
+++ b/src/mobile/src/error.html
@@ -11,6 +11,15 @@
         {{#if ios}}
         font-size: 40px;
         {{/if}}
+        background-color: #ffffff;
+        color: #000000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #000000;
+          color: #ffffff;
+        }
       }
 
       .container {

--- a/src/mobile/src/index.html
+++ b/src/mobile/src/index.html
@@ -6,6 +6,15 @@
       body {
         font-family: "Helvetica", "Arial", sans-serif;
         font-size: 28px;
+        background-color: #ffffff;
+        color: #000000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #000000;
+          color: #ffffff;
+        }
       }
 
       .container {


### PR DESCRIPTION
Add CSS prefers-color-scheme media queries to index.html and error.html so the
loading and error screens use a dark background with light text in dark mode.
Create Android values-night/styles.xml to set the native window background to
black in dark mode, and explicitly set it to white in light mode.

https://claude.ai/code/session_01CRPPesVxSBFyVA6DVsmvZn