### PR TITLE
Remove duplicate time plan activity note from big plan activity view

### DIFF
--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -195,9 +195,6 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
   z.object({
     intent: z.literal("target-big-plan-create-note"),
   }),
-  z.object({
-    intent: z.literal("activity-create-note"),
-  }),
 ]);
 
 export const handle = {
@@ -253,7 +250,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       targetInboxTaskInfo: inboxTaskResult,
       targetBigPlan: result.target_big_plan,
       targetBigPlanInfo: bigPlanResult,
-      activityNote: result.note,
       activityTimeEventBlocks: result.time_event_blocks,
     });
   } catch (error) {
@@ -565,16 +561,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
         return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
       }
 
-      case "activity-create-note": {
-        await apiClient.notes.noteCreate({
-          namespace: NoteNamespace.TIME_PLAN_ACTIVITY,
-          source_entity_ref_id: activityId,
-          content: [],
-        });
-
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
-      }
-
       default:
         throw new Response("Bad Intent", { status: 500 });
     }
@@ -718,34 +704,6 @@ export default function TimePlanActivity() {
             <FieldError actionResult={actionData} fieldName="/feasability" />
           </FormControl>
         </Stack>
-      </SectionCard>
-
-      <SectionCard
-        title="Note"
-        actions={
-          <SectionActions
-            id="activity-note"
-            topLevelInfo={topLevelInfo}
-            inputsEnabled={inputsEnabled}
-            actions={[
-              ActionSingle({
-                text: "Create",
-                value: "activity-create-note",
-                highlight: false,
-                disabled:
-                  loaderData.activityNote !== null &&
-                  loaderData.activityNote !== undefined,
-              }),
-            ]}
-          />
-        }
-      >
-        {loaderData.activityNote && (
-          <EntityNoteEditor
-            initialNote={loaderData.activityNote}
-            inputsEnabled={inputsEnabled}
-          />
-        )}
       </SectionCard>
 
       {loaderData.targetInboxTask && (


### PR DESCRIPTION
The view was showing two "Note" sections — one for the time plan activity
itself and one for the target big plan. Remove the time plan activity note
section (UI, loader data, action handler, and schema entry) so only the
big plan's note is shown.

https://claude.ai/code/session_015yV4ezoXeUmtcF2EVd6c4M