### PR TITLE
Block event selection when creating time event from time plan activity

### DIFF
--- a/src/webui/app/routes/app/workspace/calendar.tsx
+++ b/src/webui/app/routes/app/workspace/calendar.tsx
@@ -125,7 +125,9 @@ export default function CalendarView() {
     /\/app\/workspace\/calendar/,
     "",
   );
-  const isAdding = location.pathname.endsWith("/new");
+  const isAdding =
+    location.pathname.endsWith("/new") ||
+    location.pathname.endsWith("/new-for-time-plan-activity");
 
   const topLevelInfo = useContext(TopLevelInfoContext);
 


### PR DESCRIPTION
Extend the `isAdding` check in the calendar view to also match the
`/new-for-time-plan-activity` route, so clicking on other calendar
events is blocked during time plan activity time event creation, just
like it is for all other event creation flows.

https://claude.ai/code/session_01TaTdzgVZPcfgwc3qLFuYea