### PR TITLE
Fix OOM/500 on calendar-load-for-date-and-period from unbounded shared-schedule query

### DIFF
--- a/src/core/jupiter/core/calendar/service/load_for_date_and_period.py
+++ b/src/core/jupiter/core/calendar/service/load_for_date_and_period.py
@@ -59,6 +59,12 @@ from jupiter.framework.use_case_io import (
     use_case_result_part,
 )
 
+# Postgres caps bind parameters per query at 65535. Keep `IN (...)` owner
+# lookups well under that (and out of unbounded-memory territory) by
+# batching, since a shared schedule stream's history can span thousands
+# of events.
+_OWNER_QUERY_BATCH_SIZE = 500
+
 
 @use_case_result_part
 class ScheduleInDayEventEntry(UseCaseResultBase):
@@ -843,7 +849,7 @@ class CalendarLoadForDateAndPeriodService:
             for ref_id in full_days_event_ref_ids
             if ref_id not in time_events_full_days_by_event
         ]
-        if missing_full_days:
+        for batch in self._batched(missing_full_days, _OWNER_QUERY_BATCH_SIZE):
             full_days_blocks = await uow.get(
                 TimeEventFullDaysBlockRepository
             ).find_for_owner(
@@ -851,39 +857,46 @@ class CalendarLoadForDateAndPeriodService:
                     EntityLink.std(
                         NamedEntityTag.SCHEDULE_EVENT_FULL_DAYS_BLOCK.value, ref_id
                     )
-                    for ref_id in missing_full_days
+                    for ref_id in batch
                 ],
                 allow_archived=False,
+                start_date=schedule.first_day,
+                end_date=schedule.end_day,
             )
             for full_days_block in full_days_blocks:
-                if (
-                    full_days_block.end_date >= schedule.first_day
-                    and full_days_block.start_date <= schedule.end_day
-                ):
-                    time_events_full_days_by_event[full_days_block.owner.ref_id] = (
-                        full_days_block
-                    )
+                time_events_full_days_by_event[full_days_block.owner.ref_id] = (
+                    full_days_block
+                )
 
         missing_in_day = [
             ref_id
             for ref_id in in_day_event_ref_ids
             if ref_id not in time_events_in_day_by_event
         ]
-        if missing_in_day:
-            in_day_blocks = await uow.get_for(TimeEventInDayBlock).find_all_generic(
-                parent_ref_id=None,
-                allow_archived=False,
-                owner=[
+        in_day_start = schedule.first_day.subtract_days(2)
+        for batch in self._batched(missing_in_day, _OWNER_QUERY_BATCH_SIZE):
+            in_day_blocks = await uow.get(TimeEventInDayBlockRepository).find_for_owner(
+                [
                     EntityLink.std(NamedEntityTag.SCHEDULE_EVENT_IN_DAY.value, ref_id)
-                    for ref_id in missing_in_day
+                    for ref_id in batch
                 ],
+                allow_archived=False,
+                start_date=in_day_start,
+                end_date=schedule.end_day,
             )
-            in_day_start = schedule.first_day.subtract_days(2)
             for in_day_block in in_day_blocks:
-                if in_day_start <= in_day_block.start_date <= schedule.end_day:
-                    time_events_in_day_by_event[in_day_block.owner.ref_id] = (
-                        in_day_block
-                    )
+                time_events_in_day_by_event[in_day_block.owner.ref_id] = (
+                    in_day_block
+                )
+
+    @staticmethod
+    def _batched(
+        items: list[EntityId], batch_size: int
+    ) -> list[list[EntityId]]:
+        """Split a list into fixed-size batches (bounds SQL `IN` clause size)."""
+        return [
+            items[idx : idx + batch_size] for idx in range(0, len(items), batch_size)
+        ]
 
     async def _ensure_streams_for_events(
         self,

--- a/src/core/jupiter/core/common/sub/time_events/impl/postgres_repository.py
+++ b/src/core/jupiter/core/common/sub/time_events/impl/postgres_repository.py
@@ -67,6 +67,45 @@ class PostgresTimeEventInDayBlockRepository(
             )
         return self._row_to_entity(result)
 
+    async def find_for_owner(
+        self,
+        owner: EntityLink | list[EntityLink],
+        allow_archived: (
+            bool | JupiterArchivalReason | list[JupiterArchivalReason]
+        ) = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
+    ) -> list[TimeEventInDayBlock]:
+        """Retrieve time events in day blocks for the given owner link(s)."""
+        owners = owner if isinstance(owner, list) else [owner]
+        encoded = [self._realm_codec_registry.db_encode(o) for o in owners]
+        query_stmt = select(self._table).where(self._table.c.owner.in_(encoded))
+        if isinstance(allow_archived, bool):
+            if not allow_archived:
+                query_stmt = query_stmt.where(self._table.c.archived.is_(False))
+        elif isinstance(allow_archived, JupiterArchivalReason):
+            query_stmt = query_stmt.where(
+                (self._table.c.archived.is_(False))
+                | (self._table.c.archival_reason == str(allow_archived.value))
+            )
+        elif isinstance(allow_archived, list):
+            query_stmt = query_stmt.where(
+                (self._table.c.archived.is_(False))
+                | (
+                    self._table.c.archival_reason.in_(
+                        [str(reason.value) for reason in allow_archived]
+                    )
+                )
+            )
+        if start_date is not None:
+            query_stmt = query_stmt.where(
+                self._table.c.start_date >= start_date.the_date
+            )
+        if end_date is not None:
+            query_stmt = query_stmt.where(self._table.c.start_date <= end_date.the_date)
+        result = await self._connection.execute(query_stmt)
+        return [self._row_to_entity(row) for row in result]
+
     async def find_all_between(
         self, parent_ref_id: EntityId, start_date: ADate, end_date: ADate
     ) -> list[TimeEventInDayBlock]:
@@ -158,6 +197,8 @@ class PostgresTimeEventFullDaysBlockRepository(
         allow_archived: (
             bool | JupiterArchivalReason | list[JupiterArchivalReason]
         ) = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
     ) -> list[TimeEventFullDaysBlock]:
         """Retrieve time events in full day blocks for the given owner link(s)."""
         owners = owner if isinstance(owner, list) else [owner]
@@ -178,6 +219,26 @@ class PostgresTimeEventFullDaysBlockRepository(
                     self._table.c.archival_reason.in_(
                         [str(reason.value) for reason in allow_archived]
                     )
+                )
+            )
+        if start_date is not None and end_date is not None:
+            query_stmt = query_stmt.where(
+                or_(
+                    # Start date is in range
+                    and_(
+                        self._table.c.start_date >= start_date.the_date,
+                        self._table.c.start_date <= end_date.the_date,
+                    ),
+                    # End date is in range
+                    and_(
+                        self._table.c.end_date >= start_date.the_date,
+                        self._table.c.end_date <= end_date.the_date,
+                    ),
+                    # Start and end date span the range
+                    and_(
+                        self._table.c.start_date <= start_date.the_date,
+                        self._table.c.end_date >= end_date.the_date,
+                    ),
                 )
             )
         result = await self._connection.execute(query_stmt)

--- a/src/core/jupiter/core/common/sub/time_events/impl/sqlite_repository.py
+++ b/src/core/jupiter/core/common/sub/time_events/impl/sqlite_repository.py
@@ -67,6 +67,45 @@ class SqliteTimeEventInDayBlockRepository(
             )
         return self._row_to_entity(result)
 
+    async def find_for_owner(
+        self,
+        owner: EntityLink | list[EntityLink],
+        allow_archived: (
+            bool | JupiterArchivalReason | list[JupiterArchivalReason]
+        ) = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
+    ) -> list[TimeEventInDayBlock]:
+        """Retrieve time events in day blocks for the given owner link(s)."""
+        owners = owner if isinstance(owner, list) else [owner]
+        encoded = [self._realm_codec_registry.db_encode(o) for o in owners]
+        query_stmt = select(self._table).where(self._table.c.owner.in_(encoded))
+        if isinstance(allow_archived, bool):
+            if not allow_archived:
+                query_stmt = query_stmt.where(self._table.c.archived.is_(False))
+        elif isinstance(allow_archived, JupiterArchivalReason):
+            query_stmt = query_stmt.where(
+                (self._table.c.archived.is_(False))
+                | (self._table.c.archival_reason == str(allow_archived.value))
+            )
+        elif isinstance(allow_archived, list):
+            query_stmt = query_stmt.where(
+                (self._table.c.archived.is_(False))
+                | (
+                    self._table.c.archival_reason.in_(
+                        [str(reason.value) for reason in allow_archived]
+                    )
+                )
+            )
+        if start_date is not None:
+            query_stmt = query_stmt.where(
+                self._table.c.start_date >= start_date.the_date
+            )
+        if end_date is not None:
+            query_stmt = query_stmt.where(self._table.c.start_date <= end_date.the_date)
+        result = await self._connection.execute(query_stmt)
+        return [self._row_to_entity(row) for row in result]
+
     async def find_all_between(
         self, parent_ref_id: EntityId, start_date: ADate, end_date: ADate
     ) -> list[TimeEventInDayBlock]:
@@ -157,6 +196,8 @@ class SqliteTimeEventFullDaysBlockRepository(
         allow_archived: (
             bool | JupiterArchivalReason | list[JupiterArchivalReason]
         ) = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
     ) -> list[TimeEventFullDaysBlock]:
         """Retrieve time events in full day blocks for the given owner link(s)."""
         owners = owner if isinstance(owner, list) else [owner]
@@ -177,6 +218,26 @@ class SqliteTimeEventFullDaysBlockRepository(
                     self._table.c.archival_reason.in_(
                         [str(reason.value) for reason in allow_archived]
                     )
+                )
+            )
+        if start_date is not None and end_date is not None:
+            query_stmt = query_stmt.where(
+                or_(
+                    # Start date is in range
+                    and_(
+                        self._table.c.start_date >= start_date.the_date,
+                        self._table.c.start_date <= end_date.the_date,
+                    ),
+                    # End date is in range
+                    and_(
+                        self._table.c.end_date >= start_date.the_date,
+                        self._table.c.end_date <= end_date.the_date,
+                    ),
+                    # Start and end date span the range
+                    and_(
+                        self._table.c.start_date <= start_date.the_date,
+                        self._table.c.end_date >= end_date.the_date,
+                    ),
                 )
             )
         result = await self._connection.execute(query_stmt)

--- a/src/core/jupiter/core/common/sub/time_events/sub/full_days_block/root.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/full_days_block/root.py
@@ -218,8 +218,10 @@ class TimeEventFullDaysBlockRepository(
         self,
         owner: EntityLink | list[EntityLink],
         allow_archived: bool = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
     ) -> list[TimeEventFullDaysBlock]:
-        """Find all blocks for the given owner link(s)."""
+        """Find all blocks for the given owner link(s), optionally scoped to a date range."""
 
     @abc.abstractmethod
     async def find_all_between(

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.py
@@ -272,6 +272,16 @@ class TimeEventInDayBlockRepository(LeafEntityRepository[TimeEventInDayBlock], a
         """Load a time event in day block by its owner link."""
 
     @abc.abstractmethod
+    async def find_for_owner(
+        self,
+        owner: EntityLink | list[EntityLink],
+        allow_archived: bool = False,
+        start_date: ADate | None = None,
+        end_date: ADate | None = None,
+    ) -> list[TimeEventInDayBlock]:
+        """Find all blocks for the given owner link(s), optionally scoped to a date range."""
+
+    @abc.abstractmethod
     async def find_all_between(
         self,
         parent_ref_id: EntityId,


### PR DESCRIPTION
## Summary

- `webapi-srv` was crashing with `POST /calendar-load-for-date-and-period 500` and "Ran out of memory (used over 512MB)" after the recent `sharing-is-caring` / `sharing-is-caring-2` merges.
- Root cause: `_merge_shared_schedule_event_time_blocks` (new code from the sharing feature) fetches **every** `AccessStatus` the requesting user has for `SCHEDULE_EVENT_FULL_DAYS_BLOCK`/`SCHEDULE_EVENT_IN_DAY` entities with no date bound, then loads the full row for every one of those ref ids before filtering down to the requested day/week in Python. Granting a user access to a schedule stream cascades an `AccessStatus` to every descendant event that stream has *ever* had (`GrantRightsToUserService._cascade_to_children`), so a stream with a long history pulls thousands of full rows into memory just to render a single day/week. Once the ref-id list gets large enough, the resulting `IN (...)` query can also exceed Postgres's hard cap of 65535 bind parameters and fail outright — matching the massive parameterized query visible in the logs.
- Fix: push date-range filtering into SQL instead of loading full history and filtering client-side, and batch the owner-id lookups so the `IN (...)` parameter count can never approach Postgres's limit.

## Changes

- Added optional `start_date`/`end_date` to `TimeEvent{FullDays,InDay}Block.find_for_owner` (Postgres + SQLite impls), reusing the same overlap logic already used by `find_all_between`.
- Added a real `find_for_owner` to `TimeEventInDayBlockRepository` (it previously only had an unfiltered generic ORM helper).
- Batched the owner-id `IN (...)` lookups in `_merge_shared_schedule_event_time_blocks` (500 at a time) so query size stays bounded regardless of how large a shared stream's history is.

## Test plan

- [x] `mypy` (project config, `src/core`) — clean, no new errors.
- [x] `ruff check` on all touched files — clean.
- [x] Verified all touched modules import successfully.
- [ ] Manual verification against production data (can't reproduce the OOM locally without the same dataset scale).


---
_Generated by [Claude Code](https://claude.ai/code/session_019BWUR9RMWmFWUBiBoswThC)_