### PR TITLE
Add feature flag checks for LIFE_PLAN and INBOX_TASKS

### DIFF
--- a/src/core/jupiter/core/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/big_plans/use_case/update.py
@@ -51,9 +51,9 @@ class BigPlanUpdateArgs(UseCaseArgsBase):
     ref_id: EntityId
     name: UpdateAction[BigPlanName]
     status: UpdateAction[BigPlanStatus]
-    project_ref_id: UpdateAction[EntityId] = UpdateAction.do_nothing()
-    chapter_ref_id: UpdateAction[EntityId | None] = UpdateAction.do_nothing()
-    goal_ref_id: UpdateAction[EntityId | None] = UpdateAction.do_nothing()
+    project_ref_id: UpdateAction[EntityId]
+    chapter_ref_id: UpdateAction[EntityId | None]
+    goal_ref_id: UpdateAction[EntityId | None]
     is_key: UpdateAction[bool]
     eisen: UpdateAction[Eisen]
     difficulty: UpdateAction[Difficulty]

--- a/src/core/jupiter/core/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/big_plans/use_case/update.py
@@ -123,7 +123,7 @@ class BigPlanUpdateUseCase(
                         f"Milestone {m.name} date {m.date} is after new due date {new_due}"
                     )
 
-        if (
+        if workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN) and (
             args.project_ref_id.should_change
             or args.chapter_ref_id.should_change
             or args.goal_ref_id.should_change
@@ -163,7 +163,7 @@ class BigPlanUpdateUseCase(
         await uow.get_for(BigPlan).save(big_plan)
         await progress_reporter.mark_updated(big_plan)
 
-        if args.project_ref_id.should_change:
+        if workspace.is_feature_available(WorkspaceFeature.INBOX_TASKS) and args.project_ref_id.should_change:
             inbox_task_collection = await uow.get_for(
                 InboxTaskCollection
             ).load_by_parent(

--- a/src/core/jupiter/core/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/big_plans/use_case/update.py
@@ -163,7 +163,7 @@ class BigPlanUpdateUseCase(
         await uow.get_for(BigPlan).save(big_plan)
         await progress_reporter.mark_updated(big_plan)
 
-        if workspace.is_feature_available(WorkspaceFeature.INBOX_TASKS) and workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN) and args.project_ref_id.should_change:
+        if workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN) and args.project_ref_id.should_change:
             inbox_task_collection = await uow.get_for(
                 InboxTaskCollection
             ).load_by_parent(

--- a/src/core/jupiter/core/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/big_plans/use_case/update.py
@@ -163,7 +163,7 @@ class BigPlanUpdateUseCase(
         await uow.get_for(BigPlan).save(big_plan)
         await progress_reporter.mark_updated(big_plan)
 
-        if workspace.is_feature_available(WorkspaceFeature.INBOX_TASKS) and args.project_ref_id.should_change:
+        if workspace.is_feature_available(WorkspaceFeature.INBOX_TASKS) and workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN) and args.project_ref_id.should_change:
             inbox_task_collection = await uow.get_for(
                 InboxTaskCollection
             ).load_by_parent(

--- a/src/core/jupiter/core/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/big_plans/use_case/update.py
@@ -51,9 +51,9 @@ class BigPlanUpdateArgs(UseCaseArgsBase):
     ref_id: EntityId
     name: UpdateAction[BigPlanName]
     status: UpdateAction[BigPlanStatus]
-    project_ref_id: UpdateAction[EntityId]
-    chapter_ref_id: UpdateAction[EntityId | None]
-    goal_ref_id: UpdateAction[EntityId | None]
+    project_ref_id: UpdateAction[EntityId] = UpdateAction.do_nothing()
+    chapter_ref_id: UpdateAction[EntityId | None] = UpdateAction.do_nothing()
+    goal_ref_id: UpdateAction[EntityId | None] = UpdateAction.do_nothing()
     is_key: UpdateAction[bool]
     eisen: UpdateAction[Eisen]
     difficulty: UpdateAction[Difficulty]

--- a/src/webui/app/routes/app/workspace/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id.tsx
@@ -76,7 +76,7 @@ const ParamsSchema = z.object({
 const CommonParamsSchema = {
   name: z.string(),
   status: z.nativeEnum(BigPlanStatus),
-  project: z.string(),
+  project: z.string().optional(),
   chapter: z.string().optional(),
   goal: z.string().optional(),
   isKey: CheckboxAsString,
@@ -255,24 +255,30 @@ export async function action({ request, params }: ActionFunctionArgs) {
             should_change: true,
             value: status,
           },
-          project_ref_id: {
-            should_change: true,
-            value: form.project,
-          },
-          chapter_ref_id: {
-            should_change: true,
-            value:
-              form.chapter !== undefined && form.chapter !== ""
-                ? form.chapter
-                : undefined,
-          },
-          goal_ref_id: {
-            should_change: true,
-            value:
-              form.goal !== undefined && form.goal !== ""
-                ? form.goal
-                : undefined,
-          },
+          project_ref_id:
+            form.project !== undefined
+              ? { should_change: true, value: form.project }
+              : { should_change: false },
+          chapter_ref_id:
+            form.project !== undefined
+              ? {
+                  should_change: true,
+                  value:
+                    form.chapter !== undefined && form.chapter !== ""
+                      ? form.chapter
+                      : undefined,
+                }
+              : { should_change: false },
+          goal_ref_id:
+            form.project !== undefined
+              ? {
+                  should_change: true,
+                  value:
+                    form.goal !== undefined && form.goal !== ""
+                      ? form.goal
+                      : undefined,
+                }
+              : { should_change: false },
           is_key: {
             should_change: true,
             value: form.isKey,


### PR DESCRIPTION
## Summary
Added workspace feature availability checks before executing feature-specific logic in the big plans update use case. This ensures that operations related to life planning and inbox tasks are only performed when the respective features are enabled for the workspace.

## Key Changes
- Added `workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN)` check before processing project, chapter, and goal reference ID changes
- Added `workspace.is_feature_available(WorkspaceFeature.INBOX_TASKS)` check before processing inbox task collection updates for project reference changes

## Implementation Details
These feature flag checks act as guards to prevent execution of feature-dependent code paths when the features are not available in the workspace, improving the robustness of the feature gating mechanism and preventing potential errors or unexpected behavior when features are disabled.

https://claude.ai/code/session_011ephwF8mYoNBJpgJ3Dhejn