### PR TITLE
Add Life Chapters widget to home dashboard

### DIFF
--- a/gen/py/webapi-client/jupiter_webapi_client/models/widget_type.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/widget_type.py
@@ -16,6 +16,9 @@ class WidgetType(str, Enum):
     SCHEDULE_DAY = "schedule-day"
     TIME_PLAN_VIEW = "time-plan-view"
     UPCOMING_BIRTHDAYS = "upcoming-birthdays"
+    LIFE_WEEKS = "life-weeks"
+    LIFE_VISION = "life-vision"
+    LIFE_CHAPTERS = "life-chapters"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/gen/ts/webapi-client/gen/models/WidgetType.ts
+++ b/gen/ts/webapi-client/gen/models/WidgetType.ts
@@ -22,4 +22,5 @@ export enum WidgetType {
     GAMIFICATION_HISTORY_MONTHLY = 'gamification-history-monthly',
     LIFE_WEEKS = 'life-weeks',
     LIFE_VISION = 'life-vision',
+    LIFE_CHAPTERS = 'life-chapters',
 }

--- a/src/core/jupiter/core/home/component/common.tsx
+++ b/src/core/jupiter/core/home/component/common.tsx
@@ -23,6 +23,7 @@ import {
   UserFeature,
   WidgetGeometry,
   BigPlanMilestone,
+  ProjectSummary,
 } from "@jupiter/webapi-client";
 import {
   Box,
@@ -131,6 +132,7 @@ export interface WidgetProps {
   lifePlan?: LifePlan;
   activeVision?: { vision: Vision; note: Note };
   activeChapters?: ChapterSummary[];
+  projectsByRefId?: Record<string, ProjectSummary>;
   geometry: WidgetGeometry;
 }
 

--- a/src/core/jupiter/core/home/component/common.tsx
+++ b/src/core/jupiter/core/home/component/common.tsx
@@ -1,5 +1,6 @@
 import {
   ADate,
+  ChapterSummary,
   InboxTask,
   LifePlan,
   MOTD,
@@ -129,6 +130,7 @@ export interface WidgetProps {
   gamificationHistory?: UserScoreHistory;
   lifePlan?: LifePlan;
   activeVision?: { vision: Vision; note: Note };
+  activeChapters?: ChapterSummary[];
   geometry: WidgetGeometry;
 }
 

--- a/src/core/jupiter/core/home/sub/widget/root.ts
+++ b/src/core/jupiter/core/home/sub/widget/root.ts
@@ -40,6 +40,8 @@ export function widgetTypeName(type: WidgetType): string {
       return "Life Weeks";
     case WidgetType.LIFE_VISION:
       return "Life Vision";
+    case WidgetType.LIFE_CHAPTERS:
+      return "Life Chapters";
   }
 }
 

--- a/src/core/jupiter/core/home/widget.py
+++ b/src/core/jupiter/core/home/widget.py
@@ -112,6 +112,7 @@ class WidgetType(EnumValue):
     GAMIFICATION_HISTORY_MONTHLY = "gamification-history-monthly"
     LIFE_WEEKS = "life-weeks"
     LIFE_VISION = "life-vision"
+    LIFE_CHAPTERS = "life-chapters"
 
 
 @value
@@ -353,6 +354,19 @@ WIDGET_CONSTRAINTS = {
                 WidgetDimension.DIM_1x1,
                 WidgetDimension.DIM_1x2,
                 WidgetDimension.DIM_1x3,
+            ],
+            HomeTabTarget.SMALL_SCREEN: [
+                WidgetDimension.DIM_1x1,
+            ],
+        },
+        only_for_workspace_features=[WorkspaceFeature.LIFE_PLAN],
+        only_for_user_features=None,
+    ),
+    WidgetType.LIFE_CHAPTERS: WidgetTypeConstraints(
+        allowed_dimensions={
+            HomeTabTarget.BIG_SCREEN: [
+                WidgetDimension.DIM_1x1,
+                WidgetDimension.DIM_2x1,
             ],
             HomeTabTarget.SMALL_SCREEN: [
                 WidgetDimension.DIM_1x1,

--- a/src/core/jupiter/core/life_plan/component/life-chapters-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-chapters-widget.tsx
@@ -1,0 +1,42 @@
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Link } from "@remix-run/react";
+import { WidgetProps } from "#/core/home/component/common";
+
+export function LifeChaptersWidget(props: WidgetProps) {
+  const { activeChapters } = props;
+
+  return (
+    <Stack
+      direction="column"
+      sx={{ width: "100%", height: "100%", gap: 1, overflow: "hidden" }}
+    >
+      <Typography variant="h6" sx={{ fontSize: "0.9rem", fontWeight: "bold", flexShrink: 0 }}>
+        Active Chapters
+      </Typography>
+
+      {(!activeChapters || activeChapters.length === 0) && (
+        <Typography variant="body2" sx={{ color: "text.secondary", fontSize: "0.75rem" }}>
+          No active chapters right now.
+        </Typography>
+      )}
+
+      {activeChapters && activeChapters.length > 0 && (
+        <Box sx={{ flex: 1, overflow: "auto" }}>
+          <Stack direction="column" gap={0.5}>
+            {activeChapters.map((chapter) => (
+              <Chip
+                key={chapter.ref_id}
+                label={`📖 ${chapter.name}`}
+                size="small"
+                component={Link}
+                to={`/app/workspace/life-plan/chapters/${chapter.ref_id}`}
+                clickable
+                sx={{ justifyContent: "flex-start", fontSize: "0.75rem" }}
+              />
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/src/core/jupiter/core/life_plan/component/life-chapters-widget.tsx
+++ b/src/core/jupiter/core/life_plan/component/life-chapters-widget.tsx
@@ -3,7 +3,15 @@ import { Link } from "@remix-run/react";
 import { WidgetProps } from "#/core/home/component/common";
 
 export function LifeChaptersWidget(props: WidgetProps) {
-  const { activeChapters } = props;
+  const { activeChapters, projectsByRefId } = props;
+
+  const sortedChapters = activeChapters
+    ? [...activeChapters].sort((a, b) => {
+        const projectNameA = projectsByRefId?.[a.project_ref_id]?.name ?? "";
+        const projectNameB = projectsByRefId?.[b.project_ref_id]?.name ?? "";
+        return projectNameA.localeCompare(projectNameB);
+      })
+    : undefined;
 
   return (
     <Stack
@@ -14,26 +22,32 @@ export function LifeChaptersWidget(props: WidgetProps) {
         Active Chapters
       </Typography>
 
-      {(!activeChapters || activeChapters.length === 0) && (
+      {(!sortedChapters || sortedChapters.length === 0) && (
         <Typography variant="body2" sx={{ color: "text.secondary", fontSize: "0.75rem" }}>
           No active chapters right now.
         </Typography>
       )}
 
-      {activeChapters && activeChapters.length > 0 && (
+      {sortedChapters && sortedChapters.length > 0 && (
         <Box sx={{ flex: 1, overflow: "auto" }}>
           <Stack direction="column" gap={0.5}>
-            {activeChapters.map((chapter) => (
-              <Chip
-                key={chapter.ref_id}
-                label={`📖 ${chapter.name}`}
-                size="small"
-                component={Link}
-                to={`/app/workspace/life-plan/chapters/${chapter.ref_id}`}
-                clickable
-                sx={{ justifyContent: "flex-start", fontSize: "0.75rem" }}
-              />
-            ))}
+            {sortedChapters.map((chapter) => {
+              const projectName = projectsByRefId?.[chapter.project_ref_id]?.name;
+              const label = projectName
+                ? `📖 ${projectName} / ${chapter.name}`
+                : `📖 ${chapter.name}`;
+              return (
+                <Chip
+                  key={chapter.ref_id}
+                  label={label}
+                  size="small"
+                  component={Link}
+                  to={`/app/workspace/life-plan/chapters/${chapter.ref_id}`}
+                  clickable
+                  sx={{ justifyContent: "flex-start", fontSize: "0.75rem" }}
+                />
+              );
+            })}
           </Stack>
         </Box>
       )}

--- a/src/webui/app/routes/app/workspace/index.tsx
+++ b/src/webui/app/routes/app/workspace/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@remix-run/react";
 import {
   BigScreenHomeTabWidgetPlacement,
+  ChapterSummary,
   HabitLoadResult,
   HomeTab,
   HomeTabTarget,
@@ -17,6 +18,7 @@ import {
   InboxTaskSource,
   InboxTaskStatus,
   LifePlan,
+  MilestoneSummary,
   Note,
   RecurringTaskPeriod,
   SmallScreenHomeTabWidgetPlacement,
@@ -90,6 +92,10 @@ import { GamificationHistoryMonthlyWidget } from "@jupiter/core/gamification/com
 import { KeyBigPlansProgressWidget } from "@jupiter/core/big_plans/component/key-big-plans-progress-widget";
 import { LifeWeeksWidget } from "@jupiter/core/life_plan/component/life-weeks-widget";
 import { LifeVisionWidget } from "@jupiter/core/life_plan/component/life-vision-widget";
+import { LifeChaptersWidget } from "@jupiter/core/life_plan/component/life-chapters-widget";
+import { midDate } from "@jupiter/core/life_plan/partial-date";
+import { lifePlanBirthdayDate } from "@jupiter/core/life_plan/root";
+import { aDateToDate } from "@jupiter/core/common/adate";
 
 import { newURLParams } from "~/logic/navigation";
 import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
@@ -117,6 +123,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     include_big_plans: true,
     include_persons: true,
     include_life_plan: true,
+    include_chapters: true,
+    include_milestones: true,
   });
 
   const workspace = summaryResponse.workspace!;
@@ -308,6 +316,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     gamificationOverview: userResponse.user_score_overview,
     gamificationHistory: userResponse.user_score_history,
     lifePlan: summaryResponse.life_plan as LifePlan | undefined,
+    allChapters: summaryResponse.chapters as ChapterSummary[] | undefined,
+    allMilestones: summaryResponse.milestones as MilestoneSummary[] | undefined,
     activeVision:
       activeVisionResponse?.vision && activeVisionResponse?.note
         ? { vision: activeVisionResponse.vision as Vision, note: activeVisionResponse.note as Note }
@@ -477,6 +487,22 @@ export default function WorkspaceHome() {
     }, 0);
   }
 
+  const activeChapters: ChapterSummary[] | undefined = (() => {
+    if (!loaderData.allChapters || !loaderData.lifePlan) return undefined;
+    const birthday = lifePlanBirthdayDate(loaderData.lifePlan);
+    const todayDt = aDateToDate(topLevelInfo.today);
+    const milestones = loaderData.allMilestones ?? [];
+    return loaderData.allChapters.filter((chapter) => {
+      try {
+        const startDt = midDate(chapter.start_date, birthday, todayDt, milestones);
+        const endDt = midDate(chapter.end_date, birthday, todayDt, milestones);
+        return startDt.toMillis() <= todayDt.toMillis() && todayDt.toMillis() < endDt.toMillis();
+      } catch {
+        return false;
+      }
+    });
+  })();
+
   const widgetProps: WidgetPropsNoGeometry = {
     rightNow,
     timezone: topLevelInfo.user.timezone,
@@ -548,6 +574,7 @@ export default function WorkspaceHome() {
     gamificationHistory: loaderData.gamificationHistory ?? undefined,
     lifePlan: loaderData.lifePlan ?? undefined,
     activeVision: loaderData.activeVision ?? undefined,
+    activeChapters: activeChapters,
   };
 
   return (
@@ -967,6 +994,8 @@ function ActualWidgetItself({ widget, widgetProps }: ActualWidgetItselfProps) {
       return <LifeWeeksWidget {...widgetPropsWithGeometry} />;
     case WidgetType.LIFE_VISION:
       return <LifeVisionWidget {...widgetPropsWithGeometry} />;
+    case WidgetType.LIFE_CHAPTERS:
+      return <LifeChaptersWidget {...widgetPropsWithGeometry} />;
   }
 }
 

--- a/src/webui/app/routes/app/workspace/index.tsx
+++ b/src/webui/app/routes/app/workspace/index.tsx
@@ -32,6 +32,7 @@ import {
   User,
   Workspace,
   DocsHelpSubject,
+  ProjectSummary,
 } from "@jupiter/webapi-client";
 import { Fragment, useContext, useEffect, useState } from "react";
 import { DateTime } from "luxon";
@@ -125,6 +126,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     include_life_plan: true,
     include_chapters: true,
     include_milestones: true,
+    include_projects: true,
   });
 
   const workspace = summaryResponse.workspace!;
@@ -318,6 +320,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     lifePlan: summaryResponse.life_plan as LifePlan | undefined,
     allChapters: summaryResponse.chapters as ChapterSummary[] | undefined,
     allMilestones: summaryResponse.milestones as MilestoneSummary[] | undefined,
+    allProjects: summaryResponse.projects as ProjectSummary[] | undefined,
     activeVision:
       activeVisionResponse?.vision && activeVisionResponse?.note
         ? { vision: activeVisionResponse.vision as Vision, note: activeVisionResponse.note as Note }
@@ -575,6 +578,9 @@ export default function WorkspaceHome() {
     lifePlan: loaderData.lifePlan ?? undefined,
     activeVision: loaderData.activeVision ?? undefined,
     activeChapters: activeChapters,
+    projectsByRefId: loaderData.allProjects
+      ? Object.fromEntries(loaderData.allProjects.map((p) => [p.ref_id, p]))
+      : undefined,
   };
 
   return (


### PR DESCRIPTION
## Summary
This PR adds a new "Life Chapters" widget to the home dashboard, allowing users to view their currently active life chapters at a glance.

## Key Changes
- **New Widget Component**: Created `LifeChaptersWidget` that displays active life chapters as clickable chips with navigation links to individual chapter details
- **Widget Registration**: Added `LIFE_CHAPTERS` widget type to the widget system with support for 1x1 and 2x1 dimensions on big screens, and 1x1 on small screens
- **Active Chapters Logic**: Implemented filtering logic in the workspace home loader to determine which chapters are currently active based on:
  - Chapter start and end dates
  - Life plan birthday reference point
  - Current date comparison using the `midDate` utility function
- **Data Loading**: Extended the workspace summary API request to include chapters and milestones data
- **Type Updates**: Updated TypeScript and Python type definitions to include the new widget type and added `activeChapters` to widget props

## Implementation Details
- The widget displays a message when no active chapters exist
- Active chapters are rendered as Material-UI Chips with a book emoji (📖) and are clickable links to `/app/workspace/life-plan/chapters/{chapter_id}`
- The active chapters calculation gracefully handles errors by filtering out chapters that fail date calculations
- The widget respects the LIFE_PLAN workspace feature requirement

https://claude.ai/code/session_01GLdhmegV3JdTR7ccZ29MYV