### PR TITLE
Add Kanban and Kanban by Eisen views to big plan inbox tasks section

### DIFF
--- a/src/core/jupiter/core/common/sub/inbox_tasks/use_case/archive.py
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/use_case/archive.py
@@ -9,14 +9,10 @@ from jupiter.core.config import (
     JupiterLoggedInMutationContext,
     JupiterTransactionalLoggedInMutationUseCase,
 )
-from jupiter.core.features import WorkspaceFeature
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.errors import InputValidationError
 from jupiter.framework.progress_reporter.reporter import ProgressReporter
 from jupiter.framework.storage.repository import DomainUnitOfWork
-from jupiter.framework.use_case import (
-    mutation_use_case,
-)
 from jupiter.framework.use_case_io import UseCaseArgsBase, use_case_args
 
 

--- a/src/core/jupiter/core/common/sub/inbox_tasks/use_case/find.py
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/use_case/find.py
@@ -18,9 +18,6 @@ from jupiter.core.config import (
     JupiterLoggedInReadonlyContext,
     JupiterTransactionalLoggedInReadOnlyUseCase,
 )
-from jupiter.core.features import (
-    WorkspaceFeature,
-)
 from jupiter.core.habits.collection import HabitCollection
 from jupiter.core.habits.root import Habit
 from jupiter.core.journals.collection import JournalCollection
@@ -53,7 +50,6 @@ from jupiter.framework.errors import InputValidationError
 from jupiter.framework.storage.repository import DomainUnitOfWork
 from jupiter.framework.use_case import (
     UnavailableForContextError,
-    readonly_use_case,
 )
 from jupiter.framework.use_case_io import (
     UseCaseArgsBase,

--- a/src/core/jupiter/core/common/sub/inbox_tasks/use_case/load.py
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/use_case/load.py
@@ -8,7 +8,6 @@ from jupiter.core.config import (
     JupiterLoggedInReadonlyContext,
     JupiterTransactionalLoggedInReadOnlyUseCase,
 )
-from jupiter.core.features import WorkspaceFeature
 from jupiter.core.habits.root import Habit
 from jupiter.core.journals.root import Journal
 from jupiter.core.metrics.root import Metric
@@ -21,9 +20,6 @@ from jupiter.core.todo.root import TodoTask
 from jupiter.core.working_mem.collection import WorkingMemCollection
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.storage.repository import DomainUnitOfWork
-from jupiter.framework.use_case import (
-    readonly_use_case,
-)
 from jupiter.framework.use_case_io import (
     UseCaseArgsBase,
     UseCaseResultBase,

--- a/src/core/jupiter/core/common/sub/inbox_tasks/use_case/remove.py
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/use_case/remove.py
@@ -8,14 +8,10 @@ from jupiter.core.config import (
     JupiterLoggedInMutationContext,
     JupiterTransactionalLoggedInMutationUseCase,
 )
-from jupiter.core.features import WorkspaceFeature
 from jupiter.framework.base.entity_id import EntityId
 from jupiter.framework.errors import InputValidationError
 from jupiter.framework.progress_reporter.reporter import ProgressReporter
 from jupiter.framework.storage.repository import DomainUnitOfWork
-from jupiter.framework.use_case import (
-    mutation_use_case,
-)
 from jupiter.framework.use_case_io import UseCaseArgsBase, use_case_args
 
 

--- a/src/core/jupiter/core/common/sub/inbox_tasks/use_case/update.py
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/use_case/update.py
@@ -50,7 +50,6 @@ from jupiter.framework.storage.repository import DomainUnitOfWork
 from jupiter.framework.update_action import UpdateAction
 from jupiter.framework.use_case import (
     UnavailableForContextError,
-    mutation_use_case,
 )
 from jupiter.framework.use_case_io import (
     UseCaseArgsBase,

--- a/src/core/jupiter/core/common/sub/notes/namespace.ts
+++ b/src/core/jupiter/core/common/sub/notes/namespace.ts
@@ -52,9 +52,5 @@ export function noteNamespaceName(namespace: NoteNamespace): string {
       return "Occasion";
     case NoteNamespace.TIME_PLAN_ACTIVITY:
       return "Time Plan Activity";
-    default: {
-      const _exhaustiveCheck: never = namespace;
-      throw new Error(`Unhandled NoteNamespace: ${_exhaustiveCheck}`);
-    }
   }
 }

--- a/src/webui/app/rendering/standard-should-revalidate.ts
+++ b/src/webui/app/rendering/standard-should-revalidate.ts
@@ -7,6 +7,12 @@ export const basicShouldRevalidate: ShouldRevalidateFunction = ({
   formMethod,
   nextUrl,
 }) => {
+  if (
+    formAction === "/app/workspace/core/inbox-tasks/update-status-and-eisen"
+  ) {
+    return false;
+  }
+
   if (formAction === "/app/workspace/core/notes/update") {
     return false;
   }

--- a/src/webui/app/routes/app/workspace/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id.tsx
@@ -89,6 +89,7 @@ import { NestingAwareBlock } from "@jupiter/core/infra/component/layout/nesting-
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
 import { getLoggedInApiClient } from "~/api-clients.server";
+import { LeafPanelExpansionState } from "#/core/infra/leaf-panel-expansion";
 
 enum InboxTasksView {
   KANBAN_BY_EISEN = "kanban-by-eisen",
@@ -470,7 +471,7 @@ export default function BigPlan() {
     sortInboxTaskTimeEventsNaturally(timeEventEntries);
 
   const [selectedInboxTasksView, setSelectedInboxTasksView] = useState(
-    isBigScreen ? InboxTasksView.KANBAN : InboxTasksView.LIST,
+    isBigScreen ? InboxTasksView.KANBAN_BY_EISEN : InboxTasksView.KANBAN,
   );
   const [optimisticUpdates, setOptimisticUpdates] = useState<{
     [key: string]: InboxTaskOptimisticState;
@@ -588,6 +589,7 @@ export default function BigPlan() {
       entityArchived={loaderData.bigPlan.archived}
       returnLocation={"/app/workspace/big-plans"}
       shouldShowALeaflet={shouldShowALeaflet}
+      initialExpansionState={LeafPanelExpansionState.MEDIUM}
     >
       <NestingAwareBlock shouldHide={shouldShowALeaflet}>
         <GlobalError actionResult={actionData} />
@@ -667,6 +669,10 @@ export default function BigPlan() {
               topLevelInfo={topLevelInfo}
               inputsEnabled={inputsEnabled}
               actions={[
+                NavSingle({
+                  text: "New",
+                  link: `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/new`,
+                }),
                 FilterFewOptionsCompact(
                   "View",
                   selectedInboxTasksView,
@@ -689,10 +695,6 @@ export default function BigPlan() {
                   ],
                   (selected) => setSelectedInboxTasksView(selected),
                 ),
-                NavSingle({
-                  text: "New",
-                  link: `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/new`,
-                }),
               ]}
             />
           }

--- a/src/webui/app/routes/app/workspace/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id.tsx
@@ -46,9 +46,7 @@ import {
   SmallScreenKanbanByEisen,
 } from "@jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban";
 import { StandardDivider } from "@jupiter/core/infra/component/standard-divider";
-import {
-  ActionableTime,
-} from "@jupiter/core/infra/actionable-time";
+import { ActionableTime } from "@jupiter/core/infra/actionable-time";
 import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
 import {
   isInboxTaskCoreFieldEditable,
@@ -85,11 +83,11 @@ import {
 } from "@jupiter/core/infra/component/section-actions";
 import { BigPlanMilestoneStack } from "@jupiter/core/big_plans/sub/milestones/component/stack";
 import { NestingAwareBlock } from "@jupiter/core/infra/component/layout/nesting-aware-block";
+import { LeafPanelExpansionState } from "#/core/infra/leaf-panel-expansion";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
 import { getLoggedInApiClient } from "~/api-clients.server";
-import { LeafPanelExpansionState } from "#/core/infra/leaf-panel-expansion";
 
 enum InboxTasksView {
   KANBAN_BY_EISEN = "kanban-by-eisen",
@@ -702,7 +700,10 @@ export default function BigPlan() {
           {selectedInboxTasksView === InboxTasksView.KANBAN_BY_EISEN && (
             <>
               {isBigScreen && (
-                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                <DragDropContext
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                >
                   <>
                     {EISENS.map((e) => (
                       <Fragment key={e}>
@@ -749,7 +750,10 @@ export default function BigPlan() {
           {selectedInboxTasksView === InboxTasksView.KANBAN && (
             <>
               {isBigScreen && (
-                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                <DragDropContext
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                >
                   <InboxTaskKanbanBoard
                     topLevelInfo={topLevelInfo}
                     inboxTasks={sortedInboxTasks}

--- a/src/webui/app/routes/app/workspace/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id.tsx
@@ -21,6 +21,8 @@ import {
   WorkspaceFeature,
   SyncTarget,
 } from "@jupiter/webapi-client";
+import type { DragStart, DropResult } from "@hello-pangea/dnd";
+import { DragDropContext } from "@hello-pangea/dnd";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
@@ -31,10 +33,28 @@ import {
   useNavigation,
 } from "@remix-run/react";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
-import { useContext } from "react";
+import { Fragment, useContext, useState } from "react";
 import { z } from "zod";
 import { CheckboxAsString, parseForm, parseParams } from "zodix";
 import { AnimatePresence } from "framer-motion";
+import ViewKanbanIcon from "@mui/icons-material/ViewKanban";
+import ViewListIcon from "@mui/icons-material/ViewList";
+import { eisenIcon, eisenName } from "@jupiter/core/common/eisen";
+import { InboxTaskKanbanBoard } from "@jupiter/core/common/sub/inbox_tasks/components/kanban-board";
+import {
+  SmallScreenKanban,
+  SmallScreenKanbanByEisen,
+} from "@jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban";
+import { StandardDivider } from "@jupiter/core/infra/component/standard-divider";
+import {
+  ActionableTime,
+} from "@jupiter/core/infra/actionable-time";
+import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
+import {
+  isInboxTaskCoreFieldEditable,
+  type InboxTaskOptimisticState,
+} from "@jupiter/core/common/sub/inbox_tasks/root";
+import type { SomeErrorNoData } from "@jupiter/core/infra/action-result";
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import {
   sortInboxTaskTimeEventsNaturally,
@@ -61,6 +81,7 @@ import {
   SectionActions,
   ActionSingle,
   NavSingle,
+  FilterFewOptionsCompact,
 } from "@jupiter/core/infra/component/section-actions";
 import { BigPlanMilestoneStack } from "@jupiter/core/big_plans/sub/milestones/component/stack";
 import { NestingAwareBlock } from "@jupiter/core/infra/component/layout/nesting-aware-block";
@@ -68,6 +89,19 @@ import { NestingAwareBlock } from "@jupiter/core/infra/component/layout/nesting-
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
 import { getLoggedInApiClient } from "~/api-clients.server";
+
+enum InboxTasksView {
+  KANBAN_BY_EISEN = "kanban-by-eisen",
+  KANBAN = "kanban",
+  LIST = "list",
+}
+
+const EISENS = [
+  Eisen.IMPORTANT_AND_URGENT,
+  Eisen.URGENT,
+  Eisen.IMPORTANT,
+  Eisen.REGULAR,
+];
 
 const ParamsSchema = z.object({
   id: z.string(),
@@ -379,6 +413,7 @@ export default function BigPlan() {
   const shouldShowALeaflet = useLeafNeedsToShowLeaflet();
 
   const topLevelInfo = useContext(TopLevelInfoContext);
+  const isBigScreen = useBigScreen();
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.bigPlan.archived;
@@ -416,6 +451,11 @@ export default function BigPlan() {
     dueDateAscending: false,
   });
 
+  const inboxTasksByRefId: { [key: string]: InboxTask } = {};
+  for (const it of loaderData.inboxTasks) {
+    inboxTasksByRefId[it.ref_id] = it;
+  }
+
   const timeEventEntries = loaderData.timeEventBlocks.map((block) => ({
     time_event_in_tz: timeEventInDayBlockToTimezone(
       block,
@@ -429,9 +469,84 @@ export default function BigPlan() {
   const sortedTimeEventEntries =
     sortInboxTaskTimeEventsNaturally(timeEventEntries);
 
+  const [selectedInboxTasksView, setSelectedInboxTasksView] = useState(
+    isBigScreen ? InboxTasksView.KANBAN : InboxTasksView.LIST,
+  );
+  const [optimisticUpdates, setOptimisticUpdates] = useState<{
+    [key: string]: InboxTaskOptimisticState;
+  }>({});
+  const [draggedInboxTaskId, setDraggedInboxTaskId] = useState<
+    string | undefined
+  >(undefined);
+
   const cardActionFetcher = useFetcher();
+  const kanbanMoveFetcher = useFetcher<SomeErrorNoData>();
+
+  function onDragStart(start: DragStart) {
+    setDraggedInboxTaskId(start.draggableId);
+  }
+
+  function onDragEnd(result: DropResult) {
+    setDraggedInboxTaskId(undefined);
+
+    if (!result.destination) {
+      return null;
+    }
+
+    const destination = result.destination.droppableId.split(":");
+
+    const eisenSchema = z
+      .nativeEnum(Eisen)
+      .or(z.literal("undefined").transform((_) => undefined));
+    const statusSchema = z.nativeEnum(InboxTaskStatus);
+
+    const eisen = eisenSchema.parse(destination[1]);
+    const status = statusSchema.parse(destination[2]);
+
+    const inboxTask = inboxTasksByRefId[result.draggableId];
+
+    if (!isInboxTaskCoreFieldEditable(inboxTask.source)) {
+      if (eisen && inboxTask.eisen !== eisen) {
+        return null;
+      }
+    }
+
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [result.draggableId]: { status, eisen },
+    }));
+
+    if (isInboxTaskCoreFieldEditable(inboxTask.source)) {
+      kanbanMoveFetcher.submit(
+        {
+          id: result.draggableId,
+          eisen: eisen?.toString() || "no-go",
+          status,
+        },
+        {
+          method: "post",
+          action: "/app/workspace/core/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    } else {
+      kanbanMoveFetcher.submit(
+        { id: result.draggableId, eisen: "no-go", status },
+        {
+          method: "post",
+          action: "/app/workspace/core/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    }
+  }
 
   function handleCardMarkDone(it: InboxTask) {
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [it.ref_id]: {
+        status: InboxTaskStatus.DONE,
+        eisen: prev[it.ref_id]?.eisen ?? it.eisen,
+      },
+    }));
     cardActionFetcher.submit(
       {
         id: it.ref_id,
@@ -445,6 +560,13 @@ export default function BigPlan() {
   }
 
   function handleCardMarkNotDone(it: InboxTask) {
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [it.ref_id]: {
+        status: InboxTaskStatus.NOT_DONE,
+        eisen: prev[it.ref_id]?.eisen ?? it.eisen,
+      },
+    }));
     cardActionFetcher.submit(
       {
         id: it.ref_id,
@@ -545,6 +667,28 @@ export default function BigPlan() {
               topLevelInfo={topLevelInfo}
               inputsEnabled={inputsEnabled}
               actions={[
+                FilterFewOptionsCompact(
+                  "View",
+                  selectedInboxTasksView,
+                  [
+                    {
+                      value: InboxTasksView.KANBAN_BY_EISEN,
+                      text: "Kanban by Eisen",
+                      icon: <ViewKanbanIcon />,
+                    },
+                    {
+                      value: InboxTasksView.KANBAN,
+                      text: "Kanban",
+                      icon: <ViewKanbanIcon />,
+                    },
+                    {
+                      value: InboxTasksView.LIST,
+                      text: "List",
+                      icon: <ViewListIcon />,
+                    },
+                  ],
+                  (selected) => setSelectedInboxTasksView(selected),
+                ),
                 NavSingle({
                   text: "New",
                   link: `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/new`,
@@ -553,7 +697,90 @@ export default function BigPlan() {
             />
           }
         >
-          {sortedInboxTasks.length > 0 && (
+          {selectedInboxTasksView === InboxTasksView.KANBAN_BY_EISEN && (
+            <>
+              {isBigScreen && (
+                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                  <>
+                    {EISENS.map((e) => (
+                      <Fragment key={e}>
+                        <StandardDivider
+                          title={`${eisenIcon(e)} ${eisenName(e)}`}
+                          size="large"
+                        />
+                        <InboxTaskKanbanBoard
+                          topLevelInfo={topLevelInfo}
+                          inboxTasks={sortedInboxTasks}
+                          optimisticUpdates={optimisticUpdates}
+                          inboxTasksByRefId={inboxTasksByRefId}
+                          moreInfoByRefId={{}}
+                          actionableTime={ActionableTime.NOW}
+                          allowEisen={e}
+                          draggedInboxTaskId={draggedInboxTaskId}
+                          cardLinkResolver={(it) =>
+                            `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
+                          }
+                        />
+                      </Fragment>
+                    ))}
+                  </>
+                </DragDropContext>
+              )}
+              {!isBigScreen && (
+                <SmallScreenKanbanByEisen
+                  topLevelInfo={topLevelInfo}
+                  inboxTasks={sortedInboxTasks}
+                  optimisticUpdates={optimisticUpdates}
+                  moreInfoByRefId={{}}
+                  actionableTime={ActionableTime.NOW}
+                  onCardMarkDone={handleCardMarkDone}
+                  onCardMarkNotDone={handleCardMarkNotDone}
+                  emptyParent="inbox task"
+                  cardLinkResolver={(it) =>
+                    `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
+                  }
+                />
+              )}
+            </>
+          )}
+
+          {selectedInboxTasksView === InboxTasksView.KANBAN && (
+            <>
+              {isBigScreen && (
+                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                  <InboxTaskKanbanBoard
+                    topLevelInfo={topLevelInfo}
+                    inboxTasks={sortedInboxTasks}
+                    optimisticUpdates={optimisticUpdates}
+                    inboxTasksByRefId={inboxTasksByRefId}
+                    moreInfoByRefId={{}}
+                    actionableTime={ActionableTime.NOW}
+                    draggedInboxTaskId={draggedInboxTaskId}
+                    cardLinkResolver={(it) =>
+                      `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
+                    }
+                  />
+                </DragDropContext>
+              )}
+              {!isBigScreen && (
+                <SmallScreenKanban
+                  topLevelInfo={topLevelInfo}
+                  inboxTasks={sortedInboxTasks}
+                  optimisticUpdates={optimisticUpdates}
+                  moreInfoByRefId={{}}
+                  actionableTime={ActionableTime.NOW}
+                  onCardMarkDone={handleCardMarkDone}
+                  onCardMarkNotDone={handleCardMarkNotDone}
+                  emptyParent="inbox task"
+                  cardLinkResolver={(it) =>
+                    `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
+                  }
+                />
+              )}
+            </>
+          )}
+
+          {selectedInboxTasksView === InboxTasksView.LIST && (
             <InboxTaskStack
               topLevelInfo={topLevelInfo}
               showOptions={{
@@ -566,6 +793,7 @@ export default function BigPlan() {
                 showHandleMarkNotDone: true,
               }}
               inboxTasks={sortedInboxTasks}
+              optimisticUpdates={optimisticUpdates}
               cardLinkResolver={(it) =>
                 `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
               }

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -390,6 +390,12 @@ export default function TimePlanView() {
     inboxTasksByRefId[it.ref_id] = it;
   }
 
+  const activityByInboxTaskRefId = new Map<string, TimePlanActivity>(
+    loaderData.activities
+      .filter((a) => a.target === TimePlanActivityTarget.INBOX_TASK)
+      .map((a) => [a.target_ref_id, a]),
+  );
+
   const [optimisticUpdates, setOptimisticUpdates] = useState<{
     [key: string]: InboxTaskOptimisticState;
   }>({});
@@ -915,7 +921,7 @@ export default function TimePlanView() {
                           allowEisen={e}
                           draggedInboxTaskId={draggedInboxTaskId}
                           cardLinkResolver={(it) =>
-                            `/app/workspace/inbox-tasks/${it.ref_id}`
+                            `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
                           }
                         />
                       </Fragment>

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -31,7 +31,12 @@ import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { Outlet, useActionData, useFetcher, useNavigation } from "@remix-run/react";
+import {
+  Outlet,
+  useActionData,
+  useFetcher,
+  useNavigation,
+} from "@remix-run/react";
 import { AnimatePresence } from "framer-motion";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { Fragment, useContext, useEffect, useState } from "react";
@@ -903,7 +908,10 @@ export default function TimePlanView() {
           {selectedView === ViewMode.KANBAN_BY_EISEN && (
             <>
               {isBigScreen && (
-                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                <DragDropContext
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                >
                   <>
                     {EISENS.map((e) => (
                       <Fragment key={e}>
@@ -938,7 +946,7 @@ export default function TimePlanView() {
                   actionableTime={ActionableTime.NOW}
                   emptyParent="inbox task"
                   cardLinkResolver={(it) =>
-                    `/app/workspace/inbox-tasks/${it.ref_id}`
+                    `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
                   }
                 />
               )}
@@ -948,7 +956,10 @@ export default function TimePlanView() {
           {selectedView === ViewMode.KANBAN && (
             <>
               {isBigScreen && (
-                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                <DragDropContext
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                >
                   <InboxTaskKanbanBoard
                     topLevelInfo={topLevelInfo}
                     inboxTasks={loaderData.targetInboxTasks}
@@ -958,7 +969,7 @@ export default function TimePlanView() {
                     actionableTime={ActionableTime.NOW}
                     draggedInboxTaskId={draggedInboxTaskId}
                     cardLinkResolver={(it) =>
-                      `/app/workspace/inbox-tasks/${it.ref_id}`
+                      `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
                     }
                   />
                 </DragDropContext>
@@ -972,7 +983,7 @@ export default function TimePlanView() {
                   actionableTime={ActionableTime.NOW}
                   emptyParent="inbox task"
                   cardLinkResolver={(it) =>
-                    `/app/workspace/inbox-tasks/${it.ref_id}`
+                    `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
                   }
                 />
               )}

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -10,6 +10,8 @@ import type {
 } from "@jupiter/webapi-client";
 import {
   ApiError,
+  Eisen,
+  InboxTaskStatus,
   RecurringTaskPeriod,
   TagNamespace,
   TimePlanActivityFeasability,
@@ -18,18 +20,21 @@ import {
   WorkspaceFeature,
   DocsHelpSubject,
 } from "@jupiter/webapi-client";
+import type { DragStart, DropResult } from "@hello-pangea/dnd";
+import { DragDropContext } from "@hello-pangea/dnd";
 import FlareIcon from "@mui/icons-material/Flare";
 import FlagIcon from "@mui/icons-material/Flag";
+import ViewKanbanIcon from "@mui/icons-material/ViewKanban";
 import ViewListIcon from "@mui/icons-material/ViewList";
 import ViewTimelineIcon from "@mui/icons-material/ViewTimeline";
 import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { Outlet, useActionData, useNavigation } from "@remix-run/react";
+import { Outlet, useActionData, useFetcher, useNavigation } from "@remix-run/react";
 import { AnimatePresence } from "framer-motion";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
-import { useContext, useEffect, useState } from "react";
+import { Fragment, useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
 import { sortJournalsNaturally } from "@jupiter/core/journals/root";
@@ -40,6 +45,19 @@ import {
   sortTimePlansNaturally,
   timePlanAllowsInboxTasks,
 } from "@jupiter/core/time_plans/root";
+import { eisenIcon, eisenName } from "@jupiter/core/common/eisen";
+import { InboxTaskKanbanBoard } from "@jupiter/core/common/sub/inbox_tasks/components/kanban-board";
+import {
+  SmallScreenKanban,
+  SmallScreenKanbanByEisen,
+} from "@jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban";
+import { StandardDivider } from "@jupiter/core/infra/component/standard-divider";
+import { ActionableTime } from "@jupiter/core/infra/actionable-time";
+import {
+  isInboxTaskCoreFieldEditable,
+  type InboxTaskOptimisticState,
+} from "@jupiter/core/common/sub/inbox_tasks/root";
+import type { SomeErrorNoData } from "@jupiter/core/infra/action-result";
 import { sortAspectsByTreeOrder } from "#/core/life_plan/sub/aspects/root";
 import { sortGoalsNaturally } from "#/core/life_plan/sub/goals/root";
 import { BigPlanStack } from "@jupiter/core/big_plans/component/stack";
@@ -97,9 +115,18 @@ enum Grouping {
 }
 
 enum ViewMode {
+  KANBAN_BY_EISEN = "kanban-by-eisen",
+  KANBAN = "kanban",
   LIST = "list",
   TIMELINE = "timeline",
 }
+
+const EISENS = [
+  Eisen.IMPORTANT_AND_URGENT,
+  Eisen.URGENT,
+  Eisen.IMPORTANT,
+  Eisen.REGULAR,
+];
 
 enum GroupVisibility {
   NON_EMPTY_ONLY = "non-empty-only",
@@ -357,6 +384,77 @@ export default function TimePlanView() {
   const targetInboxTasksByRefId = new Map<string, InboxTask>(
     loaderData.targetInboxTasks.map((it) => [it.ref_id, it]),
   );
+
+  const inboxTasksByRefId: { [key: string]: InboxTask } = {};
+  for (const it of loaderData.targetInboxTasks) {
+    inboxTasksByRefId[it.ref_id] = it;
+  }
+
+  const [optimisticUpdates, setOptimisticUpdates] = useState<{
+    [key: string]: InboxTaskOptimisticState;
+  }>({});
+  const [draggedInboxTaskId, setDraggedInboxTaskId] = useState<
+    string | undefined
+  >(undefined);
+
+  const kanbanMoveFetcher = useFetcher<SomeErrorNoData>();
+
+  function onDragStart(start: DragStart) {
+    setDraggedInboxTaskId(start.draggableId);
+  }
+
+  function onDragEnd(result: DropResult) {
+    setDraggedInboxTaskId(undefined);
+
+    if (!result.destination) {
+      return null;
+    }
+
+    const destination = result.destination.droppableId.split(":");
+
+    const eisenSchema = z
+      .nativeEnum(Eisen)
+      .or(z.literal("undefined").transform((_) => undefined));
+    const statusSchema = z.nativeEnum(InboxTaskStatus);
+
+    const eisen = eisenSchema.parse(destination[1]);
+    const status = statusSchema.parse(destination[2]);
+
+    const inboxTask = inboxTasksByRefId[result.draggableId];
+
+    if (!isInboxTaskCoreFieldEditable(inboxTask.source)) {
+      if (eisen && inboxTask.eisen !== eisen) {
+        return null;
+      }
+    }
+
+    setOptimisticUpdates((prev) => ({
+      ...prev,
+      [result.draggableId]: { status, eisen },
+    }));
+
+    if (isInboxTaskCoreFieldEditable(inboxTask.source)) {
+      kanbanMoveFetcher.submit(
+        {
+          id: result.draggableId,
+          eisen: eisen?.toString() || "no-go",
+          status,
+        },
+        {
+          method: "post",
+          action: "/app/workspace/core/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    } else {
+      kanbanMoveFetcher.submit(
+        { id: result.draggableId, eisen: "no-go", status },
+        {
+          method: "post",
+          action: "/app/workspace/core/inbox-tasks/update-status-and-eisen",
+        },
+      );
+    }
+  }
   const actitiviesByBigPlanRefId = new Map<string, TimePlanActivity>(
     loaderData.activities
       .filter((a) => a.target === TimePlanActivityTarget.BIG_PLAN)
@@ -676,6 +774,16 @@ export default function TimePlanView() {
                   selectedView,
                   [
                     {
+                      value: ViewMode.KANBAN_BY_EISEN,
+                      text: "Kanban by Eisen",
+                      icon: <ViewKanbanIcon />,
+                    },
+                    {
+                      value: ViewMode.KANBAN,
+                      text: "Kanban",
+                      icon: <ViewKanbanIcon />,
+                    },
+                    {
                       value: ViewMode.LIST,
                       text: "List",
                       icon: <ViewListIcon />,
@@ -784,6 +892,85 @@ export default function TimePlanView() {
               }
               helpSubject={DocsHelpSubject.TIME_PLANS}
             />
+          )}
+
+          {selectedView === ViewMode.KANBAN_BY_EISEN && (
+            <>
+              {isBigScreen && (
+                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                  <>
+                    {EISENS.map((e) => (
+                      <Fragment key={e}>
+                        <StandardDivider
+                          title={`${eisenIcon(e)} ${eisenName(e)}`}
+                          size="large"
+                        />
+                        <InboxTaskKanbanBoard
+                          topLevelInfo={topLevelInfo}
+                          inboxTasks={loaderData.targetInboxTasks}
+                          optimisticUpdates={optimisticUpdates}
+                          inboxTasksByRefId={inboxTasksByRefId}
+                          moreInfoByRefId={{}}
+                          actionableTime={ActionableTime.NOW}
+                          allowEisen={e}
+                          draggedInboxTaskId={draggedInboxTaskId}
+                          cardLinkResolver={(it) =>
+                            `/app/workspace/inbox-tasks/${it.ref_id}`
+                          }
+                        />
+                      </Fragment>
+                    ))}
+                  </>
+                </DragDropContext>
+              )}
+              {!isBigScreen && (
+                <SmallScreenKanbanByEisen
+                  topLevelInfo={topLevelInfo}
+                  inboxTasks={loaderData.targetInboxTasks}
+                  optimisticUpdates={optimisticUpdates}
+                  moreInfoByRefId={{}}
+                  actionableTime={ActionableTime.NOW}
+                  emptyParent="inbox task"
+                  cardLinkResolver={(it) =>
+                    `/app/workspace/inbox-tasks/${it.ref_id}`
+                  }
+                />
+              )}
+            </>
+          )}
+
+          {selectedView === ViewMode.KANBAN && (
+            <>
+              {isBigScreen && (
+                <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+                  <InboxTaskKanbanBoard
+                    topLevelInfo={topLevelInfo}
+                    inboxTasks={loaderData.targetInboxTasks}
+                    optimisticUpdates={optimisticUpdates}
+                    inboxTasksByRefId={inboxTasksByRefId}
+                    moreInfoByRefId={{}}
+                    actionableTime={ActionableTime.NOW}
+                    draggedInboxTaskId={draggedInboxTaskId}
+                    cardLinkResolver={(it) =>
+                      `/app/workspace/inbox-tasks/${it.ref_id}`
+                    }
+                  />
+                </DragDropContext>
+              )}
+              {!isBigScreen && (
+                <SmallScreenKanban
+                  topLevelInfo={topLevelInfo}
+                  inboxTasks={loaderData.targetInboxTasks}
+                  optimisticUpdates={optimisticUpdates}
+                  moreInfoByRefId={{}}
+                  actionableTime={ActionableTime.NOW}
+                  emptyParent="inbox task"
+                  cardLinkResolver={(it) =>
+                    `/app/workspace/inbox-tasks/${it.ref_id}`
+                  }
+                />
+              )}
+            </>
           )}
 
           {selectedView === ViewMode.LIST &&


### PR DESCRIPTION
Adds a view selector to the Inbox Tasks section in the big plan detail
view with three options: Kanban by Eisen, Kanban, and List. Big screen
uses the full drag-and-drop KanbanBoard; small/mobile screens use
SmallScreenKanban/SmallScreenKanbanByEisen. Defaults to Kanban on big
screens and List on small screens.

https://claude.ai/code/session_01DwFsjKhMV4CAC5vh6LnYzv