### PR TITLE
Make search dialog fullscreen on mobile

### DIFF
--- a/src/core/jupiter/core/search/components/search-widget.tsx
+++ b/src/core/jupiter/core/search/components/search-widget.tsx
@@ -191,6 +191,7 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
         open={open}
         onClose={handleClose}
         fullWidth
+        fullScreen={!isBigScreen}
         maxWidth={false}
         slotProps={{
           paper: {
@@ -200,13 +201,11 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
               display: "flex",
               flexDirection: "column",
               overflow: "hidden",
-              m: { xs: "0.5rem", sm: "2rem" },
+              m: { xs: 0, sm: "2rem" },
               width: {
-                xs: "calc(100vw - 1rem)",
                 sm: "min(56rem, calc(100vw - 4rem))",
               },
               height: {
-                xs: "calc(100 * var(--vh, 1vh) - 1rem)",
                 sm: "min(80vh, calc(100 * var(--vh, 1vh) - 4rem))",
               },
             },


### PR DESCRIPTION
Uses MUI Dialog's fullScreen prop on small screens so the search widget
covers the entire viewport on mobile instead of leaving a small gap.

https://claude.ai/code/session_01DfD9GWvsBjEAQdAPGFuUDH