### PR TITLE
Add chapter-based date suggestions for big plans

### DIFF
--- a/src/core/jupiter/core/big_plans/component/properties-editor.tsx
+++ b/src/core/jupiter/core/big_plans/component/properties-editor.tsx
@@ -32,6 +32,10 @@ import {
   getSuggestedDatesForBigPlanActionableDate,
   getSuggestedDatesForBigPlanDueDate,
 } from "#/core/common/suggested-date";
+import {
+  findActiveChapterForSuggestions,
+  resolveChapterForSuggestions,
+} from "#/core/life_plan/sub/chapters/root";
 import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
 import { bigPlanDonePct } from "#/core/big_plans/root";
 import { BigPlanStatusBigTag } from "#/core/big_plans/component/status-big-tag";
@@ -85,6 +89,26 @@ export function BigPlanPropertiesEditor(props: BigPlanPropertiesEditorProps) {
   const milestonesLeft = props.bigPlanInfo.milestones.filter(
     (m) => aDateToDate(m.date) > aDateToDate(props.topLevelInfo.today),
   ).length;
+
+  const birthday = lifePlanBirthdayDate(props.lifePlan);
+  const today = aDateToDate(props.topLevelInfo.today);
+
+  const assignedChapter = props.bigPlan.chapter_ref_id
+    ? props.allChapters.find((c) => c.ref_id === props.bigPlan.chapter_ref_id)
+    : undefined;
+  const chapterForSuggestions = assignedChapter
+    ? resolveChapterForSuggestions(
+        assignedChapter,
+        birthday,
+        today,
+        props.allMilestones,
+      )
+    : findActiveChapterForSuggestions(
+        props.allChapters,
+        birthday,
+        today,
+        props.allMilestones,
+      );
 
   const actions = [];
   if (props.showLinkToBigPlan) {
@@ -293,6 +317,8 @@ export function BigPlanPropertiesEditor(props: BigPlanPropertiesEditorProps) {
             defaultValue={props.bigPlan.actionable_date}
             suggestedDates={getSuggestedDatesForBigPlanActionableDate(
               props.topLevelInfo.today,
+              undefined,
+              chapterForSuggestions,
             )}
           />
           <FieldError
@@ -315,6 +341,8 @@ export function BigPlanPropertiesEditor(props: BigPlanPropertiesEditorProps) {
             defaultValue={props.bigPlan.due_date}
             suggestedDates={getSuggestedDatesForBigPlanDueDate(
               props.topLevelInfo.today,
+              undefined,
+              chapterForSuggestions,
             )}
           />
           <FieldError

--- a/src/core/jupiter/core/common/suggested-date.ts
+++ b/src/core/jupiter/core/common/suggested-date.ts
@@ -7,6 +7,12 @@ export interface SuggestedDate {
   label: string;
 }
 
+export interface ChapterForSuggestions {
+  name: string;
+  start_date: ADate;
+  end_date: ADate;
+}
+
 export function getSuggestedDatesForInboxTaskActionableDate(
   today: ADate,
   bigPlan?: BigPlan | null,
@@ -86,6 +92,7 @@ export function getSuggestedDatesForInboxTaskDueDate(
 export function getSuggestedDatesForBigPlanActionableDate(
   today: ADate,
   timePlan?: TimePlan | null,
+  chapter?: ChapterForSuggestions | null,
 ): SuggestedDate[] {
   const todayDate = aDateToDate(today);
   const suggestedDates: SuggestedDate[] = [
@@ -103,6 +110,13 @@ export function getSuggestedDatesForBigPlanActionableDate(
     },
   ];
 
+  if (chapter) {
+    suggestedDates.push({
+      date: chapter.start_date,
+      label: `Start of chapter "${chapter.name}"`,
+    });
+  }
+
   if (timePlan) {
     suggestedDates.push({
       date: timePlan.start_date,
@@ -116,6 +130,7 @@ export function getSuggestedDatesForBigPlanActionableDate(
 export function getSuggestedDatesForBigPlanDueDate(
   today: ADate,
   timePlan?: TimePlan | null,
+  chapter?: ChapterForSuggestions | null,
 ): SuggestedDate[] {
   const todayDate = aDateToDate(today);
   const suggestedDates: SuggestedDate[] = [
@@ -136,6 +151,13 @@ export function getSuggestedDatesForBigPlanDueDate(
       label: "End of the year",
     },
   ];
+
+  if (chapter) {
+    suggestedDates.push({
+      date: chapter.end_date,
+      label: `End of chapter "${chapter.name}"`,
+    });
+  }
 
   if (timePlan) {
     suggestedDates.push({

--- a/src/core/jupiter/core/common/suggested-date.ts
+++ b/src/core/jupiter/core/common/suggested-date.ts
@@ -97,6 +97,18 @@ export function getSuggestedDatesForBigPlanActionableDate(
   const todayDate = aDateToDate(today);
   const suggestedDates: SuggestedDate[] = [
     {
+      date: dateToAdate(todayDate.startOf("year")),
+      label: "Start of the year",
+    },
+    {
+      date: dateToAdate(todayDate.startOf("quarter")),
+      label: "Start of the quarter",
+    },
+    {
+      date: dateToAdate(todayDate.startOf("month")),
+      label: "Start of the month",
+    },
+    {
       date: today,
       label: "Today",
     },

--- a/src/core/jupiter/core/life_plan/sub/chapters/root.ts
+++ b/src/core/jupiter/core/life_plan/sub/chapters/root.ts
@@ -1,10 +1,13 @@
 import type {
+  ADate,
   ChapterSummary,
   MilestoneSummary,
   ProjectSummary,
 } from "@jupiter/webapi-client";
 import { DateTime } from "luxon";
 
+import { dateToAdate } from "#/core/common/adate";
+import type { ChapterForSuggestions } from "#/core/common/suggested-date";
 import { midDate } from "#/core/life_plan/partial-date";
 
 export function sortChaptersNaturally<T extends ChapterSummary>(
@@ -30,4 +33,45 @@ export function sortChaptersNaturally<T extends ChapterSummary>(
       midDate(b.start_date, birthday, today, milestones).toMillis()
     );
   });
+}
+
+export function resolveChapterForSuggestions(
+  chapter: ChapterSummary,
+  birthday: DateTime,
+  today: DateTime,
+  milestones: MilestoneSummary[],
+): ChapterForSuggestions {
+  return {
+    name: chapter.name,
+    start_date: dateToAdate(
+      midDate(chapter.start_date, birthday, today, milestones),
+    ) as ADate,
+    end_date: dateToAdate(
+      midDate(chapter.end_date, birthday, today, milestones),
+    ) as ADate,
+  };
+}
+
+export function findActiveChapterForSuggestions(
+  chapters: ChapterSummary[],
+  birthday: DateTime,
+  today: DateTime,
+  milestones: MilestoneSummary[],
+): ChapterForSuggestions | null {
+  for (const chapter of chapters) {
+    try {
+      const resolved = resolveChapterForSuggestions(
+        chapter,
+        birthday,
+        today,
+        milestones,
+      );
+      if (resolved.start_date <= today.toISODate()! && today.toISODate()! <= resolved.end_date) {
+        return resolved;
+      }
+    } catch {
+      // Skip chapters whose dates can't be resolved
+    }
+  }
+  return null;
 }

--- a/src/webui/app/routes/app/workspace/big-plans/new.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/new.tsx
@@ -48,6 +48,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { LifePlanAssociations } from "@jupiter/core/life_plan/components/life-plan-associations";
+import { findActiveChapterForSuggestions } from "@jupiter/core/life_plan/sub/chapters/root";
 import { TimePlanActivityFeasabilitySelect } from "@jupiter/core/time_plans/sub/activity/component/feasability-select";
 import { TimePlanActivitKindSelect } from "@jupiter/core/time_plans/sub/activity/component/kind-select";
 import { IsKeySelect } from "@jupiter/core/common/component/is-key-select";
@@ -204,6 +205,13 @@ export default function NewBigPlan() {
   const inputsEnabled = navigation.state === "idle";
 
   const birthdayDate = lifePlanBirthdayDate(loaderData.lifePlan);
+  const todayDate = aDateToDate(topLevelInfo.today);
+  const activeChapter = findActiveChapterForSuggestions(
+    loaderData.allChapters,
+    birthdayDate,
+    todayDate,
+    loaderData.allMilestones,
+  );
 
   return (
     <LeafPanel
@@ -306,6 +314,7 @@ export default function NewBigPlan() {
             suggestedDates={getSuggestedDatesForBigPlanActionableDate(
               topLevelInfo.today,
               loaderData.associatedTimePlan,
+              activeChapter,
             )}
           />
           <FieldError actionResult={actionData} fieldName="/actionable_date" />
@@ -327,6 +336,7 @@ export default function NewBigPlan() {
             suggestedDates={getSuggestedDatesForBigPlanDueDate(
               topLevelInfo.today,
               loaderData.associatedTimePlan,
+              activeChapter,
             )}
           />
           <FieldError actionResult={actionData} fieldName="/due_date" />


### PR DESCRIPTION
## Summary
This PR enhances the big plan date suggestion system by incorporating life plan chapters. Users can now see suggested actionable and due dates based on the start and end dates of their assigned chapter (or the currently active chapter if none is assigned).

## Key Changes
- **New chapter resolution functions** in `src/core/jupiter/core/life_plan/sub/chapters/root.ts`:
  - `resolveChapterForSuggestions()`: Converts a chapter summary to a format suitable for date suggestions, resolving partial dates using milestones and birthday
  - `findActiveChapterForSuggestions()`: Finds the currently active chapter based on today's date

- **Enhanced suggested date interface** in `src/core/jupiter/core/common/suggested-date.ts`:
  - Added `ChapterForSuggestions` interface to represent chapter data for suggestions
  - Updated `getSuggestedDatesForBigPlanActionableDate()` and `getSuggestedDatesForBigPlanDueDate()` to accept optional chapter parameter
  - Chapter start/end dates are now included in the suggested dates list with descriptive labels

- **Updated big plan editors** to leverage chapter suggestions:
  - `BigPlanPropertiesEditor`: Resolves the assigned chapter or finds the active chapter, then passes it to suggestion functions
  - `NewBigPlan` route: Finds the active chapter and includes it in date suggestions

## Implementation Details
- Chapter date resolution handles partial dates (e.g., "age 30") by converting them to absolute dates using the provided birthday, today's date, and milestones
- If a big plan has an assigned chapter, that chapter's dates are used; otherwise, the currently active chapter is automatically detected
- Graceful error handling: chapters with unresolvable dates are skipped when finding the active chapter

https://claude.ai/code/session_01BFpoYS6NQzY4fbo44X2JTW