### PR TITLE
Add goal-based breakdown to report functionality

### DIFF
--- a/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
@@ -509,6 +509,7 @@ from .paragraph_block_kind import ParagraphBlockKind
 from .partial_date_type import PartialDateType
 from .per_big_plan_breakdown_item import PerBigPlanBreakdownItem
 from .per_chore_breakdown_item import PerChoreBreakdownItem
+from .per_goal_breakdown_item import PerGoalBreakdownItem
 from .per_habit_breakdown_item import PerHabitBreakdownItem
 from .per_period_breakdown_item import PerPeriodBreakdownItem
 from .per_project_breakdown_item import PerProjectBreakdownItem
@@ -1383,6 +1384,7 @@ __all__ = (
     "PartialDateType",
     "PerBigPlanBreakdownItem",
     "PerChoreBreakdownItem",
+    "PerGoalBreakdownItem",
     "PerHabitBreakdownItem",
     "PerPeriodBreakdownItem",
     "PerProjectBreakdownItem",

--- a/gen/py/webapi-client/jupiter_webapi_client/models/per_goal_breakdown_item.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/per_goal_breakdown_item.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.inbox_tasks_summary import InboxTasksSummary
+    from ..models.workable_summary import WorkableSummary
+
+
+T = TypeVar("T", bound="PerGoalBreakdownItem")
+
+
+@_attrs_define
+class PerGoalBreakdownItem:
+    """The report for a particular goal.
+
+    Attributes:
+        ref_id (str): A generic entity id.
+        name (str): The name for an entity which acts as both name and unique identifier.
+        inbox_tasks_summary (InboxTasksSummary): A bigger summary for inbox tasks.
+        big_plans_summary (WorkableSummary): The reporting summary.
+    """
+
+    ref_id: str
+    name: str
+    inbox_tasks_summary: InboxTasksSummary
+    big_plans_summary: WorkableSummary
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        ref_id = self.ref_id
+
+        name = self.name
+
+        inbox_tasks_summary = self.inbox_tasks_summary.to_dict()
+
+        big_plans_summary = self.big_plans_summary.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "ref_id": ref_id,
+                "name": name,
+                "inbox_tasks_summary": inbox_tasks_summary,
+                "big_plans_summary": big_plans_summary,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inbox_tasks_summary import InboxTasksSummary
+        from ..models.workable_summary import WorkableSummary
+
+        d = dict(src_dict)
+        ref_id = d.pop("ref_id")
+
+        name = d.pop("name")
+
+        inbox_tasks_summary = InboxTasksSummary.from_dict(d.pop("inbox_tasks_summary"))
+
+        big_plans_summary = WorkableSummary.from_dict(d.pop("big_plans_summary"))
+
+        per_goal_breakdown_item = cls(
+            ref_id=ref_id,
+            name=name,
+            inbox_tasks_summary=inbox_tasks_summary,
+            big_plans_summary=big_plans_summary,
+        )
+
+        per_goal_breakdown_item.additional_properties = d
+        return per_goal_breakdown_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/report_breakdown.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/report_breakdown.py
@@ -5,6 +5,7 @@ class ReportBreakdown(str, Enum):
     BIG_PLANS = "big-plans"
     CHORES = "chores"
     GLOBAL = "global"
+    GOALS = "goals"
     HABITS = "habits"
     PERIODS = "periods"
     PROJECTS = "projects"

--- a/gen/py/webapi-client/jupiter_webapi_client/models/report_period_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/report_period_result.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from ..models.inbox_tasks_summary import InboxTasksSummary
     from ..models.per_big_plan_breakdown_item import PerBigPlanBreakdownItem
     from ..models.per_chore_breakdown_item import PerChoreBreakdownItem
+    from ..models.per_goal_breakdown_item import PerGoalBreakdownItem
     from ..models.per_habit_breakdown_item import PerHabitBreakdownItem
     from ..models.per_period_breakdown_item import PerPeriodBreakdownItem
     from ..models.per_project_breakdown_item import PerProjectBreakdownItem
@@ -37,6 +38,7 @@ class ReportPeriodResult:
         global_inbox_tasks_summary (InboxTasksSummary): A bigger summary for inbox tasks.
         global_big_plans_summary (WorkableSummary): The reporting summary.
         per_project_breakdown (list[PerProjectBreakdownItem]):
+        per_goal_breakdown (list[PerGoalBreakdownItem]):
         per_period_breakdown (list[PerPeriodBreakdownItem]):
         per_habit_breakdown (list[PerHabitBreakdownItem]):
         per_chore_breakdown (list[PerChoreBreakdownItem]):
@@ -52,6 +54,7 @@ class ReportPeriodResult:
     global_inbox_tasks_summary: InboxTasksSummary
     global_big_plans_summary: WorkableSummary
     per_project_breakdown: list[PerProjectBreakdownItem]
+    per_goal_breakdown: list[PerGoalBreakdownItem]
     per_period_breakdown: list[PerPeriodBreakdownItem]
     per_habit_breakdown: list[PerHabitBreakdownItem]
     per_chore_breakdown: list[PerChoreBreakdownItem]
@@ -85,6 +88,11 @@ class ReportPeriodResult:
         for per_project_breakdown_item_data in self.per_project_breakdown:
             per_project_breakdown_item = per_project_breakdown_item_data.to_dict()
             per_project_breakdown.append(per_project_breakdown_item)
+
+        per_goal_breakdown = []
+        for per_goal_breakdown_item_data in self.per_goal_breakdown:
+            per_goal_breakdown_item = per_goal_breakdown_item_data.to_dict()
+            per_goal_breakdown.append(per_goal_breakdown_item)
 
         per_period_breakdown = []
         for per_period_breakdown_item_data in self.per_period_breakdown:
@@ -133,6 +141,7 @@ class ReportPeriodResult:
                 "global_inbox_tasks_summary": global_inbox_tasks_summary,
                 "global_big_plans_summary": global_big_plans_summary,
                 "per_project_breakdown": per_project_breakdown,
+                "per_goal_breakdown": per_goal_breakdown,
                 "per_period_breakdown": per_period_breakdown,
                 "per_habit_breakdown": per_habit_breakdown,
                 "per_chore_breakdown": per_chore_breakdown,
@@ -151,6 +160,7 @@ class ReportPeriodResult:
         from ..models.inbox_tasks_summary import InboxTasksSummary
         from ..models.per_big_plan_breakdown_item import PerBigPlanBreakdownItem
         from ..models.per_chore_breakdown_item import PerChoreBreakdownItem
+        from ..models.per_goal_breakdown_item import PerGoalBreakdownItem
         from ..models.per_habit_breakdown_item import PerHabitBreakdownItem
         from ..models.per_period_breakdown_item import PerPeriodBreakdownItem
         from ..models.per_project_breakdown_item import PerProjectBreakdownItem
@@ -186,6 +196,13 @@ class ReportPeriodResult:
             per_project_breakdown_item = PerProjectBreakdownItem.from_dict(per_project_breakdown_item_data)
 
             per_project_breakdown.append(per_project_breakdown_item)
+
+        per_goal_breakdown = []
+        _per_goal_breakdown = d.pop("per_goal_breakdown")
+        for per_goal_breakdown_item_data in _per_goal_breakdown:
+            per_goal_breakdown_item = PerGoalBreakdownItem.from_dict(per_goal_breakdown_item_data)
+
+            per_goal_breakdown.append(per_goal_breakdown_item)
 
         per_period_breakdown = []
         _per_period_breakdown = d.pop("per_period_breakdown")
@@ -257,6 +274,7 @@ class ReportPeriodResult:
             global_inbox_tasks_summary=global_inbox_tasks_summary,
             global_big_plans_summary=global_big_plans_summary,
             per_project_breakdown=per_project_breakdown,
+            per_goal_breakdown=per_goal_breakdown,
             per_period_breakdown=per_period_breakdown,
             per_habit_breakdown=per_habit_breakdown,
             per_chore_breakdown=per_chore_breakdown,

--- a/gen/ts/webapi-client/gen/index.ts
+++ b/gen/ts/webapi-client/gen/index.ts
@@ -391,6 +391,7 @@ export type { PasswordNewPlain } from './models/PasswordNewPlain';
 export type { PasswordPlain } from './models/PasswordPlain';
 export type { PerBigPlanBreakdownItem } from './models/PerBigPlanBreakdownItem';
 export type { PerChoreBreakdownItem } from './models/PerChoreBreakdownItem';
+export type { PerGoalBreakdownItem } from './models/PerGoalBreakdownItem';
 export type { PerHabitBreakdownItem } from './models/PerHabitBreakdownItem';
 export type { PerPeriodBreakdownItem } from './models/PerPeriodBreakdownItem';
 export type { PerProjectBreakdownItem } from './models/PerProjectBreakdownItem';

--- a/gen/ts/webapi-client/gen/models/PerGoalBreakdownItem.ts
+++ b/gen/ts/webapi-client/gen/models/PerGoalBreakdownItem.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { EntityName } from './EntityName';
+import type { InboxTasksSummary } from './InboxTasksSummary';
+import type { WorkableSummary } from './WorkableSummary';
+/**
+ * The report for a particular goal.
+ */
+export type PerGoalBreakdownItem = {
+    ref_id: EntityId;
+    name: EntityName;
+    inbox_tasks_summary: InboxTasksSummary;
+    big_plans_summary: WorkableSummary;
+};
+

--- a/gen/ts/webapi-client/gen/models/ReportBreakdown.ts
+++ b/gen/ts/webapi-client/gen/models/ReportBreakdown.ts
@@ -9,6 +9,7 @@ export enum ReportBreakdown {
     GLOBAL = 'global',
     PERIODS = 'periods',
     PROJECTS = 'projects',
+    GOALS = 'goals',
     HABITS = 'habits',
     CHORES = 'chores',
     BIG_PLANS = 'big-plans',

--- a/gen/ts/webapi-client/gen/models/ReportPeriodResult.ts
+++ b/gen/ts/webapi-client/gen/models/ReportPeriodResult.ts
@@ -7,6 +7,7 @@ import type { InboxTaskSource } from './InboxTaskSource';
 import type { InboxTasksSummary } from './InboxTasksSummary';
 import type { PerBigPlanBreakdownItem } from './PerBigPlanBreakdownItem';
 import type { PerChoreBreakdownItem } from './PerChoreBreakdownItem';
+import type { PerGoalBreakdownItem } from './PerGoalBreakdownItem';
 import type { PerHabitBreakdownItem } from './PerHabitBreakdownItem';
 import type { PerPeriodBreakdownItem } from './PerPeriodBreakdownItem';
 import type { PerProjectBreakdownItem } from './PerProjectBreakdownItem';
@@ -26,6 +27,7 @@ export type ReportPeriodResult = {
     global_inbox_tasks_summary: InboxTasksSummary;
     global_big_plans_summary: WorkableSummary;
     per_project_breakdown: Array<PerProjectBreakdownItem>;
+    per_goal_breakdown: Array<PerGoalBreakdownItem>;
     per_period_breakdown: Array<PerPeriodBreakdownItem>;
     per_habit_breakdown: Array<PerHabitBreakdownItem>;
     per_chore_breakdown: Array<PerChoreBreakdownItem>;

--- a/src/core/jupiter/core/report/breakdown.py
+++ b/src/core/jupiter/core/report/breakdown.py
@@ -10,6 +10,7 @@ class ReportBreakdown(EnumValue):
     GLOBAL = "global"
     PERIODS = "periods"
     PROJECTS = "projects"
+    GOALS = "goals"
     HABITS = "habits"
     CHORES = "chores"
     BIG_PLANS = "big-plans"

--- a/src/core/jupiter/core/report/component/show-report.tsx
+++ b/src/core/jupiter/core/report/component/show-report.tsx
@@ -1,4 +1,5 @@
 import type {
+  GoalSummary,
   InboxTasksSummary,
   ProjectSummary,
   ReportPeriodResult,
@@ -36,6 +37,7 @@ import {
   computeProjectHierarchicalNameFromRoot,
   sortProjectsByTreeOrder,
 } from "#/core/life_plan/sub/aspects/root";
+import { sortGoalsNaturally } from "#/core/life_plan/sub/goals/root";
 import { isUserFeatureAvailable } from "#/core/users/root";
 import {
   inferSourcesForEnabledFeatures,
@@ -65,12 +67,14 @@ const _SOURCES_TO_REPORT = [
 interface ShowReportProps {
   topLevelInfo: TopLevelInfo;
   allProjects: ProjectSummary[];
+  allGoals: GoalSummary[];
   report: ReportPeriodResult;
 }
 
 export function ShowReport({
   topLevelInfo,
   allProjects,
+  allGoals,
   report,
 }: ShowReportProps) {
   const isBigScreen = useBigScreen();
@@ -80,9 +84,10 @@ export function ShowReport({
     global: 0,
     "by-periods": 1,
     "by-projects": 2,
-    "by-habits": 3,
-    "by-chores": 4,
-    "by-big-plans": 5,
+    "by-goals": 3,
+    "by-habits": 4,
+    "by-chores": 5,
+    "by-big-plans": 6,
   };
 
   if (
@@ -91,6 +96,7 @@ export function ShowReport({
       WorkspaceFeature.LIFE_PLAN,
     )
   ) {
+    tabIndicesMap["by-goals"] -= 1;
     tabIndicesMap["by-habits"] -= 1;
     tabIndicesMap["by-chores"] -= 1;
     tabIndicesMap["by-big-plans"] -= 1;
@@ -116,6 +122,10 @@ export function ShowReport({
   const allProjectsSorted = sortProjectsByTreeOrder(allProjects);
   const allProjectsByRefId = new Map<string, ProjectSummary>(
     allProjects.map((p) => [p.ref_id, p]),
+  );
+  const allGoalsSorted = sortGoalsNaturally(allGoals);
+  const allGoalsByRefId = new Map<string, GoalSummary>(
+    allGoals.map((g) => [g.ref_id, g]),
   );
 
   return (
@@ -155,6 +165,10 @@ export function ShowReport({
           topLevelInfo.workspace,
           WorkspaceFeature.LIFE_PLAN,
         ) && <Tab label="💡 By Projects" />}
+        {isWorkspaceFeatureAvailable(
+          topLevelInfo.workspace,
+          WorkspaceFeature.LIFE_PLAN,
+        ) && <Tab label="🎯 By Goals" />}
         {isWorkspaceFeatureAvailable(
           topLevelInfo.workspace,
           WorkspaceFeature.HABITS,
@@ -219,6 +233,43 @@ export function ShowReport({
                     topLevelInfo={topLevelInfo}
                     inboxTasksSummary={pb.inbox_tasks_summary}
                     bigPlansSummary={pb.big_plans_summary}
+                  />
+                </Fragment>
+              );
+            })}
+          </Stack>
+        </TabPanel>
+      )}
+
+      {isWorkspaceFeatureAvailable(
+        topLevelInfo.workspace,
+        WorkspaceFeature.LIFE_PLAN,
+      ) && (
+        <TabPanel value={showTab} index={tabIndicesMap["by-goals"]}>
+          <Stack spacing={2} useFlexGap>
+            {allGoalsSorted.map((goal) => {
+              const gb = report.per_goal_breakdown.find(
+                (gb) => gb.ref_id === goal.ref_id,
+              );
+
+              if (gb === undefined) {
+                return null;
+              }
+
+              const parentGoal = goal.parent_goal_ref_id
+                ? allGoalsByRefId.get(goal.parent_goal_ref_id)
+                : undefined;
+              const goalLabel = parentGoal
+                ? `${parentGoal.name} / ${goal.name}`
+                : String(goal.name);
+
+              return (
+                <Fragment key={gb.ref_id}>
+                  <StandardDivider title={goalLabel} size="large" />
+                  <OverviewReport
+                    topLevelInfo={topLevelInfo}
+                    inboxTasksSummary={gb.inbox_tasks_summary}
+                    bigPlansSummary={gb.big_plans_summary}
                   />
                 </Fragment>
               );

--- a/src/core/jupiter/core/report/period_result.py
+++ b/src/core/jupiter/core/report/period_result.py
@@ -136,6 +136,16 @@ class PerPeriodBreakdownItem(CompositeValue):
 
 
 @value
+class PerGoalBreakdownItem(CompositeValue):
+    """The report for a particular goal."""
+
+    ref_id: EntityId
+    name: EntityName
+    inbox_tasks_summary: InboxTasksSummary
+    big_plans_summary: WorkableSummary
+
+
+@value
 class PerProjectBreakdownItem(CompositeValue):
     """The report for a particular project."""
 
@@ -157,6 +167,7 @@ class ReportPeriodResult(CompositeValue):
     global_inbox_tasks_summary: InboxTasksSummary
     global_big_plans_summary: WorkableSummary
     per_project_breakdown: list[PerProjectBreakdownItem]
+    per_goal_breakdown: list[PerGoalBreakdownItem]
     per_period_breakdown: list[PerPeriodBreakdownItem]
     per_habit_breakdown: list[PerHabitBreakdownItem]
     per_chore_breakdown: list[PerChoreBreakdownItem]
@@ -221,6 +232,7 @@ class ReportPeriodResult(CompositeValue):
                 done_big_plans=[],
             ),
             per_project_breakdown=[],
+            per_goal_breakdown=[],
             per_period_breakdown=[],
             per_habit_breakdown=[],
             per_chore_breakdown=[],

--- a/src/core/jupiter/core/report/service/report.py
+++ b/src/core/jupiter/core/report/service/report.py
@@ -35,6 +35,7 @@ from jupiter.core.inbox_tasks.status import InboxTaskStatus
 from jupiter.core.life_plan.root import LifePlan
 from jupiter.core.life_plan.sub.aspects.name import ProjectName
 from jupiter.core.life_plan.sub.aspects.root import Project
+from jupiter.core.life_plan.sub.goals.root import Goal
 from jupiter.core.metrics.collection import MetricCollection
 from jupiter.core.metrics.root import Metric
 from jupiter.core.prm.root import PRM
@@ -47,6 +48,7 @@ from jupiter.core.report.period_result import (
     NestedResultPerSource,
     PerBigPlanBreakdownItem,
     PerChoreBreakdownItem,
+    PerGoalBreakdownItem,
     PerHabitBreakdownItem,
     PerPeriodBreakdownItem,
     PerProjectBreakdownItem,
@@ -307,6 +309,15 @@ class ReportService:
                 rt.ref_id: rt for rt in all_chores
             }
 
+            all_goals = await uow.get_for(Goal).find_all_generic(
+                parent_ref_id=life_plan.ref_id,
+                allow_archived=True,
+                ref_id=NoFilter(),
+            )
+            all_goals_by_ref_id: dict[EntityId, Goal] = {
+                g.ref_id: g for g in all_goals
+            }
+
             all_big_plans = await uow.get_for(BigPlan).find_all_generic(
                 parent_ref_id=big_plan_collection.ref_id,
                 allow_archived=True,
@@ -388,6 +399,59 @@ class ReportService:
             ]
         else:
             per_project_breakdown = []
+
+        # Build per goal breakdown
+
+        if workspace.is_feature_available(WorkspaceFeature.LIFE_PLAN):
+            per_goal_inbox_tasks_summary = {
+                k: self._run_report_for_inbox_tasks(schedule, (vx[1] for vx in v))
+                for (k, v) in groupby(
+                    sorted(
+                        [
+                            (it.goal_ref_id, it)
+                            for it in all_inbox_tasks
+                            if it.goal_ref_id is not None
+                        ],
+                        key=itemgetter(0),
+                    ),
+                    key=itemgetter(0),
+                )
+            }
+
+            if workspace.is_feature_available(WorkspaceFeature.BIG_PLANS):
+                per_goal_big_plans_summary = {
+                    k: self._run_report_for_big_plan(schedule, (vx[1] for vx in v))
+                    for (k, v) in groupby(
+                        sorted(
+                            [
+                                (bp.goal_ref_id, bp)
+                                for bp in all_big_plans
+                                if bp.goal_ref_id is not None
+                            ],
+                            key=itemgetter(0),
+                        ),
+                        key=itemgetter(0),
+                    )
+                }
+            else:
+                per_goal_big_plans_summary = {}
+
+            per_goal_breakdown = [
+                PerGoalBreakdownItem(
+                    ref_id=goal_ref_id,
+                    name=all_goals_by_ref_id[goal_ref_id].name,
+                    inbox_tasks_summary=inbox_summary,
+                    big_plans_summary=per_goal_big_plans_summary.get(
+                        goal_ref_id,
+                        WorkableSummary(0, 0, 0, 0, 0, [], []),
+                    ),
+                )
+                for (goal_ref_id, inbox_summary) in per_goal_inbox_tasks_summary.items()
+                if goal_ref_id in all_goals_by_ref_id
+                and not all_goals_by_ref_id[goal_ref_id].archived
+            ]
+        else:
+            per_goal_breakdown = []
 
         # Build per period breakdown
         per_period_breakdown = []
@@ -549,6 +613,7 @@ class ReportService:
             global_inbox_tasks_summary=global_inbox_tasks_summary,
             global_big_plans_summary=global_big_plans_summary,
             per_project_breakdown=per_project_breakdown,
+            per_goal_breakdown=per_goal_breakdown,
             per_period_breakdown=per_period_breakdown,
             per_habit_breakdown=per_habit_breakdown,
             per_chore_breakdown=per_chore_breakdown,

--- a/src/core/jupiter/core/report/service/report.py
+++ b/src/core/jupiter/core/report/service/report.py
@@ -314,9 +314,7 @@ class ReportService:
                 allow_archived=True,
                 ref_id=NoFilter(),
             )
-            all_goals_by_ref_id: dict[EntityId, Goal] = {
-                g.ref_id: g for g in all_goals
-            }
+            all_goals_by_ref_id: dict[EntityId, Goal] = {g.ref_id: g for g in all_goals}
 
             all_big_plans = await uow.get_for(BigPlan).find_all_generic(
                 parent_ref_id=big_plan_collection.ref_id,

--- a/src/webui/app/routes/app/workspace/journals/$id.tsx
+++ b/src/webui/app/routes/app/workspace/journals/$id.tsx
@@ -4,7 +4,7 @@ import {
   TagNamespace,
   WorkspaceFeature,
 } from "@jupiter/webapi-client";
-import type { Tag } from "@jupiter/webapi-client";
+import type { GoalSummary, Tag } from "@jupiter/webapi-client";
 import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
@@ -74,6 +74,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const summaryResponse = await apiClient.application.getSummaries({
     include_workspace: true,
     include_projects: true,
+    include_goals: true,
   });
 
   try {
@@ -101,6 +102,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     return json({
       allProjects: summaryResponse.projects || undefined,
+      allGoals: (summaryResponse.goals as Array<GoalSummary>) || undefined,
       journal: result.journal,
       journalStats: result.journal_stats,
       note: result.note,
@@ -297,6 +299,7 @@ export default function Journal() {
         <ShowReport
           topLevelInfo={topLevelInfo}
           allProjects={loaderData.allProjects || []}
+          allGoals={loaderData.allGoals || []}
           report={loaderData.journalStats.report}
         />
       </SectionCard>

--- a/src/webui/app/routes/app/workspace/tools/report.tsx
+++ b/src/webui/app/routes/app/workspace/tools/report.tsx
@@ -1,4 +1,8 @@
-import type { ProjectSummary, ReportResult } from "@jupiter/webapi-client";
+import type {
+  GoalSummary,
+  ProjectSummary,
+  ReportResult,
+} from "@jupiter/webapi-client";
 import { ApiError, RecurringTaskPeriod } from "@jupiter/webapi-client";
 import {
   FormControl,
@@ -70,6 +74,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const summaryResponse = await apiClient.application.getSummaries({
     include_projects: true,
+    include_goals: true,
   });
 
   try {
@@ -83,6 +88,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return json(
       noErrorSomeData({
         allProjects: summaryResponse.projects as Array<ProjectSummary>,
+        allGoals: summaryResponse.goals as Array<GoalSummary>,
         report: reportResponse,
       }),
     );
@@ -106,6 +112,7 @@ export default function Report() {
     typeof loader
   >() as ActionResult<{
     allProjects: Array<ProjectSummary> | undefined;
+    allGoals: Array<GoalSummary> | undefined;
     report: ReportResult | undefined;
   }>;
   const navigation = useNavigation();
@@ -236,6 +243,7 @@ export default function Report() {
           <ShowReport
             topLevelInfo={topLevelInfo}
             allProjects={loaderData.data.allProjects}
+            allGoals={loaderData.data.allGoals ?? []}
             report={loaderData.data.report.period_result}
           />
         )}

--- a/src/webui/app/routes/app/workspace/tools/report.tsx
+++ b/src/webui/app/routes/app/workspace/tools/report.tsx
@@ -87,8 +87,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     return json(
       noErrorSomeData({
-        allProjects: summaryResponse.projects as Array<ProjectSummary>,
-        allGoals: summaryResponse.goals as Array<GoalSummary>,
+        allProjects: summaryResponse.projects,
+        allGoals: summaryResponse.goals,
         report: reportResponse,
       }),
     );
@@ -242,7 +242,7 @@ export default function Report() {
         loaderData.data.report !== undefined && (
           <ShowReport
             topLevelInfo={topLevelInfo}
-            allProjects={loaderData.data.allProjects}
+            allProjects={loaderData.data.allProjects ?? []}
             allGoals={loaderData.data.allGoals ?? []}
             report={loaderData.data.report.period_result}
           />


### PR DESCRIPTION
## Summary
This PR adds support for displaying report breakdowns by goals, allowing users to see inbox tasks and big plans summaries organized by their associated goals in the Life Plan feature.

## Key Changes

- **Backend Report Service**: 
  - Added fetching and indexing of all goals from the life plan
  - Implemented per-goal breakdown logic that groups inbox tasks and big plans by goal reference ID
  - Added `per_goal_breakdown` field to `ReportPeriodResult` containing `PerGoalBreakdownItem` objects
  - Breakdown is only generated when the LIFE_PLAN workspace feature is available

- **Data Models**:
  - Created new `PerGoalBreakdownItem` composite value class with goal metadata and summaries
  - Updated `ReportPeriodResult` to include `per_goal_breakdown` list
  - Added `GOALS` to `ReportBreakdown` enum

- **Frontend UI**:
  - Added "🎯 By Goals" tab to the report view (positioned after "By Projects")
  - Implemented goal breakdown display with hierarchical goal naming (parent/child relationships)
  - Updated tab index mapping to accommodate the new goals tab
  - Integrated goal sorting using existing `sortGoalsNaturally` utility

- **API Integration**:
  - Updated report loader to fetch goals via `include_goals` parameter in `getSummaries()`
  - Passed goals data to `ShowReport` component across report and journal views
  - Generated TypeScript types for `PerGoalBreakdownItem` and updated `ReportPeriodResult` types

## Implementation Details

- Goal breakdown respects the same filtering logic as other breakdowns (excludes archived goals)
- Gracefully handles missing goal data by filtering out goals not found in the goals index
- Reuses existing `OverviewReport` component for consistent UI presentation
- Feature is gated behind the `LIFE_PLAN` workspace feature flag

https://claude.ai/code/session_01SdMLTQEbJyU7PqxG62zSAw