### PR TITLE
Use actual names for time plan activities in calendar events

### DIFF
--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -1777,21 +1777,23 @@ export function choreNameForEvent(chore: Chore): string {
 export function timePlanActivityNameForEvent(
   entry: TimePlanActivityEntry,
 ): string {
-  const activityName = `Work on activity ${entry.time_plan_activity.ref_id}`;
-
   if (entry.target_inbox_task) {
+    const name = entry.target_inbox_task.name;
     if (entry.target_inbox_task.status === InboxTaskStatus.DONE) {
-      return `✅ ${activityName}`;
+      return `✅ ${name}`;
     } else if (entry.target_inbox_task.status === InboxTaskStatus.NOT_DONE) {
-      return `❌ ${activityName}`;
+      return `❌ ${name}`;
     }
+    return `${name}`;
   }
   if (entry.target_big_plan) {
+    const name = entry.target_big_plan.name;
     if (entry.target_big_plan.status === BigPlanStatus.DONE) {
-      return `✅ ${activityName}`;
+      return `✅ ${name}`;
     } else if (entry.target_big_plan.status === BigPlanStatus.NOT_DONE) {
-      return `❌ ${activityName}`;
+      return `❌ ${name}`;
     }
+    return `${name}`;
   }
-  return `📋 ${activityName}`;
+  return `📋 Work on activity ${entry.time_plan_activity.ref_id}`;
 }


### PR DESCRIPTION
## Summary
Updated the `timePlanActivityNameForEvent` function to display the actual names of linked inbox tasks and big plans instead of a generic activity reference ID.

## Key Changes
- When a time plan activity is linked to an inbox task, display the task's name with appropriate status emoji (✅ for done, ❌ for not done)
- When a time plan activity is linked to a big plan, display the plan's name with appropriate status emoji (✅ for done, ❌ for not done)
- Fall back to the generic "Work on activity {ref_id}" format only when no linked task or plan exists
- Removed the generic `activityName` variable that was used for all cases

## Implementation Details
The function now checks for linked targets in order of priority (inbox task → big plan → fallback) and uses the actual name from the linked entity rather than always showing the activity reference ID. This provides better context and readability in calendar views.

https://claude.ai/code/session_01FRrzJAfr9Mq4Rna3KWgeFB