### PR TITLE
Add overdue label to big plans, with danger sign in timeline views

### DIFF
--- a/src/core/jupiter/core/big_plans/component/card.tsx
+++ b/src/core/jupiter/core/big_plans/component/card.tsx
@@ -1,18 +1,25 @@
 import type {
+  ADate,
   BigPlan,
   BigPlanMilestone,
   BigPlanStats,
+  BigPlanStatus,
   Chapter,
   Goal,
   Project,
   Tag,
 } from "@jupiter/webapi-client";
 import { WorkspaceFeature } from "@jupiter/webapi-client";
-import { Divider } from "@mui/material";
+import type { ChipProps } from "@mui/material";
+import { Chip, Divider, styled } from "@mui/material";
+import { useContext } from "react";
 
 import { aDateToDate } from "#/core/common/adate";
 import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
 import { bigPlanDonePct, type BigPlanParent } from "#/core/big_plans/root";
+import { isCompleted } from "#/core/big_plans/status";
+import { ClientOnly } from "#/core/infra/component/client-only";
+import { ServicePropertiesContext } from "#/core/config-client";
 import type { TopLevelInfo } from "#/core/infra/top-level-context";
 import { ADateTag } from "#/core/common/component/adate-tag";
 import { BigPlanStatusTag } from "#/core/big_plans/component/status-tag";
@@ -89,6 +96,11 @@ export function BigPlanCard(props: BigPlanCardProps) {
           : undefined
       }
     >
+      <OverdueWarning
+        today={props.topLevelInfo.today}
+        status={props.bigPlan.status}
+        dueDate={props.bigPlan.due_date}
+      />
       <EntityLink
         to={`/app/workspace/big-plans/${props.bigPlan.ref_id}`}
         block={props.onClick !== undefined}
@@ -164,3 +176,62 @@ export function BigPlanCard(props: BigPlanCardProps) {
     </EntityCard>
   );
 }
+
+interface OverdueWarningProps {
+  today: ADate;
+  status: BigPlanStatus;
+  dueDate?: ADate | null;
+}
+
+function OverdueWarning({ today, status, dueDate }: OverdueWarningProps) {
+  const serviceProperties = useContext(ServicePropertiesContext);
+
+  if (isCompleted(status)) {
+    return null;
+  }
+
+  if (!dueDate) {
+    return null;
+  }
+
+  const theToday = aDateToDate(today);
+  const theDueDate = aDateToDate(dueDate);
+
+  return (
+    <ClientOnly fallback={<></>}>
+      {() => {
+        if (
+          theDueDate <=
+          theToday.minus({ days: serviceProperties.overdueDangerDays })
+        ) {
+          return <OverdueWarningChip label="Overdue" color="error" />;
+        } else if (
+          theDueDate <=
+          theToday.minus({ days: serviceProperties.overdueWarningDays })
+        ) {
+          return <OverdueWarningChip label="Overdue" color="warning" />;
+        } else if (
+          theDueDate <=
+          theToday.minus({ days: serviceProperties.overdueInfoDays })
+        ) {
+          return <OverdueWarningChip label="Overdue" color="info" />;
+        }
+        return null;
+      }}
+    </ClientOnly>
+  );
+}
+
+const OverdueWarningChip = styled(Chip)<ChipProps>(() => ({
+  position: "absolute",
+  top: "0px",
+  fontSize: "0.75rem",
+  height: "1rem",
+  left: "0px",
+  paddingTop: "0.05rem",
+  paddingBottom: "0.05rem",
+  paddingRight: "0.5rem",
+  paddingLeft: "0.5rem",
+  borderRadius: "0px",
+  borderBottomRightRadius: "4px",
+}));

--- a/src/core/jupiter/core/big_plans/component/timeline-big-screen.tsx
+++ b/src/core/jupiter/core/big_plans/component/timeline-big-screen.tsx
@@ -21,6 +21,7 @@ import type { DateTime } from "luxon";
 
 import { aDateToDate } from "#/core/common/adate";
 import { bigPlanDonePct } from "#/core/big_plans/root";
+import { isCompleted } from "#/core/big_plans/status";
 import { BigPlanStatusTag } from "#/core/big_plans/component/status-tag";
 import { EntityNameOneLineComponent } from "#/core/common/component/entity-name";
 import { EntityLink } from "#/core/infra/component/entity-card";
@@ -36,6 +37,7 @@ interface DateMarker {
 }
 
 interface BigPlanTimelineBigScreenProps {
+  today: ADate;
   thisYear: DateTime;
   bigPlans: Array<BigPlan>;
   bigPlanMilestonesByRefId: Map<string, Array<BigPlanMilestone>>;
@@ -47,6 +49,7 @@ interface BigPlanTimelineBigScreenProps {
 }
 
 export function BigPlanTimelineBigScreen({
+  today,
   thisYear,
   bigPlans,
   bigPlanMilestonesByRefId,
@@ -112,6 +115,7 @@ export function BigPlanTimelineBigScreen({
                     singleLine
                   >
                     <IsKeyTag isKey={entry.is_key} />
+                    <OverdueSign today={today} entry={entry} />
                     <EntityNameOneLineComponent name={entry.name} />
                   </EntityLink>
                 </TableCell>
@@ -286,4 +290,32 @@ function computeBigPlanGnattPosition(thisYear: DateTime, entry: BigPlan) {
   const betterLeftMargin = leftMargin > 0.6 ? 0.6 : leftMargin;
 
   return { leftMargin, width, betterWidth, betterLeftMargin };
+}
+
+interface OverdueSignProps {
+  today: ADate;
+  entry: BigPlan;
+}
+
+function OverdueSign({ today, entry }: OverdueSignProps) {
+  if (isCompleted(entry.status)) {
+    return null;
+  }
+
+  if (!entry.due_date) {
+    return null;
+  }
+
+  const theToday = aDateToDate(today);
+  const theDueDate = aDateToDate(entry.due_date);
+
+  if (theDueDate >= theToday) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="Overdue" placement="top">
+      <span>⚠️</span>
+    </Tooltip>
+  );
 }

--- a/src/core/jupiter/core/big_plans/component/timeline-small-screen.tsx
+++ b/src/core/jupiter/core/big_plans/component/timeline-small-screen.tsx
@@ -10,6 +10,7 @@ import type { DateTime } from "luxon";
 
 import { aDateToDate } from "#/core/common/adate";
 import { bigPlanDonePct } from "#/core/big_plans/root";
+import { isCompleted } from "#/core/big_plans/status";
 import { BigPlanStatusTag } from "#/core/big_plans/component/status-tag";
 import { EntityNameOneLineComponent } from "#/core/common/component/entity-name";
 import { EntityStack } from "#/core/infra/component/entity-stack";
@@ -22,6 +23,7 @@ interface DateMarker {
 }
 
 interface BigPlanTimelineSmallScreenProps {
+  today: ADate;
   thisYear: DateTime;
   bigPlans: Array<BigPlan>;
   bigPlanMilestonesByRefId: Map<string, Array<BigPlanMilestone>>;
@@ -33,6 +35,7 @@ interface BigPlanTimelineSmallScreenProps {
 }
 
 export function BigPlanTimelineSmallScreen({
+  today,
   thisYear,
   bigPlans,
   bigPlanMilestonesByRefId,
@@ -134,6 +137,7 @@ export function BigPlanTimelineSmallScreen({
               >
                 <BigPlanStatusTag status={bigPlan.status} format="icon" />
                 <IsKeyTag isKey={bigPlan.is_key} />
+                <OverdueSign today={today} bigPlan={bigPlan} />
                 <EntityNameOneLineComponent
                   name={`[${bigPlanDonePct(
                     bigPlan,
@@ -342,4 +346,32 @@ function computeMarkerPosition(thisYear: DateTime, date: ADate): number {
   } else {
     return markerDate.ordinal / startOfYear.daysInYear;
   }
+}
+
+interface OverdueSignProps {
+  today: ADate;
+  bigPlan: BigPlan;
+}
+
+function OverdueSign({ today, bigPlan }: OverdueSignProps) {
+  if (isCompleted(bigPlan.status)) {
+    return null;
+  }
+
+  if (!bigPlan.due_date) {
+    return null;
+  }
+
+  const theToday = aDateToDate(today);
+  const theDueDate = aDateToDate(bigPlan.due_date);
+
+  if (theDueDate >= theToday) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="Overdue" placement="top">
+      <span>⚠️</span>
+    </Tooltip>
+  );
 }

--- a/src/webui/app/routes/app/workspace/big-plans.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans.tsx
@@ -248,6 +248,7 @@ export default function BigPlans() {
                     <>
                       {isBigScreen && (
                         <BigPlanTimelineBigScreen
+                          today={topLevelInfo.today}
                           thisYear={thisYear}
                           bigPlans={theBigPlans}
                           bigPlanMilestonesByRefId={bigPlanMilestonesByRefId}
@@ -263,6 +264,7 @@ export default function BigPlans() {
                       )}
                       {!isBigScreen && (
                         <BigPlanTimelineSmallScreen
+                          today={topLevelInfo.today}
                           thisYear={thisYear}
                           bigPlans={theBigPlans}
                           bigPlanMilestonesByRefId={bigPlanMilestonesByRefId}
@@ -287,6 +289,7 @@ export default function BigPlans() {
           <>
             {isBigScreen && (
               <BigPlanTimelineBigScreen
+                today={topLevelInfo.today}
                 thisYear={thisYear}
                 bigPlans={sortedBigPlans}
                 bigPlanMilestonesByRefId={bigPlanMilestonesByRefId}
@@ -302,6 +305,7 @@ export default function BigPlans() {
             )}
             {!isBigScreen && (
               <BigPlanTimelineSmallScreen
+                today={topLevelInfo.today}
                 thisYear={thisYear}
                 bigPlans={sortedBigPlans}
                 bigPlanMilestonesByRefId={bigPlanMilestonesByRefId}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-big-plans.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-big-plans.tsx
@@ -538,6 +538,7 @@ function BigPlanTimeline(props: BigPlanTimelineProps) {
   if (isBigScreen) {
     return (
       <BigPlanTimelineBigScreen
+        today={props.topLevelInfo.today}
         thisYear={props.thisYear}
         bigPlans={props.bigPlans}
         bigPlanMilestonesByRefId={props.bigPlanMilestonesByRefId}
@@ -567,6 +568,7 @@ function BigPlanTimeline(props: BigPlanTimelineProps) {
   } else {
     return (
       <BigPlanTimelineSmallScreen
+        today={props.topLevelInfo.today}
         thisYear={props.thisYear}
         bigPlans={props.bigPlans}
         bigPlanMilestonesByRefId={props.bigPlanMilestonesByRefId}


### PR DESCRIPTION
- BigPlanCard now shows an "Overdue" chip (matching inbox task behavior)
  when the plan has a due_date in the past and is not completed
- Timeline big-screen and small-screen views show a ⚠️ danger sign
  with an "Overdue" tooltip before the plan name when overdue
- Added today prop to both timeline components; updated all callers

https://claude.ai/code/session_01BKM8bfpiXyFTcy6AJ3xcx8