### PR TITLE
Add life vision widget to the home dashboard

### DIFF
--- a/gen/ts/webapi-client/gen/models/WidgetType.ts
+++ b/gen/ts/webapi-client/gen/models/WidgetType.ts
@@ -21,4 +21,5 @@ export enum WidgetType {
     GAMIFICATION_HISTORY_WEEKLY = 'gamification-history-weekly',
     GAMIFICATION_HISTORY_MONTHLY = 'gamification-history-monthly',
     LIFE_WEEKS = 'life-weeks',
+    LIFE_VISION = 'life-vision',
 }

--- a/src/core/jupiter/core/home/component/common.tsx
+++ b/src/core/jupiter/core/home/component/common.tsx
@@ -128,8 +128,7 @@ export interface WidgetProps {
   gamificationOverview?: UserScoreOverview;
   gamificationHistory?: UserScoreHistory;
   lifePlan?: LifePlan;
-  activeVision?: Vision;
-  activeVisionNote?: Note;
+  activeVision?: { vision: Vision; note: Note };
   geometry: WidgetGeometry;
 }
 

--- a/src/core/jupiter/core/home/component/common.tsx
+++ b/src/core/jupiter/core/home/component/common.tsx
@@ -3,6 +3,7 @@ import {
   InboxTask,
   LifePlan,
   MOTD,
+  Note,
   Timezone,
   TimePlanActivityDoneness,
   BigPlan,
@@ -15,6 +16,7 @@ import {
   UserScoreOverview,
   UserScoreHistory,
   BigPlanStats,
+  Vision,
   WidgetType,
   WorkspaceFeature,
   UserFeature,
@@ -126,6 +128,8 @@ export interface WidgetProps {
   gamificationOverview?: UserScoreOverview;
   gamificationHistory?: UserScoreHistory;
   lifePlan?: LifePlan;
+  activeVision?: Vision;
+  activeVisionNote?: Note;
   geometry: WidgetGeometry;
 }
 

--- a/src/core/jupiter/core/home/sub/widget/root.ts
+++ b/src/core/jupiter/core/home/sub/widget/root.ts
@@ -38,6 +38,8 @@ export function widgetTypeName(type: WidgetType): string {
       return "Monthly Score History";
     case WidgetType.LIFE_WEEKS:
       return "Life Weeks";
+    case WidgetType.LIFE_VISION:
+      return "Life Vision";
   }
 }
 

--- a/src/core/jupiter/core/home/widget.py
+++ b/src/core/jupiter/core/home/widget.py
@@ -111,6 +111,7 @@ class WidgetType(EnumValue):
     GAMIFICATION_HISTORY_WEEKLY = "gamification-history-weekly"
     GAMIFICATION_HISTORY_MONTHLY = "gamification-history-monthly"
     LIFE_WEEKS = "life-weeks"
+    LIFE_VISION = "life-vision"
 
 
 @value
@@ -342,6 +343,20 @@ WIDGET_CONSTRAINTS = {
         allowed_dimensions={
             HomeTabTarget.BIG_SCREEN: [WidgetDimension.DIM_1x1],
             HomeTabTarget.SMALL_SCREEN: [WidgetDimension.DIM_1x1],
+        },
+        only_for_workspace_features=[WorkspaceFeature.LIFE_PLAN],
+        only_for_user_features=None,
+    ),
+    WidgetType.LIFE_VISION: WidgetTypeConstraints(
+        allowed_dimensions={
+            HomeTabTarget.BIG_SCREEN: [
+                WidgetDimension.DIM_1x1,
+                WidgetDimension.DIM_1x2,
+                WidgetDimension.DIM_1x3,
+            ],
+            HomeTabTarget.SMALL_SCREEN: [
+                WidgetDimension.DIM_1x1,
+            ],
         },
         only_for_workspace_features=[WorkspaceFeature.LIFE_PLAN],
         only_for_user_features=None,

--- a/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
@@ -1,13 +1,41 @@
-import { Box } from "@mui/material";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Link } from "@remix-run/react";
 import { WidgetProps } from "#/core/home/component/common";
 import { VisionSnippet } from "#/core/life_plan/sub/visions/components/snippet";
 
 export function LifeVisionWidget(props: WidgetProps) {
   const { activeVision } = props;
 
+  const editUrl = activeVision
+    ? `/app/workspace/life-plan/visions/${activeVision.vision.ref_id}`
+    : `/app/workspace/life-plan/visions`;
+
   return (
-    <Box sx={{ width: "100%", height: "100%", overflow: "hidden" }}>
-      <VisionSnippet vision={activeVision?.vision} note={activeVision?.note} />
-    </Box>
+    <Stack
+      direction="column"
+      sx={{ width: "100%", height: "100%", gap: 1, overflow: "hidden" }}
+    >
+      <Stack
+        direction="row"
+        sx={{ alignItems: "center", justifyContent: "space-between" }}
+      >
+        <Typography variant="h6" sx={{ fontSize: "0.9rem", fontWeight: "bold" }}>
+          Life Vision
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          component={Link}
+          to={editUrl}
+          sx={{ fontSize: "0.7rem", padding: "2px 8px" }}
+        >
+          Edit
+        </Button>
+      </Stack>
+
+      <Box sx={{ flex: 1, overflow: "hidden" }}>
+        <VisionSnippet vision={activeVision?.vision} note={activeVision?.note} />
+      </Box>
+    </Stack>
   );
 }

--- a/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
@@ -1,37 +1,13 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
-import { Link } from "@remix-run/react";
+import { Box } from "@mui/material";
 import { WidgetProps } from "#/core/home/component/common";
 import { VisionSnippet } from "#/core/life_plan/sub/visions/components/snippet";
 
 export function LifeVisionWidget(props: WidgetProps) {
-  const { activeVision, activeVisionNote } = props;
+  const { activeVision } = props;
 
   return (
-    <Stack
-      direction="column"
-      sx={{ width: "100%", height: "100%", gap: 1, overflow: "hidden" }}
-    >
-      <Stack
-        direction="row"
-        sx={{ alignItems: "center", justifyContent: "space-between" }}
-      >
-        <Typography variant="h6" sx={{ fontSize: "0.9rem", fontWeight: "bold" }}>
-          Life Vision
-        </Typography>
-        <Button
-          size="small"
-          variant="outlined"
-          component={Link}
-          to="/app/workspace/life-plan/visions"
-          sx={{ fontSize: "0.7rem", padding: "2px 8px" }}
-        >
-          View All
-        </Button>
-      </Stack>
-
-      <Box sx={{ flex: 1, overflow: "hidden" }}>
-        <VisionSnippet vision={activeVision} note={activeVisionNote} />
-      </Box>
-    </Stack>
+    <Box sx={{ width: "100%", height: "100%", overflow: "hidden" }}>
+      <VisionSnippet vision={activeVision?.vision} note={activeVision?.note} />
+    </Box>
   );
 }

--- a/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
@@ -6,10 +6,6 @@ import { VisionSnippet } from "#/core/life_plan/sub/visions/components/snippet";
 export function LifeVisionWidget(props: WidgetProps) {
   const { activeVision } = props;
 
-  const editUrl = activeVision
-    ? `/app/workspace/life-plan/visions/${activeVision.vision.ref_id}`
-    : `/app/workspace/life-plan/visions`;
-
   return (
     <Stack
       direction="column"
@@ -26,7 +22,7 @@ export function LifeVisionWidget(props: WidgetProps) {
           size="small"
           variant="outlined"
           component={Link}
-          to={editUrl}
+          to="/app/workspace/life-plan/visions/new-draft"
           sx={{ fontSize: "0.7rem", padding: "2px 8px" }}
         >
           Edit

--- a/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-vision-widget.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Link } from "@remix-run/react";
+import { WidgetProps } from "#/core/home/component/common";
+import { VisionSnippet } from "#/core/life_plan/sub/visions/components/snippet";
+
+export function LifeVisionWidget(props: WidgetProps) {
+  const { activeVision, activeVisionNote } = props;
+
+  return (
+    <Stack
+      direction="column"
+      sx={{ width: "100%", height: "100%", gap: 1, overflow: "hidden" }}
+    >
+      <Stack
+        direction="row"
+        sx={{ alignItems: "center", justifyContent: "space-between" }}
+      >
+        <Typography variant="h6" sx={{ fontSize: "0.9rem", fontWeight: "bold" }}>
+          Life Vision
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          component={Link}
+          to="/app/workspace/life-plan/visions"
+          sx={{ fontSize: "0.7rem", padding: "2px 8px" }}
+        >
+          View All
+        </Button>
+      </Stack>
+
+      <Box sx={{ flex: 1, overflow: "hidden" }}>
+        <VisionSnippet vision={activeVision} note={activeVisionNote} />
+      </Box>
+    </Stack>
+  );
+}

--- a/src/webui/app/routes/app/workspace/index.tsx
+++ b/src/webui/app/routes/app/workspace/index.tsx
@@ -308,8 +308,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     gamificationOverview: userResponse.user_score_overview,
     gamificationHistory: userResponse.user_score_history,
     lifePlan: summaryResponse.life_plan as LifePlan | undefined,
-    activeVision: activeVisionResponse?.vision as Vision | undefined,
-    activeVisionNote: activeVisionResponse?.note as Note | undefined,
+    activeVision:
+      activeVisionResponse?.vision && activeVisionResponse?.note
+        ? { vision: activeVisionResponse.vision as Vision, note: activeVisionResponse.note as Note }
+        : undefined,
   });
 }
 
@@ -546,7 +548,6 @@ export default function WorkspaceHome() {
     gamificationHistory: loaderData.gamificationHistory ?? undefined,
     lifePlan: loaderData.lifePlan ?? undefined,
     activeVision: loaderData.activeVision ?? undefined,
-    activeVisionNote: loaderData.activeVisionNote ?? undefined,
   };
 
   return (

--- a/src/webui/app/routes/app/workspace/index.tsx
+++ b/src/webui/app/routes/app/workspace/index.tsx
@@ -17,8 +17,10 @@ import {
   InboxTaskSource,
   InboxTaskStatus,
   LifePlan,
+  Note,
   RecurringTaskPeriod,
   SmallScreenHomeTabWidgetPlacement,
+  Vision,
   WidgetType,
   BigPlanLoadResult,
   InboxTaskFindResult,
@@ -87,6 +89,7 @@ import { GamificationHistoryWeeklyWidget } from "@jupiter/core/gamification/comp
 import { GamificationHistoryMonthlyWidget } from "@jupiter/core/gamification/component/history-monthly-widget";
 import { KeyBigPlansProgressWidget } from "@jupiter/core/big_plans/component/key-big-plans-progress-widget";
 import { LifeWeeksWidget } from "@jupiter/core/life_plan/component/life-weeks-widget";
+import { LifeVisionWidget } from "@jupiter/core/life_plan/component/life-vision-widget";
 
 import { newURLParams } from "~/logic/navigation";
 import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
@@ -255,6 +258,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const userResponse = await apiClient.users.userLoad({});
 
+  let activeVisionResponse = null;
+
+  if (isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.LIFE_PLAN)) {
+    activeVisionResponse = await apiClient.lifePlan.visionLoadActive({});
+  }
+
   return json({
     homeConfig: {
       config: homeConfigResponse.home_config,
@@ -299,6 +308,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     gamificationOverview: userResponse.user_score_overview,
     gamificationHistory: userResponse.user_score_history,
     lifePlan: summaryResponse.life_plan as LifePlan | undefined,
+    activeVision: activeVisionResponse?.vision as Vision | undefined,
+    activeVisionNote: activeVisionResponse?.note as Note | undefined,
   });
 }
 
@@ -534,6 +545,8 @@ export default function WorkspaceHome() {
     gamificationOverview: loaderData.gamificationOverview ?? undefined,
     gamificationHistory: loaderData.gamificationHistory ?? undefined,
     lifePlan: loaderData.lifePlan ?? undefined,
+    activeVision: loaderData.activeVision ?? undefined,
+    activeVisionNote: loaderData.activeVisionNote ?? undefined,
   };
 
   return (
@@ -951,6 +964,8 @@ function ActualWidgetItself({ widget, widgetProps }: ActualWidgetItselfProps) {
       return <GamificationHistoryMonthlyWidget {...widgetPropsWithGeometry} />;
     case WidgetType.LIFE_WEEKS:
       return <LifeWeeksWidget {...widgetPropsWithGeometry} />;
+    case WidgetType.LIFE_VISION:
+      return <LifeVisionWidget {...widgetPropsWithGeometry} />;
   }
 }
 


### PR DESCRIPTION
Introduces a new LIFE_VISION widget type that displays the user's active
life vision snippet on the home screen, with a link to the full visions
page and a CTA to create a vision if none exists.

https://claude.ai/code/session_01J95VjvqN5pda5h32JV4o8W