### PR TITLE
Add Kind and Feasability filters to time plan activities

### DIFF
--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -686,11 +686,15 @@ export default function TimePlanView() {
               actions={[
                 NavMultipleCompact({
                   navs: [
-                    NavSingle({
-                      text: "New Todo",
-                      link: `/app/workspace/todos/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
-                      gatedOn: WorkspaceFeature.TODO_TASK,
-                    }),
+                    ...(timePlanAllowsInboxTasks(loaderData.timePlan)
+                      ? [
+                          NavSingle({
+                            text: "New Todo",
+                            link: `/app/workspace/todos/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                            gatedOn: WorkspaceFeature.TODO_TASK,
+                          }),
+                        ]
+                      : []),
                     NavSingle({
                       text: "New Big Plan",
                       link: `/app/workspace/big-plans/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
@@ -37,6 +37,7 @@ import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
 import {
   ActionMultipleSpread,
   ActionSingle,
+  FilterFewOptionsCompact,
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
@@ -237,6 +238,14 @@ export default function TimePlanAddFromCurrentTimePlans() {
     new Set<string>(),
   );
 
+  const [filterKind, setFilterKind] = useState<TimePlanActivityKind | null>(
+    null,
+  );
+  const [
+    filterFeasability,
+    setFilterFeasability,
+  ] = useState<TimePlanActivityFeasability | null>(null);
+
   const otherTargetInboxTasksByRefId = new Map<string, InboxTask>(
     loaderData.otherTargetInboxTasks.map((it) => [it.ref_id, it]),
   );
@@ -254,7 +263,7 @@ export default function TimePlanAddFromCurrentTimePlans() {
   //   otherTimeEventsByRefId.set(`bp:${e.big_plan.ref_id}`, e.time_events);
   // }
 
-  const filteredOtherActivities = filterActivitiesByTargetStatus(
+  const filteredOtherActivitiesByStatus = filterActivitiesByTargetStatus(
     loaderData.otherActivities,
     otherTargetInboxTasksByRefId,
     otherTargetBigPlansByRefId,
@@ -263,6 +272,11 @@ export default function TimePlanAddFromCurrentTimePlans() {
     (activity) =>
       !isTimePlanActivityInboxTaskTarget(activity.target) ||
       timePlanAllowsInboxTasks(loaderData.mainTimePlan),
+  );
+  const filteredOtherActivities = filteredOtherActivitiesByStatus.filter(
+    (activity) =>
+      (filterKind === null || activity.kind === filterKind) &&
+      (filterFeasability === null || activity.feasability === filterFeasability),
   );
   const sortedOtherActivities = sortTimePlanActivitiesNaturally(
     filteredOtherActivities,
@@ -301,6 +315,48 @@ export default function TimePlanAddFromCurrentTimePlans() {
                   }),
                 ],
               }),
+              FilterFewOptionsCompact(
+                "Kind",
+                null,
+                [
+                  {
+                    value: null,
+                    text: "All",
+                  },
+                  {
+                    value: TimePlanActivityKind.FINISH,
+                    text: "Finish",
+                  },
+                  {
+                    value: TimePlanActivityKind.MAKE_PROGRESS,
+                    text: "Make Progress",
+                  },
+                ],
+                (selected) => setFilterKind(selected),
+              ),
+              FilterFewOptionsCompact(
+                "Feasability",
+                null,
+                [
+                  {
+                    value: null,
+                    text: "All",
+                  },
+                  {
+                    value: TimePlanActivityFeasability.MUST_DO,
+                    text: "Must Do",
+                  },
+                  {
+                    value: TimePlanActivityFeasability.NICE_TO_HAVE,
+                    text: "Nice To Have",
+                  },
+                  {
+                    value: TimePlanActivityFeasability.STRETCH,
+                    text: "Stretch",
+                  },
+                ],
+                (selected) => setFilterFeasability(selected),
+              ),
             ]}
           />
         }


### PR DESCRIPTION
## Summary
Added filtering capabilities to the "Add from Current Time Plans" page, allowing users to filter activities by their kind (Finish/Make Progress) and feasability level (Must Do/Nice To Have/Stretch).

## Key Changes
- Imported `FilterFewOptionsCompact` component for compact filter UI
- Added two new state variables:
  - `filterKind`: tracks the selected activity kind filter
  - `filterFeasability`: tracks the selected feasability level filter
- Refactored activity filtering logic:
  - Renamed `filteredOtherActivities` to `filteredOtherActivitiesByStatus` for clarity
  - Added a second filtering step that applies kind and feasability filters
- Added two new filter UI sections in the actions panel:
  - Kind filter with options: All, Finish, Make Progress
  - Feasability filter with options: All, Must Do, Nice To Have, Stretch

## Implementation Details
- Filters default to `null` (showing all activities) and can be independently toggled
- Filtering is applied after the existing status-based filtering
- Both filters use the compact filter component for consistent UI

https://claude.ai/code/session_01VQRJoWqsqsn7Eet8s5EZqU