### PR TITLE
Show all tasks in big-plan Kanban view regardless of actionable date

### DIFF
--- a/src/core/jupiter/core/common/sub/inbox_tasks/components/kanban-board.tsx
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/components/kanban-board.tsx
@@ -44,7 +44,7 @@ export interface InboxTaskKanbanBoardProps {
   optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
   inboxTasksByRefId: { [key: string]: InboxTask };
   moreInfoByRefId: { [key: string]: InboxTaskParent };
-  actionableTime: ActionableTime;
+  actionableTime?: ActionableTime;
   allowEisen?: Eisen;
   groupId?: string;
   draggedInboxTaskId?: string;
@@ -169,7 +169,7 @@ interface InboxTasksColumnProps {
   inboxTasksByRefId: { [key: string]: InboxTask };
   optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
   moreInfoByRefId: { [key: string]: InboxTaskParent };
-  actionableTime: ActionableTime;
+  actionableTime?: ActionableTime;
   collapsed?: boolean;
   allowStatus: InboxTaskStatus;
   allowEisen?: Eisen;

--- a/src/core/jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban.tsx
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban.tsx
@@ -27,7 +27,7 @@ interface SmallScreenKanbanBaseProps {
   optimisticUpdates: { [key: string]: InboxTaskOptimisticState };
   moreInfoByRefId: { [key: string]: InboxTaskParent };
   allowEisen?: Eisen;
-  actionableTime: ActionableTime;
+  actionableTime?: ActionableTime;
   onCardMarkDone?: (it: InboxTask) => void;
   onCardMarkNotDone?: (it: InboxTask) => void;
   emptyParent: string;

--- a/src/core/jupiter/core/infra/actionable-time.ts
+++ b/src/core/jupiter/core/infra/actionable-time.ts
@@ -8,9 +8,12 @@ export enum ActionableTime {
 }
 
 export function actionableTimeToDateTime(
-  actionableTime: ActionableTime,
+  actionableTime: ActionableTime | undefined,
   timezone: Timezone,
-): DateTime {
+): DateTime | undefined {
+  if (actionableTime === undefined) {
+    return undefined;
+  }
   switch (actionableTime) {
     case ActionableTime.NOW:
       return DateTime.local({ zone: timezone });

--- a/src/webui/app/routes/app/workspace/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id.tsx
@@ -47,7 +47,6 @@ import {
   SmallScreenKanbanByEisen,
 } from "@jupiter/core/common/sub/inbox_tasks/components/small-screen-kanban";
 import { StandardDivider } from "@jupiter/core/infra/component/standard-divider";
-import { ActionableTime } from "@jupiter/core/infra/actionable-time";
 import { useBigScreen } from "@jupiter/core/infra/component/use-big-screen";
 import {
   isInboxTaskCoreFieldEditable,
@@ -720,7 +719,6 @@ export default function BigPlan() {
                           optimisticUpdates={optimisticUpdates}
                           inboxTasksByRefId={inboxTasksByRefId}
                           moreInfoByRefId={{}}
-                          actionableTime={ActionableTime.NOW}
                           allowEisen={e}
                           draggedInboxTaskId={draggedInboxTaskId}
                           cardLinkResolver={(it) =>
@@ -738,7 +736,6 @@ export default function BigPlan() {
                   inboxTasks={sortedInboxTasks}
                   optimisticUpdates={optimisticUpdates}
                   moreInfoByRefId={{}}
-                  actionableTime={ActionableTime.NOW}
                   onCardMarkDone={handleCardMarkDone}
                   onCardMarkNotDone={handleCardMarkNotDone}
                   emptyParent="inbox task"
@@ -763,7 +760,6 @@ export default function BigPlan() {
                     optimisticUpdates={optimisticUpdates}
                     inboxTasksByRefId={inboxTasksByRefId}
                     moreInfoByRefId={{}}
-                    actionableTime={ActionableTime.NOW}
                     draggedInboxTaskId={draggedInboxTaskId}
                     cardLinkResolver={(it) =>
                       `/app/workspace/big-plans/${loaderData.bigPlan.ref_id}/inbox-tasks/${it.ref_id}`
@@ -777,7 +773,6 @@ export default function BigPlan() {
                   inboxTasks={sortedInboxTasks}
                   optimisticUpdates={optimisticUpdates}
                   moreInfoByRefId={{}}
-                  actionableTime={ActionableTime.NOW}
                   onCardMarkDone={handleCardMarkDone}
                   onCardMarkNotDone={handleCardMarkNotDone}
                   emptyParent="inbox task"


### PR DESCRIPTION
Previously the Kanban board filtered out tasks whose actionable_date was
in the future, hiding them from view. In the big-plan context the user
wants to see every task belonging to the plan, not just the currently
actionable ones.

Changes:
- Make actionableTime optional in InboxTaskKanbanBoard and
  SmallScreenKanban props (undefined = no date filter)
- Update actionableTimeToDateTime to accept/return undefined
- Remove actionableTime from all four kanban usages in big-plans
  so all tasks are shown

https://claude.ai/code/session_01P3Rvb7NZH4c8pkvppLHaVc