### PR TITLE
Restrict inbox tasks for monthly/quarterly/yearly time plans

### DIFF
--- a/src/core/jupiter/core/time_plans/use_case/associate_inbox_task_with_plan.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_inbox_task_with_plan.py
@@ -2,6 +2,7 @@
 
 from jupiter.core.app import AppCore
 from jupiter.core.big_plans.root import BigPlan
+from jupiter.core.common.recurring_task_period import RecurringTaskPeriod
 from jupiter.core.config import (
     JupiterLoggedInMutationContext,
     JupiterTransactionalLoggedInMutationUseCase,
@@ -11,6 +12,14 @@ from jupiter.core.inbox_tasks.root import InboxTask
 from jupiter.core.inbox_tasks.source import InboxTaskSource
 from jupiter.core.time_plans.domain import TimePlanDomain
 from jupiter.core.time_plans.root import TimePlan
+
+_BIG_PLAN_ONLY_PERIODS = frozenset(
+    [
+        RecurringTaskPeriod.MONTHLY,
+        RecurringTaskPeriod.QUARTERLY,
+        RecurringTaskPeriod.YEARLY,
+    ]
+)
 from jupiter.core.time_plans.sub.activity.feasability import (
     TimePlanActivityFeasability,
 )
@@ -98,6 +107,9 @@ class TimePlanAssociateInboxTaskWithPlanUseCase(
         new_time_plan_activities = []
 
         for time_plan in time_plans:
+            if time_plan.period in _BIG_PLAN_ONLY_PERIODS:
+                continue
+
             try:
                 new_time_plan_activity = TimePlanActivity.new_activity_for_inbox_task(
                     context.domain_context,

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_inbox_tasks.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_inbox_tasks.py
@@ -3,6 +3,7 @@
 from jupiter.core.app import AppCore
 from jupiter.core.big_plans.collection import BigPlanCollection
 from jupiter.core.big_plans.root import BigPlan
+from jupiter.core.common.recurring_task_period import RecurringTaskPeriod
 from jupiter.core.config import (
     JupiterLoggedInMutationContext,
     JupiterTransactionalLoggedInMutationUseCase,
@@ -38,6 +39,14 @@ from jupiter.framework.use_case_io import (
     use_case_result,
 )
 from jupiter.framework.utils.generic_creator import generic_creator
+
+_BIG_PLAN_ONLY_PERIODS = frozenset(
+    [
+        RecurringTaskPeriod.MONTHLY,
+        RecurringTaskPeriod.QUARTERLY,
+        RecurringTaskPeriod.YEARLY,
+    ]
+)
 
 
 @use_case_args
@@ -82,6 +91,11 @@ class TimePlanAssociateWithInboxTasksUseCase(
         workspace = context.workspace
 
         time_plan = await uow.get_for(TimePlan).load_by_id(args.ref_id)
+
+        if time_plan.period in _BIG_PLAN_ONLY_PERIODS:
+            raise InputValidationError(
+                f"Inbox tasks cannot be added to {time_plan.period.value} time plans; only big plans are allowed"
+            )
 
         inbox_task_collection = await uow.get_for(InboxTaskCollection).load_by_parent(
             workspace.ref_id

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -352,6 +352,11 @@ export default function TimePlanView() {
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
 
+  const isBigPlanOnlyPeriod =
+    loaderData.timePlan.period === RecurringTaskPeriod.MONTHLY ||
+    loaderData.timePlan.period === RecurringTaskPeriod.QUARTERLY ||
+    loaderData.timePlan.period === RecurringTaskPeriod.YEARLY;
+
   const targetInboxTasksByRefId = new Map<string, InboxTask>(
     loaderData.targetInboxTasks.map((it) => [it.ref_id, it]),
   );
@@ -635,23 +640,31 @@ export default function TimePlanView() {
               actions={[
                 NavMultipleCompact({
                   navs: [
-                    NavSingle({
-                      text: "New Inbox Task",
-                      link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
-                    }),
+                    ...(!isBigPlanOnlyPeriod
+                      ? [
+                          NavSingle({
+                            text: "New Inbox Task",
+                            link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                          }),
+                        ]
+                      : []),
                     NavSingle({
                       text: "New Big Plan",
                       link: `/app/workspace/big-plans/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
                       gatedOn: WorkspaceFeature.BIG_PLANS,
                     }),
-                    NavSingle({
-                      text: "From Current Inbox Tasks",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`,
-                    }),
-                    NavSingle({
-                      text: "From Generated Inbox Tasks",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
-                    }),
+                    ...(!isBigPlanOnlyPeriod
+                      ? [
+                          NavSingle({
+                            text: "From Current Inbox Tasks",
+                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`,
+                          }),
+                          NavSingle({
+                            text: "From Generated Inbox Tasks",
+                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
+                          }),
+                        ]
+                      : []),
                     NavSingle({
                       text: "From Current Big Plans",
                       link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`,
@@ -769,7 +782,11 @@ export default function TimePlanView() {
             <EntityNoNothingCard
               title="You Have To Start Somewhere"
               message="There are no activities to show. You can create a new activity."
-              newEntityLocations={`/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`}
+              newEntityLocations={
+                isBigPlanOnlyPeriod
+                  ? `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`
+                  : `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`
+              }
               helpSubject={DocsHelpSubject.TIME_PLANS}
             />
           )}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -55,8 +55,6 @@ import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
 import {
   ActionSingle,
-  NavMultipleSpread,
-  NavSingle,
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
@@ -911,28 +909,6 @@ export default function TimePlanActivity() {
             <SectionCard
               id="target-big-plan-inbox-tasks"
               title="Inbox Tasks"
-              actions={
-                <SectionActions
-                  id="target-big-plan-inbox-tasks"
-                  topLevelInfo={topLevelInfo}
-                  inputsEnabled={inputsEnabled}
-                  actions={[
-                    NavMultipleSpread({
-                      navs: [
-                        NavSingle({
-                          text: "New Inbox Task",
-                          link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${id}&bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&parentTimePlanActivityRefId=${activityId}`,
-                          highlight: true,
-                        }),
-                        NavSingle({
-                          text: "From Current Inbox Tasks",
-                          link: `/app/workspace/time-plans/${id}/add-from-current-inbox-tasks?bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&timePlanActivityRefId=${activityId}`,
-                        }),
-                      ],
-                    }),
-                  ]}
-                />
-              }
             >
               {sortedBigPlanInboxTasks.length > 0 && (
                 <InboxTaskStack


### PR DESCRIPTION
## Summary
This change restricts inbox task management for time plans with longer periods (monthly, quarterly, yearly), allowing only big plans to be associated with these time plan types.

## Key Changes

- **Frontend UI Updates** (`time-plans/$id.tsx`):
  - Added `isBigPlanOnlyPeriod` flag to identify monthly, quarterly, and yearly time plans
  - Conditionally hide "New Inbox Task", "From Current Inbox Tasks", and "From Generated Inbox Tasks" actions for big plan-only periods
  - Updated empty state to redirect to big plans instead of inbox tasks for these periods
  - Removed inbox task creation actions from big plan activity view

- **Backend Validation** (`associate_with_inbox_tasks.py`):
  - Added validation to prevent adding inbox tasks to monthly, quarterly, or yearly time plans
  - Raises `InputValidationError` with descriptive message when attempted

- **Inbox Task Association** (`associate_inbox_task_with_plan.py`):
  - Modified to skip creating time plan activities for big plan-only periods when associating inbox tasks
  - Prevents inbox tasks from being linked to these time plan types

## Implementation Details

- Introduced `_BIG_PLAN_ONLY_PERIODS` constant in both backend use cases for consistent period checking
- The restriction is enforced at both the UI level (hiding options) and API level (validation)
- Existing big plan functionality remains fully available for all time plan periods

https://claude.ai/code/session_01KHa3KKwjTgJuu6NMZKtMZL