### PR TITLE
Add birth milestone creation during workspace initialization

### DIFF
--- a/src/core/jupiter/core/application/use_case/init.py
+++ b/src/core/jupiter/core/application/use_case/init.py
@@ -45,6 +45,8 @@ from jupiter.core.journals.generation_approach import (
 from jupiter.core.life_plan.root import LifePlan
 from jupiter.core.life_plan.sub.aspects.name import ProjectName
 from jupiter.core.life_plan.sub.aspects.root import Project
+from jupiter.core.life_plan.sub.milestones.name import MilestoneName
+from jupiter.core.life_plan.sub.milestones.root import Milestone
 from jupiter.core.metrics.collection import MetricCollection
 from jupiter.core.prm.root import PRM
 from jupiter.core.prm.sub.circle.name import CircleName
@@ -248,6 +250,15 @@ class InitUseCase(JupiterGuestMutationUseCase[InitArgs, InitResult]):
             new_root_project = await uow.get_for(Project).create(
                 new_root_project,
             )
+
+            new_birth_milestone = Milestone.new_milestone(
+                ctx=context.domain_context,
+                life_plan_ref_id=new_life_plan.ref_id,
+                name=MilestoneName("Birth"),
+                project_ref_id=new_root_project.ref_id,
+                date=new_life_plan.birthday_date,
+            )
+            await uow.get_for(Milestone).create(new_birth_milestone)
 
             new_inbox_task_collection = InboxTaskCollection.new_inbox_task_collection(
                 ctx=context.domain_context,


### PR DESCRIPTION
## Summary
This change adds automatic creation of a "Birth" milestone when a new workspace is initialized. The milestone is created as part of the life plan setup process and is associated with the root project and the user's birthday date.

## Key Changes
- Import `MilestoneName` and `Milestone` classes from the life plan milestones module
- Create a new "Birth" milestone during workspace initialization that:
  - References the newly created life plan
  - References the root project
  - Uses the life plan's birthday date as the milestone date
  - Is persisted to the database via the unit of work pattern

## Implementation Details
The birth milestone is created immediately after the root project is established, ensuring all necessary references are available. It follows the same domain-driven design patterns used elsewhere in the initialization process, using the `Milestone.new_milestone()` factory method and persisting through the repository pattern.

https://claude.ai/code/session_01VGMwDyxuhhedQejDkGTh8N