### PR TITLE
Show tags and contacts on inbox tasks in all display locations

### DIFF
--- a/src/core/jupiter/core/chores/component/inbox-tasks-widget.tsx
+++ b/src/core/jupiter/core/chores/component/inbox-tasks-widget.tsx
@@ -84,6 +84,8 @@ export function ChoreInboxTasksWidget(props: WidgetProps) {
         }}
         label="Due Today"
         inboxTasks={inboxTasksForChoresDueToday}
+        inboxTaskTagsByInboxTaskRefId={choreTasks.inboxTaskTagsByInboxTaskRefId}
+        inboxTaskContactsByInboxTaskRefId={choreTasks.inboxTaskContactsByInboxTaskRefId}
         optimisticUpdates={choreTasks.optimisticUpdates}
         moreInfoByRefId={choreTasks.choreEntriesByRefId}
         onCardMarkDone={choreTasks.onCardMarkDone}
@@ -104,6 +106,8 @@ export function ChoreInboxTasksWidget(props: WidgetProps) {
         }}
         label="Due This Week"
         inboxTasks={inboxTasksForChoresDueThisWeek}
+        inboxTaskTagsByInboxTaskRefId={choreTasks.inboxTaskTagsByInboxTaskRefId}
+        inboxTaskContactsByInboxTaskRefId={choreTasks.inboxTaskContactsByInboxTaskRefId}
         optimisticUpdates={choreTasks.optimisticUpdates}
         moreInfoByRefId={choreTasks.choreEntriesByRefId}
         onCardMarkDone={choreTasks.onCardMarkDone}

--- a/src/core/jupiter/core/habits/component/inbox-tasks-widget.tsx
+++ b/src/core/jupiter/core/habits/component/inbox-tasks-widget.tsx
@@ -84,6 +84,8 @@ export function HabitInboxTasksWidget(props: WidgetProps) {
         }}
         label="Due Today"
         inboxTasks={inboxTasksForHabitsDueToday}
+        inboxTaskTagsByInboxTaskRefId={habitTasks.inboxTaskTagsByInboxTaskRefId}
+        inboxTaskContactsByInboxTaskRefId={habitTasks.inboxTaskContactsByInboxTaskRefId}
         optimisticUpdates={habitTasks.optimisticUpdates}
         moreInfoByRefId={habitTasks.habitEntriesByRefId}
         onCardMarkDone={habitTasks.onCardMarkDone}
@@ -104,6 +106,8 @@ export function HabitInboxTasksWidget(props: WidgetProps) {
         }}
         label="Due This Week"
         inboxTasks={inboxTasksForHabitsDueThisWeek}
+        inboxTaskTagsByInboxTaskRefId={habitTasks.inboxTaskTagsByInboxTaskRefId}
+        inboxTaskContactsByInboxTaskRefId={habitTasks.inboxTaskContactsByInboxTaskRefId}
         optimisticUpdates={habitTasks.optimisticUpdates}
         moreInfoByRefId={habitTasks.habitEntriesByRefId}
         onCardMarkDone={habitTasks.onCardMarkDone}

--- a/src/core/jupiter/core/home/component/common.tsx
+++ b/src/core/jupiter/core/home/component/common.tsx
@@ -1,10 +1,12 @@
 import {
   ADate,
   ChapterSummary,
+  Contact,
   InboxTask,
   LifePlan,
   MOTD,
   Note,
+  Tag,
   Timezone,
   TimePlanActivityDoneness,
   BigPlan,
@@ -74,6 +76,8 @@ export interface WidgetProps {
     habits: Habit[];
     habitInboxTasks: InboxTask[];
     habitEntriesByRefId: { [key: string]: InboxTaskParent };
+    inboxTaskTagsByInboxTaskRefId: Map<string, Array<Tag>>;
+    inboxTaskContactsByInboxTaskRefId: Map<string, Array<Contact>>;
     optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
     onCardMarkDone: (it: InboxTask) => void;
     onCardMarkNotDone: (it: InboxTask) => void;
@@ -81,6 +85,8 @@ export interface WidgetProps {
   choreTasks?: {
     choreInboxTasks: InboxTask[];
     choreEntriesByRefId: { [key: string]: InboxTaskParent };
+    inboxTaskTagsByInboxTaskRefId: Map<string, Array<Tag>>;
+    inboxTaskContactsByInboxTaskRefId: Map<string, Array<Contact>>;
     optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
     onCardMarkDone: (it: InboxTask) => void;
     onCardMarkNotDone: (it: InboxTask) => void;
@@ -88,6 +94,8 @@ export interface WidgetProps {
   personTasks?: {
     personInboxTasks: InboxTask[];
     personEntriesByRefId: { [key: string]: InboxTaskParent };
+    inboxTaskTagsByInboxTaskRefId: Map<string, Array<Tag>>;
+    inboxTaskContactsByInboxTaskRefId: Map<string, Array<Contact>>;
     optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
     onCardMarkDone: (it: InboxTask) => void;
     onCardMarkNotDone: (it: InboxTask) => void;

--- a/src/core/jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget.tsx
+++ b/src/core/jupiter/core/prm/sub/person/component/upcoming-catch-ups-widget.tsx
@@ -57,6 +57,8 @@ export function UpcomingCatchUpsWidget(props: WidgetProps) {
       }}
       label="Upcoming Catch Ups"
       inboxTasks={upcomingCatchUps}
+      inboxTaskTagsByInboxTaskRefId={personTasks.inboxTaskTagsByInboxTaskRefId}
+      inboxTaskContactsByInboxTaskRefId={personTasks.inboxTaskContactsByInboxTaskRefId}
       optimisticUpdates={personTasks.optimisticUpdates}
       moreInfoByRefId={personTasks.personEntriesByRefId}
       onCardMarkDone={personTasks.onCardMarkDone}

--- a/src/webui/app/routes/app/workspace/inbox-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/inbox-tasks.tsx
@@ -126,6 +126,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     include_notes: false,
     include_time_event_blocks: false,
     include_tags: true,
+    include_contacts: true,
   });
   const allTags = await apiClient.tags.tagFind({
     allow_archived: false,

--- a/src/webui/app/routes/app/workspace/index.tsx
+++ b/src/webui/app/routes/app/workspace/index.tsx
@@ -10,11 +10,13 @@ import {
 import {
   BigScreenHomeTabWidgetPlacement,
   ChapterSummary,
+  Contact,
   HabitLoadResult,
   HomeTab,
   HomeTabTarget,
   HomeWidget,
   InboxTask,
+  InboxTaskFindResultEntry,
   InboxTaskSource,
   InboxTaskStatus,
   LifePlan,
@@ -22,6 +24,7 @@ import {
   Note,
   RecurringTaskPeriod,
   SmallScreenHomeTabWidgetPlacement,
+  Tag,
   Vision,
   WidgetType,
   BigPlanLoadResult,
@@ -161,6 +164,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     habitInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
       allow_archived: false,
       include_tags: true,
+      include_contacts: true,
       include_notes: false,
       include_time_event_blocks: false,
       filter_sources: [InboxTaskSource.HABIT],
@@ -173,6 +177,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     choreInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
       allow_archived: false,
       include_tags: true,
+      include_contacts: true,
       include_notes: false,
       include_time_event_blocks: false,
       filter_sources: [InboxTaskSource.CHORE],
@@ -203,6 +208,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     personInboxTasksResponse = await apiClient.inboxTasks.inboxTaskFind({
       allow_archived: false,
       include_tags: true,
+      include_contacts: true,
       include_notes: false,
       include_time_event_blocks: false,
       filter_sources: [
@@ -419,6 +425,57 @@ export default function WorkspaceHome() {
     }
   }
 
+  const habitTagsByInboxTaskRefId = new Map<string, Array<Tag>>();
+  if (loaderData.habitInboxTasks) {
+    for (const entry of loaderData.habitInboxTasks) {
+      habitTagsByInboxTaskRefId.set(entry.inbox_task.ref_id, entry.tags ?? []);
+    }
+  }
+  const habitContactsByInboxTaskRefId = new Map<string, Array<Contact>>();
+  if (loaderData.habitInboxTasks) {
+    for (const entry of loaderData.habitInboxTasks) {
+      habitContactsByInboxTaskRefId.set(
+        entry.inbox_task.ref_id,
+        (entry as InboxTaskFindResultEntry & { contacts?: Array<Contact> })
+          .contacts ?? [],
+      );
+    }
+  }
+
+  const choreTagsByInboxTaskRefId = new Map<string, Array<Tag>>();
+  if (loaderData.choreInboxTasks) {
+    for (const entry of loaderData.choreInboxTasks) {
+      choreTagsByInboxTaskRefId.set(entry.inbox_task.ref_id, entry.tags ?? []);
+    }
+  }
+  const choreContactsByInboxTaskRefId = new Map<string, Array<Contact>>();
+  if (loaderData.choreInboxTasks) {
+    for (const entry of loaderData.choreInboxTasks) {
+      choreContactsByInboxTaskRefId.set(
+        entry.inbox_task.ref_id,
+        (entry as InboxTaskFindResultEntry & { contacts?: Array<Contact> })
+          .contacts ?? [],
+      );
+    }
+  }
+
+  const personTagsByInboxTaskRefId = new Map<string, Array<Tag>>();
+  if (loaderData.personInboxTasks) {
+    for (const entry of loaderData.personInboxTasks) {
+      personTagsByInboxTaskRefId.set(entry.inbox_task.ref_id, entry.tags ?? []);
+    }
+  }
+  const personContactsByInboxTaskRefId = new Map<string, Array<Contact>>();
+  if (loaderData.personInboxTasks) {
+    for (const entry of loaderData.personInboxTasks) {
+      personContactsByInboxTaskRefId.set(
+        entry.inbox_task.ref_id,
+        (entry as InboxTaskFindResultEntry & { contacts?: Array<Contact> })
+          .contacts ?? [],
+      );
+    }
+  }
+
   const [optimisticUpdates, setOptimisticUpdates] = useState<{
     [key: string]: InboxTaskOptimisticState;
   }>({});
@@ -527,6 +584,8 @@ export default function WorkspaceHome() {
           habits: loaderData.keyHabitResults.map((h) => h.habit),
           habitInboxTasks: sortedHabitInboxTasks!,
           habitEntriesByRefId: habitEntriesByRefId!,
+          inboxTaskTagsByInboxTaskRefId: habitTagsByInboxTaskRefId,
+          inboxTaskContactsByInboxTaskRefId: habitContactsByInboxTaskRefId,
           optimisticUpdates,
           onCardMarkDone: handleCardMarkDone,
           onCardMarkNotDone: handleCardMarkNotDone,
@@ -536,6 +595,8 @@ export default function WorkspaceHome() {
       ? {
           choreInboxTasks: sortedChoreInboxTasks!,
           choreEntriesByRefId: choreEntriesByRefId!,
+          inboxTaskTagsByInboxTaskRefId: choreTagsByInboxTaskRefId,
+          inboxTaskContactsByInboxTaskRefId: choreContactsByInboxTaskRefId,
           optimisticUpdates,
           onCardMarkDone: handleCardMarkDone,
           onCardMarkNotDone: handleCardMarkNotDone,
@@ -545,6 +606,8 @@ export default function WorkspaceHome() {
       ? {
           personInboxTasks: sortedPersonInboxTasks!,
           personEntriesByRefId: personEntriesByRefId!,
+          inboxTaskTagsByInboxTaskRefId: personTagsByInboxTaskRefId,
+          inboxTaskContactsByInboxTaskRefId: personContactsByInboxTaskRefId,
           optimisticUpdates,
           onCardMarkDone: handleCardMarkDone,
           onCardMarkNotDone: handleCardMarkNotDone,


### PR DESCRIPTION
- Add `include_contacts: true` to inboxTaskFind API calls in the main
  inbox-tasks loader and all three home dashboard widget loaders
  (habits, chores, persons)
- Build inboxTaskTagsByInboxTaskRefId and inboxTaskContactsByInboxTaskRefId
  maps for each widget type in the home dashboard (index.tsx)
- Extend WidgetProps habitTasks/choreTasks/personTasks to carry the tags
  and contacts maps through to the widget components
- Pass the maps to InboxTaskStack in HabitInboxTasksWidget,
  ChoreInboxTasksWidget, and UpcomingCatchUpsWidget so tags and contacts
  are rendered on every card

https://claude.ai/code/session_01HuwaZkeoyZgaGfDP2VoJdg