### PR TITLE
Add card border styling for night mode theme

### DIFF
--- a/src/webui/app/root.tsx
+++ b/src/webui/app/root.tsx
@@ -45,6 +45,17 @@ function buildTheme(useNightMode: boolean) {
     typography: {
       fontFamily: '"Helvetica", "Arial", sans-serif',
     },
+    ...(useNightMode && {
+      components: {
+        MuiCard: {
+          styleOverrides: {
+            root: {
+              border: "1px solid rgba(255, 255, 255, 0.12)",
+            },
+          },
+        },
+      },
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
Added visual styling for Material-UI Card components when night mode is enabled, improving contrast and visibility in dark theme.

## Key Changes
- Added conditional theme configuration that applies only when `useNightMode` is true
- Implemented `MuiCard` component style overrides with a subtle border (`1px solid rgba(255, 255, 255, 0.12)`)
- The border uses a semi-transparent white color to maintain consistency with Material Design dark theme guidelines

## Implementation Details
The styling is applied conditionally using the spread operator with a logical AND expression, ensuring the card border styling is only included in the theme configuration when night mode is active. This approach keeps the light theme unaffected while enhancing the visual definition of cards in dark mode.

https://claude.ai/code/session_01LBA6mGqCuCQgpJC6kYE4An