### PR TITLE
Add drag-and-drop support for calendar time events

### DIFF
--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -1,3 +1,4 @@
+import { Draggable, Droppable } from "@hello-pangea/dnd";
 import {
   ADate,
   BigPlan,
@@ -53,6 +54,7 @@ import {
   clipTimeEventFullDaysNameToWhatFits,
   buildTimeBlockOffsetsMap,
   clipTimeEventInDayNameToWhatFits,
+  isTimeEventInDayBlockEditable,
 } from "#/core/common/sub/time_events/time-event";
 import {
   scheduleStreamColorContrastingHex,
@@ -542,85 +544,144 @@ export function ViewAsCalendarTimeEventInDayColumn(
   }
 
   return (
-    <Box
-      sx={{
-        position: "relative",
-        flexGrow: 1,
-        height: `${heightInRem}rem`,
-        minWidth: "7rem",
-      }}
-      ref={wholeColumnRef}
-      onDoubleClick={createNewFromDoubleClick}
-    >
-      {props.today === props.date && (
+    <Droppable droppableId={props.date} type="calendar-time-event">
+      {(provided, snapshot) => (
         <Box
           sx={{
-            position: "absolute",
-            top: calendarTimeEventInDayStartMinutesToRems(
-              theMinutes,
-              deltaHour,
-            ),
-            height: "0.15rem",
-            width: "100%",
-            backgroundColor: theme.palette.info.dark,
-            zIndex: theme.zIndex.appBar,
+            position: "relative",
+            flexGrow: 1,
+            height: `${heightInRem}rem`,
+            minWidth: "7rem",
+            overflow: "hidden",
+            backgroundColor: snapshot.isDraggingOver
+              ? "rgba(0, 0, 0, 0.04)"
+              : undefined,
           }}
-        ></Box>
-      )}
+          ref={(node) => {
+            wholeColumnRef.current = node as HTMLDivElement | null;
+            provided.innerRef(node as HTMLElement | null);
+          }}
+          {...provided.droppableProps}
+          onDoubleClick={createNewFromDoubleClick}
+        >
+          {props.today === props.date && (
+            <Box
+              sx={{
+                position: "absolute",
+                top: calendarTimeEventInDayStartMinutesToRems(
+                  theMinutes,
+                  deltaHour,
+                ),
+                height: "0.15rem",
+                width: "100%",
+                backgroundColor: theme.palette.info.dark,
+                zIndex: theme.zIndex.appBar,
+              }}
+            ></Box>
+          )}
 
-      {hours.map((hour, idx) => {
-        if (
-          props.showOnlyFromRightNowIfDaily &&
-          hour.hour < props.rightNow.hour
-        ) {
-          return null;
-        }
+          {hours.map((hour, idx) => {
+            if (
+              props.showOnlyFromRightNowIfDaily &&
+              hour.hour < props.rightNow.hour
+            ) {
+              return null;
+            }
 
-        const locationInRem = idx * 4 - deltaHour * 4;
+            const locationInRem = idx * 4 - deltaHour * 4;
 
-        return (
-          <Box
-            key={idx}
-            sx={{
-              position: "absolute",
-              height: "0.05rem",
-              left: "-0.05rem", // Offset for gap: 0.1 in container
-              backgroundColor: theme.palette.text.disabled,
-              top: `${locationInRem}rem`,
-              width: "calc(100% + 0.1rem)", // Offset for gap 0.1 in container
-            }}
-          ></Box>
-        );
-      })}
+            return (
+              <Box
+                key={idx}
+                sx={{
+                  position: "absolute",
+                  height: "0.05rem",
+                  left: "-0.05rem", // Offset for gap: 0.1 in container
+                  backgroundColor: theme.palette.text.disabled,
+                  top: `${locationInRem}rem`,
+                  width: "calc(100% + 0.1rem)", // Offset for gap 0.1 in container
+                }}
+              ></Box>
+            );
+          })}
 
-      <TimeEventParamsNewPlaceholder
-        daysToTheLeft={props.daysToTheLeft}
-        date={props.date}
-        deltaHour={deltaHour}
-      />
-
-      {props.timeEventsInDay.map((entry, index) => {
-        return (
-          <ViewAsCalendarTimeEventInDayCell
-            key={index}
-            offset={timeBlockOffsetsMap.get(entry.time_event_in_tz.ref_id) || 0}
-            startOfDay={startOfDay}
-            entry={entry}
-            isAdding={props.isAdding}
+          <TimeEventParamsNewPlaceholder
+            daysToTheLeft={props.daysToTheLeft}
+            date={props.date}
             deltaHour={deltaHour}
           />
-        );
-      })}
-    </Box>
+
+          {props.timeEventsInDay.map((entry, index) => {
+            const offset =
+              timeBlockOffsetsMap.get(entry.time_event_in_tz.ref_id) || 0;
+            const startTime = calculateStartTimeForTimeEvent(
+              entry.time_event_in_tz,
+            );
+            const minutesSinceStartOfDay = startTime
+              .diff(startOfDay)
+              .as("minutes");
+            const topRems = calendarTimeEventInDayStartMinutesToRems(
+              minutesSinceStartOfDay,
+              deltaHour,
+            );
+
+            if (topRems === undefined) return null;
+
+            const heightRems = calendarTimeEventInDayDurationToRems(
+              minutesSinceStartOfDay,
+              entry.time_event_in_tz.duration_mins,
+            );
+            const isEditable = isTimeEventInDayBlockEditable(
+              entry.time_event_in_tz.namespace,
+            );
+            const draggableId = `${entry.time_event_in_tz.ref_id}|${entry.time_event_in_tz.start_time_in_day}|${entry.time_event_in_tz.duration_mins}`;
+
+            return (
+              <Draggable
+                key={entry.time_event_in_tz.ref_id}
+                draggableId={draggableId}
+                index={index}
+                isDragDisabled={!isEditable}
+              >
+                {(dragProvided, dragSnapshot) => (
+                  <div
+                    ref={dragProvided.innerRef}
+                    {...dragProvided.draggableProps}
+                    {...dragProvided.dragHandleProps}
+                    style={{
+                      position: "absolute",
+                      top: topRems,
+                      height: heightRems,
+                      minWidth: `calc(7rem - ${offset * 0.8}rem - 0.5rem)`,
+                      width: `calc(100% - ${offset * 0.8}rem - 0.5rem)`,
+                      marginLeft: `${offset * 0.8}rem`,
+                      zIndex: dragSnapshot.isDragging ? 5000 : offset,
+                      cursor: isEditable ? "grab" : "default",
+                      ...dragProvided.draggableProps.style,
+                    }}
+                  >
+                    <ViewAsCalendarTimeEventInDayCell
+                      startOfDay={startOfDay}
+                      entry={entry}
+                      isAdding={props.isAdding}
+                    />
+                  </div>
+                )}
+              </Draggable>
+            );
+          })}
+
+          <div style={{ display: "none" }}>{provided.placeholder}</div>
+        </Box>
+      )}
+    </Droppable>
   );
 }
 
 interface ViewAsCalendarTimeEventInDayCellProps {
-  offset: number;
   startOfDay: DateTime;
   entry: CombinedTimeEventInDayEntry;
   isAdding: boolean;
-  deltaHour: number;
 }
 
 export function ViewAsCalendarTimeEventInDayCell(
@@ -659,34 +720,18 @@ export function ViewAsCalendarTimeEventInDayCell(
         scheduleEntry.time_event.duration_mins,
       );
 
-      const topRems = calendarTimeEventInDayStartMinutesToRems(
-        minutesSinceStartOfDay,
-        props.deltaHour,
-      );
-
-      if (topRems === undefined) {
-        return null;
-      }
-
       return (
         <Box
           ref={containerRef}
           id={`schedule-event-in-day-block-${(props.entry.entry as ScheduleInDayEventEntry).event.ref_id}`}
           sx={{
             fontSize: "10px",
-            position: "absolute",
-            top: topRems,
-            height: calendarTimeEventInDayDurationToRems(
-              minutesSinceStartOfDay,
-              scheduleEntry.time_event.duration_mins,
-            ),
+            position: "relative",
+            height: "100%",
+            overflow: "hidden",
             backgroundColor: scheduleStreamColorHex(scheduleEntry.stream.color),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
-            minWidth: `calc(7rem - ${props.offset * 0.8}rem - 0.5rem)`,
-            width: `calc(100% - ${props.offset * 0.8}rem - 0.5rem)`,
-            marginLeft: `${props.offset * 0.8}rem`,
-            zIndex: props.offset,
           }}
         >
           <EntityLink
@@ -743,27 +788,15 @@ export function ViewAsCalendarTimeEventInDayCell(
         props.entry.time_event_in_tz.duration_mins,
       );
 
-      const topRems = calendarTimeEventInDayStartMinutesToRems(
-        minutesSinceStartOfDay,
-        props.deltaHour,
-      );
-
-      if (topRems === undefined) {
-        return null;
-      }
-
       return (
         <Box
           ref={containerRef}
           id={`inbox-task-event-in-day-block-${(props.entry.entry as InboxTaskEntry).inbox_task.ref_id}`}
           sx={{
             fontSize: "10px",
-            position: "absolute",
-            top: topRems,
-            height: calendarTimeEventInDayDurationToRems(
-              minutesSinceStartOfDay,
-              props.entry.time_event_in_tz.duration_mins,
-            ),
+            position: "relative",
+            height: "100%",
+            overflow: "hidden",
             backgroundColor: scheduleStreamColorHex(
               INBOX_TASK_TIME_EVENT_COLOR,
               inboxTaskEntry.inbox_task.status === InboxTaskStatus.DONE
@@ -774,10 +807,6 @@ export function ViewAsCalendarTimeEventInDayCell(
             ),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
-            minWidth: `calc(7rem - ${props.offset * 0.8}rem  - 0.5rem)`,
-            width: `calc(100% - ${props.offset * 0.8}rem - 0.5rem)`,
-            marginLeft: `${props.offset * 0.8}rem`,
-            zIndex: props.offset,
           }}
         >
           <EntityLink
@@ -834,27 +863,15 @@ export function ViewAsCalendarTimeEventInDayCell(
         props.entry.time_event_in_tz.duration_mins,
       );
 
-      const topRems = calendarTimeEventInDayStartMinutesToRems(
-        minutesSinceStartOfDay,
-        props.deltaHour,
-      );
-
-      if (topRems === undefined) {
-        return null;
-      }
-
       return (
         <Box
           ref={containerRef}
           id={`big-plan-event-in-day-block-${bigPlanEntry.big_plan.ref_id}`}
           sx={{
             fontSize: "10px",
-            position: "absolute",
-            top: topRems,
-            height: calendarTimeEventInDayDurationToRems(
-              minutesSinceStartOfDay,
-              props.entry.time_event_in_tz.duration_mins,
-            ),
+            position: "relative",
+            height: "100%",
+            overflow: "hidden",
             backgroundColor: scheduleStreamColorHex(
               BIG_PLAN_TIME_EVENT_COLOR,
               bigPlanEntry.big_plan.status === BigPlanStatus.DONE
@@ -865,10 +882,6 @@ export function ViewAsCalendarTimeEventInDayCell(
             ),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
-            minWidth: `calc(7rem - ${props.offset * 0.8}rem  - 0.5rem)`,
-            width: `calc(100% - ${props.offset * 0.8}rem - 0.5rem)`,
-            marginLeft: `${props.offset * 0.8}rem`,
-            zIndex: props.offset,
           }}
         >
           <EntityLink

--- a/src/core/jupiter/core/calendar/component/view-as-calendar-daily.tsx
+++ b/src/core/jupiter/core/calendar/component/view-as-calendar-daily.tsx
@@ -1,6 +1,9 @@
+import { DragDropContext } from "@hello-pangea/dnd";
+import type { DropResult } from "@hello-pangea/dnd";
 import { DateTime } from "luxon";
 import { useState } from "react";
 import { Box, Typography } from "@mui/material";
+import { useFetcher } from "@remix-run/react";
 
 import {
   combinedTimeEventFullDayEntryPartionByDay,
@@ -29,6 +32,8 @@ export function ViewAsCalendarDaily(props: ViewAsProps) {
 
   const [showAllTimeEventFullDays, setShowAllTimeEventFullDays] =
     useState(false);
+
+  const calendarMoveFetcher = useFetcher();
 
   if (props.entries === undefined) {
     throw new Error("Entries are required");
@@ -98,6 +103,32 @@ export function ViewAsCalendarDaily(props: ViewAsProps) {
   const thePartitionInDay =
     partitionedCombinedTimeEventInDay[props.periodStartDate] || [];
 
+  function onDragEnd(result: DropResult) {
+    if (!result.destination) return;
+    if (result.source.droppableId === result.destination.droppableId) return;
+
+    const parts = result.draggableId.split("|");
+    const eventRefId = parts[0];
+    const startTimeInDay = parts[1];
+    const durationMins = parts[2];
+    const newDate = result.destination.droppableId;
+
+    calendarMoveFetcher.submit(
+      {
+        id: eventRefId,
+        startDate: newDate,
+        startTimeInDay: startTimeInDay,
+        durationMins: durationMins,
+        userTimezone: props.timezone,
+      },
+      {
+        method: "post",
+        action:
+          "/app/workspace/calendar/time-event/in-day-block/update-time",
+      },
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -146,26 +177,28 @@ export function ViewAsCalendarDaily(props: ViewAsProps) {
         </Box>
       </ViewAsCalendarDaysAndFullDaysContiner>
 
-      <ViewAsCalendarInDayContainer>
-        <ViewAsCalendarLeftColumn
-          rightNow={props.rightNow}
-          showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
-        />
-        <ViewAsCalendarTimeEventInDayColumn
-          daysToTheLeft={0}
-          rightNow={props.rightNow}
-          today={props.today}
-          timezone={props.timezone}
-          date={props.periodStartDate}
-          timeEventsInDay={thePartitionInDay}
-          isAdding={props.isAdding}
-          showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
-        />
-        <ViewAsCalendarRightColumn
-          rightNow={props.rightNow}
-          showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
-        />
-      </ViewAsCalendarInDayContainer>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <ViewAsCalendarInDayContainer>
+          <ViewAsCalendarLeftColumn
+            rightNow={props.rightNow}
+            showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
+          />
+          <ViewAsCalendarTimeEventInDayColumn
+            daysToTheLeft={0}
+            rightNow={props.rightNow}
+            today={props.today}
+            timezone={props.timezone}
+            date={props.periodStartDate}
+            timeEventsInDay={thePartitionInDay}
+            isAdding={props.isAdding}
+            showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
+          />
+          <ViewAsCalendarRightColumn
+            rightNow={props.rightNow}
+            showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
+          />
+        </ViewAsCalendarInDayContainer>
+      </DragDropContext>
     </Box>
   );
 }

--- a/src/core/jupiter/core/calendar/component/view-as-calendar-weekly.tsx
+++ b/src/core/jupiter/core/calendar/component/view-as-calendar-weekly.tsx
@@ -1,6 +1,9 @@
+import { DragDropContext } from "@hello-pangea/dnd";
+import type { DropResult } from "@hello-pangea/dnd";
 import { DateTime } from "luxon";
 import { useState } from "react";
 import { Box, Typography } from "@mui/material";
+import { useFetcher } from "@remix-run/react";
 
 import { allDaysBetween } from "#/core/common/adate";
 import {
@@ -30,6 +33,8 @@ export function ViewAsCalendarWeekly(props: ViewAsProps) {
 
   const [showAllTimeEventFullDays, setShowAllTimeEventFullDays] =
     useState(false);
+
+  const calendarMoveFetcher = useFetcher();
 
   if (props.entries === undefined) {
     throw new Error("Entries are required");
@@ -102,6 +107,32 @@ export function ViewAsCalendarWeekly(props: ViewAsProps) {
 
   const allDays = allDaysBetween(props.periodStartDate, props.periodEndDate);
 
+  function onDragEnd(result: DropResult) {
+    if (!result.destination) return;
+    if (result.source.droppableId === result.destination.droppableId) return;
+
+    const parts = result.draggableId.split("|");
+    const eventRefId = parts[0];
+    const startTimeInDay = parts[1];
+    const durationMins = parts[2];
+    const newDate = result.destination.droppableId;
+
+    calendarMoveFetcher.submit(
+      {
+        id: eventRefId,
+        startDate: newDate,
+        startTimeInDay: startTimeInDay,
+        durationMins: durationMins,
+        userTimezone: props.timezone,
+      },
+      {
+        method: "post",
+        action:
+          "/app/workspace/calendar/time-event/in-day-block/update-time",
+      },
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -160,31 +191,33 @@ export function ViewAsCalendarWeekly(props: ViewAsProps) {
         </Box>
       </ViewAsCalendarDaysAndFullDaysContiner>
 
-      <ViewAsCalendarInDayContainer>
-        <ViewAsCalendarLeftColumn
-          rightNow={props.rightNow}
-          showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
-        />
-
-        {allDays.map((date, idx) => (
-          <ViewAsCalendarTimeEventInDayColumn
-            daysToTheLeft={allDays.length - idx - 1}
-            key={idx}
+      <DragDropContext onDragEnd={onDragEnd}>
+        <ViewAsCalendarInDayContainer>
+          <ViewAsCalendarLeftColumn
             rightNow={props.rightNow}
-            today={props.today}
-            timezone={props.timezone}
-            date={date}
-            timeEventsInDay={partitionedCombinedTimeEventInDay[date] || []}
-            isAdding={props.isAdding}
             showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
           />
-        ))}
 
-        <ViewAsCalendarRightColumn
-          rightNow={props.rightNow}
-          showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
-        />
-      </ViewAsCalendarInDayContainer>
+          {allDays.map((date, idx) => (
+            <ViewAsCalendarTimeEventInDayColumn
+              daysToTheLeft={allDays.length - idx - 1}
+              key={idx}
+              rightNow={props.rightNow}
+              today={props.today}
+              timezone={props.timezone}
+              date={date}
+              timeEventsInDay={partitionedCombinedTimeEventInDay[date] || []}
+              isAdding={props.isAdding}
+              showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
+            />
+          ))}
+
+          <ViewAsCalendarRightColumn
+            rightNow={props.rightNow}
+            showOnlyFromRightNowIfDaily={props.showOnlyFromRightNowIfDaily}
+          />
+        </ViewAsCalendarInDayContainer>
+      </DragDropContext>
     </Box>
   );
 }

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -22,6 +22,7 @@
     "http-status-codes": "^2.3.0"
   },
   "peerDependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "react-use-websocket": "^4.13.0",
     "@emotion/react": "^11.14.0",
     "emoji-picker-react": "^4.12.2",

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/update-time.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/update-time.tsx
@@ -1,0 +1,54 @@
+import { ApiError } from "@jupiter/webapi-client";
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { StatusCodes } from "http-status-codes";
+import { z } from "zod";
+import { parseForm } from "zodix";
+import {
+  noErrorNoData,
+  validationErrorToUIErrorInfo,
+} from "@jupiter/core/infra/action-result";
+import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+const UpdateTimeFormSchema = z.object({
+  id: z.string(),
+  startDate: z.string(),
+  startTimeInDay: z.string(),
+  durationMins: z.string().transform((v) => parseInt(v, 10)),
+  userTimezone: z.string(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const form = await parseForm(request, UpdateTimeFormSchema);
+
+  try {
+    const { startDate, startTimeInDay } = timeEventInDayBlockParamsToUtc(
+      {
+        startDate: form.startDate,
+        startTimeInDay: form.startTimeInDay,
+      },
+      form.userTimezone,
+    );
+
+    await apiClient.timeEvents.timeEventInDayBlockUpdate({
+      ref_id: form.id,
+      start_date: { should_change: true, value: startDate },
+      start_time_in_day: { should_change: true, value: startTimeInDay ?? "" },
+      duration_mins: { should_change: true, value: form.durationMins },
+    });
+
+    return json(noErrorNoData());
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.status === StatusCodes.UNPROCESSABLE_ENTITY
+    ) {
+      return json(validationErrorToUIErrorInfo(error.body));
+    }
+
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
Implement drag-and-drop functionality for time events in the calendar views, allowing users to move events between different days while maintaining their duration and time properties.

## Key Changes
- **Integrated `@hello-pangea/dnd` library** for drag-and-drop support in calendar components
- **Refactored `ViewAsCalendarTimeEventInDayColumn`** to wrap time events in `Draggable` and `Droppable` components from the dnd library
- **Restructured `ViewAsCalendarTimeEventInDayCell`** to use relative positioning instead of absolute positioning, moving layout responsibility to the parent `Draggable` wrapper
- **Added drag-and-drop context** to both daily and weekly calendar views with `DragDropContext` wrapper
- **Implemented `onDragEnd` handler** in both calendar views to submit time event updates via fetcher to the new `/app/workspace/calendar/time-event/in-day-block/update-time` endpoint
- **Created new server action** (`update-time.tsx`) to handle time event updates when dragged to a new date, converting day-block parameters to UTC and calling the API
- **Added editability check** using `isTimeEventInDayBlockEditable()` to disable dragging for non-editable event types
- **Enhanced visual feedback** with background color change on drag-over and cursor changes based on editability

## Implementation Details
- Draggable IDs encode event reference ID, start time, and duration to preserve event properties during drag operations
- Events are only draggable if they pass the editability check; non-editable events show default cursor
- The drag-and-drop context wraps the entire in-day container to support cross-day dragging
- Positioning calculations (top, height, margins) moved from cell component to parent draggable wrapper for proper drag behavior
- Visual feedback includes background color change when dragging over a droppable area and z-index management for dragging state

https://claude.ai/code/session_015TbQVFtSpCjorzeuUzg6XL