### PR TITLE
Add mobile app shell detection to search widget padding

### DIFF
--- a/src/core/jupiter/core/search/components/search-widget.tsx
+++ b/src/core/jupiter/core/search/components/search-widget.tsx
@@ -5,6 +5,7 @@ import type {
   SearchResult,
   Tag,
 } from "@jupiter/webapi-client";
+import { AppShell } from "@jupiter/webapi-client";
 import {
   Close as CloseIcon,
   Search as SearchIcon,
@@ -27,6 +28,7 @@ import type { ActionResult } from "#/core/infra/action-result";
 import { isNoErrorSomeData } from "#/core/infra/action-result";
 import { GlobalError } from "#/core/infra/component/errors";
 import { TopLevelInfoContext } from "#/core/infra/top-level-context";
+import { ServicePropertiesContext } from "#/core/config-client";
 import { ContactsFilterPicker } from "#/core/common/sub/contacts/component/contacts-filter-picker";
 import { TagsFilterPicker } from "#/core/common/sub/tags/component/tags-filter-picker";
 import { useBigScreen } from "#/core/infra/component/use-big-screen";
@@ -66,6 +68,9 @@ interface SearchWidgetProps {
 
 export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
   const topLevelInfo = useContext(TopLevelInfoContext);
+  const serviceProperties = useContext(ServicePropertiesContext);
+  const isMobileAppShell =
+    serviceProperties.frontDoorInfo.appShell === AppShell.MOBILE_CAPACITOR;
   const isBigScreen = useBigScreen();
   const searchFetcher = useFetcher<WorkspaceSearchInstantResponse>();
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -216,7 +221,7 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
           sx={{
             position: "relative",
             p: 2,
-            pt: { xs: "2rem", sm: 2 },
+            pt: isMobileAppShell ? "2rem" : 2,
             display: "flex",
             flexDirection: "column",
             minHeight: 0,

--- a/src/core/jupiter/core/search/components/search-widget.tsx
+++ b/src/core/jupiter/core/search/components/search-widget.tsx
@@ -216,6 +216,7 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
           sx={{
             position: "relative",
             p: 2,
+            pt: { xs: "2rem", sm: 2 },
             display: "flex",
             flexDirection: "column",
             minHeight: 0,


### PR DESCRIPTION
## Summary
Updated the SearchWidget component to detect when running in a mobile Capacitor app shell and adjust the top padding accordingly to accommodate mobile UI layouts.

## Key Changes
- Added import for `AppShell` type from `@jupiter/webapi-client`
- Added import for `ServicePropertiesContext` from config client
- Extracted `serviceProperties` from context and added logic to detect mobile Capacitor app shell environment
- Conditionally set top padding (`pt`) to `2rem` for mobile app shell, otherwise use default value of `2`

## Implementation Details
The component now checks `serviceProperties.frontDoorInfo.appShell === AppShell.MOBILE_CAPACITOR` to determine if it's running in a mobile environment. When true, the search widget's container receives additional top padding to ensure proper spacing in mobile layouts where the UI structure may differ from web layouts.

https://claude.ai/code/session_018TgcmbKaEZ5FT6LFPXgSAa