### PR TITLE
Disable email verification on staging (Render preview environments)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -24,6 +24,7 @@ envVarGroups:
         value: local-google-apple
       - key: EMAIL_VERIFICATION_STRATEGY
         value: verify
+        previewValue: none
       - key: TELEMETRY
         value: sentry
         previewValue: sentry
@@ -124,6 +125,7 @@ services:
       value: local-google-apple
     - key: EMAIL_VERIFICATION_STRATEGY
       value: verify
+      previewValue: none
 - type: web
   name: jupiter-webapi-srv
   buildFilter:


### PR DESCRIPTION
Add previewValue: none to EMAIL_VERIFICATION_STRATEGY in both the
jupiter-webapi-config env group and the jupiter-webui service, so
staging/preview deploys skip email verification while production
keeps verify.

https://claude.ai/code/session_016K3Mve5oKXuVUisRduPwQq