### PR TITLE
Add inbox task restrictions based on time plan period

### DIFF
--- a/src/core/jupiter/core/time_plans/root.py
+++ b/src/core/jupiter/core/time_plans/root.py
@@ -163,6 +163,19 @@ class TimePlan(LeafEntity):
             right_now=right_now,
         )
 
+    @property
+    def allows_big_plans(self) -> bool:
+        """Whether this time plan allows big plan activities."""
+        return True
+
+    @property
+    def allows_inbox_tasks(self) -> bool:
+        """Whether this time plan allows inbox task activities."""
+        return self.period in (
+            RecurringTaskPeriod.DAILY,
+            RecurringTaskPeriod.WEEKLY,
+        )
+
     @staticmethod
     def build_name(right_now: ADate, period: RecurringTaskPeriod) -> EntityName:
         """Build the name of the time plan."""

--- a/src/core/jupiter/core/time_plans/root.ts
+++ b/src/core/jupiter/core/time_plans/root.ts
@@ -1,7 +1,19 @@
 import type { ADate, TimePlan } from "@jupiter/webapi-client";
+import { RecurringTaskPeriod } from "@jupiter/webapi-client";
 
 import { aDateToDate, compareADate } from "#/core/common/adate";
 import { comparePeriods } from "#/core/common/recurring-task-period";
+
+export function timePlanAllowsBigPlans(_timePlan: TimePlan): boolean {
+  return true;
+}
+
+export function timePlanAllowsInboxTasks(timePlan: TimePlan): boolean {
+  return (
+    timePlan.period === RecurringTaskPeriod.DAILY ||
+    timePlan.period === RecurringTaskPeriod.WEEKLY
+  );
+}
 
 export function findTimePlansThatAreActive(
   timePlans: Array<TimePlan>,

--- a/src/core/jupiter/core/time_plans/use_case/associate_inbox_task_with_plan.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_inbox_task_with_plan.py
@@ -93,6 +93,12 @@ class TimePlanAssociateInboxTaskWithPlanUseCase(
             filter_ref_ids=args.time_plan_ref_ids,
         )
 
+        for time_plan in time_plans:
+            if not time_plan.allows_inbox_tasks:
+                raise InputValidationError(
+                    f"Time plan {time_plan.name} does not allow inbox task activities"
+                )
+
         latest_time_plan = max(time_plans, key=lambda x: x.end_date)
 
         new_time_plan_activities = []

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_activities.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_activities.py
@@ -122,6 +122,12 @@ class TimePlanAssociateWithActivitiesUseCase(
                 await progress_reporter.mark_updated(big_plan)
 
         # Then we create all the inbox tasks, with their owning big plans if not already.
+        # Skip inbox task activities if the target time plan does not allow them.
+        if not time_plan.allows_inbox_tasks:
+            return TimePlanAssociateWithActivitiesResult(
+                new_time_plan_activities=new_time_plan_actitivies
+            )
+
         for activity in activities:
             if activity.target != TimePlanActivityTarget.INBOX_TASK:
                 continue

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_inbox_tasks.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_inbox_tasks.py
@@ -83,6 +83,11 @@ class TimePlanAssociateWithInboxTasksUseCase(
 
         time_plan = await uow.get_for(TimePlan).load_by_id(args.ref_id)
 
+        if not time_plan.allows_inbox_tasks:
+            raise InputValidationError(
+                "This time plan does not allow inbox task activities"
+            )
+
         inbox_task_collection = await uow.get_for(InboxTaskCollection).load_by_parent(
             workspace.ref_id
         )

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -36,7 +36,10 @@ import { sortJournalsNaturally } from "@jupiter/core/journals/root";
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { allowUserChanges } from "@jupiter/core/time_plans/source";
 import { filterActivityByFeasabilityWithParents } from "@jupiter/core/time_plans/sub/activity/root";
-import { sortTimePlansNaturally } from "@jupiter/core/time_plans/root";
+import {
+  sortTimePlansNaturally,
+  timePlanAllowsInboxTasks,
+} from "@jupiter/core/time_plans/root";
 import { sortAspectsByTreeOrder } from "#/core/life_plan/sub/aspects/root";
 import { sortGoalsNaturally } from "#/core/life_plan/sub/goals/root";
 import { BigPlanStack } from "@jupiter/core/big_plans/component/stack";
@@ -635,23 +638,31 @@ export default function TimePlanView() {
               actions={[
                 NavMultipleCompact({
                   navs: [
-                    NavSingle({
-                      text: "New Inbox Task",
-                      link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
-                    }),
+                    ...(timePlanAllowsInboxTasks(loaderData.timePlan)
+                      ? [
+                          NavSingle({
+                            text: "New Inbox Task",
+                            link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                          }),
+                        ]
+                      : []),
                     NavSingle({
                       text: "New Big Plan",
                       link: `/app/workspace/big-plans/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
                       gatedOn: WorkspaceFeature.BIG_PLANS,
                     }),
-                    NavSingle({
-                      text: "From Current Inbox Tasks",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`,
-                    }),
-                    NavSingle({
-                      text: "From Generated Inbox Tasks",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
-                    }),
+                    ...(timePlanAllowsInboxTasks(loaderData.timePlan)
+                      ? [
+                          NavSingle({
+                            text: "From Current Inbox Tasks",
+                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`,
+                          }),
+                          NavSingle({
+                            text: "From Generated Inbox Tasks",
+                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
+                          }),
+                        ]
+                      : []),
                     NavSingle({
                       text: "From Current Big Plans",
                       link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`,
@@ -769,7 +780,11 @@ export default function TimePlanView() {
             <EntityNoNothingCard
               title="You Have To Start Somewhere"
               message="There are no activities to show. You can create a new activity."
-              newEntityLocations={`/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`}
+              newEntityLocations={
+                timePlanAllowsInboxTasks(loaderData.timePlan)
+                  ? `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-inbox-tasks`
+                  : `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`
+              }
               helpSubject={DocsHelpSubject.TIME_PLANS}
             />
           )}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -61,6 +61,7 @@ import {
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
 import { TimeEventInDayBlockStack } from "@jupiter/core/common/sub/time_events/sub/in_day_block/component/stack";
+import { timePlanAllowsInboxTasks } from "@jupiter/core/time_plans/root";
 import { TimePlanActivityFeasabilitySelect } from "@jupiter/core/time_plans/sub/activity/component/feasability-select";
 import { TimePlanActivitKindSelect } from "@jupiter/core/time_plans/sub/activity/component/kind-select";
 import { validationErrorToUIErrorInfo } from "@jupiter/core/infra/action-result";
@@ -919,15 +920,19 @@ export default function TimePlanActivity() {
                   actions={[
                     NavMultipleSpread({
                       navs: [
-                        NavSingle({
-                          text: "New Inbox Task",
-                          link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${id}&bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&parentTimePlanActivityRefId=${activityId}`,
-                          highlight: true,
-                        }),
-                        NavSingle({
-                          text: "From Current Inbox Tasks",
-                          link: `/app/workspace/time-plans/${id}/add-from-current-inbox-tasks?bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&timePlanActivityRefId=${activityId}`,
-                        }),
+                        ...(timePlanAllowsInboxTasks(timePlan)
+                          ? [
+                              NavSingle({
+                                text: "New Inbox Task",
+                                link: `/app/workspace/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${id}&bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&parentTimePlanActivityRefId=${activityId}`,
+                                highlight: true,
+                              }),
+                              NavSingle({
+                                text: "From Current Inbox Tasks",
+                                link: `/app/workspace/time-plans/${id}/add-from-current-inbox-tasks?bigPlanReason=for-big-plan&bigPlanRefId=${loaderData.targetBigPlan.ref_id}&timePlanActivityRefId=${activityId}`,
+                              }),
+                            ]
+                          : []),
                       ],
                     }),
                   ]}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
@@ -37,6 +37,7 @@ import {
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
 import { StandardDivider } from "@jupiter/core/infra/component/standard-divider";
+import { timePlanAllowsInboxTasks } from "@jupiter/core/time_plans/root";
 import { TimePlanActivityCard } from "@jupiter/core/time_plans/sub/activity/component/card";
 import { TimePlanActivityFeasabilitySelect } from "@jupiter/core/time_plans/sub/activity/component/feasability-select";
 import { TimePlanActivitKindSelect } from "@jupiter/core/time_plans/sub/activity/component/kind-select";
@@ -255,6 +256,10 @@ export default function TimePlanAddFromCurrentTimePlans() {
     otherTargetInboxTasksByRefId,
     otherTargetBigPlansByRefId,
     loaderData.otherActivityDoneness,
+  ).filter(
+    (activity) =>
+      activity.target !== TimePlanActivityTarget.INBOX_TASK ||
+      timePlanAllowsInboxTasks(loaderData.mainTimePlan),
   );
   const sortedOtherActivities = sortTimePlanActivitiesNaturally(
     filteredOtherActivities,


### PR DESCRIPTION
## Summary
This PR adds validation and UI filtering to restrict inbox task activities to only daily and weekly time plans. Monthly and other longer-period time plans can only contain big plan activities.

## Key Changes

- **New validation functions**: Added `timePlanAllowsInboxTasks()` and `timePlanAllowsBigPlans()` helper functions in both TypeScript and Python to determine which activity types are allowed for a given time plan
  - Inbox tasks are only allowed for DAILY and WEEKLY periods
  - Big plans are allowed for all periods

- **Backend validation**: Added checks in three use cases to prevent inbox task associations with incompatible time plans:
  - `associate_inbox_task_with_plan.py`: Validates time plan allows inbox tasks before association
  - `associate_with_inbox_tasks.py`: Prevents adding inbox tasks to incompatible time plans
  - `associate_with_activities.py`: Skips inbox task creation for incompatible time plans

- **Frontend UI updates**: Conditionally hide inbox task-related navigation options when the time plan doesn't support them:
  - Time plan view: Hide "New Inbox Task", "From Current Inbox Tasks", and "From Generated Inbox Tasks" options
  - Time plan activity view: Hide inbox task creation options
  - Time plan cross-linking view: Filter out inbox task activities from incompatible time plans
  - Empty state: Route to big plans instead of inbox tasks for incompatible time plans

## Implementation Details

The `allows_inbox_tasks` property is implemented as a simple period check on the TimePlan model, making it easy to maintain and test. The UI uses spread operators with conditional arrays to cleanly show/hide navigation items based on the time plan's capabilities.

https://claude.ai/code/session_01Vb4tL3qTYXu3wbczAb8cyo