### PR TITLE
Optimize score and habit streak updates with batch database operations

### DIFF
--- a/src/core/jupiter/core/gamification/impl/postgres_repository.py
+++ b/src/core/jupiter/core/gamification/impl/postgres_repository.py
@@ -44,11 +44,14 @@ from sqlalchemy import (
     MetaData,
     String,
     Table,
+    and_,
     delete,
     insert,
+    or_,
     select,
     update,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -253,6 +256,45 @@ class PostgresScoreStatsRepository(
 
         return [self._row_to_entity(row) for row in result]
 
+    async def find_all_for_keys(
+        self, keys: list[tuple[EntityId, RecurringTaskPeriod | None, str]]
+    ) -> list[ScoreStats]:
+        """Find all score stats matching the given natural keys, in one query."""
+        if not keys:
+            return []
+        conditions = [
+            and_(
+                self._score_stats_table.c.score_log_ref_id == score_log_ref_id.as_int(),
+                optional_period_pk_match(self._score_stats_table.c.period, period),
+                self._score_stats_table.c.timeline == timeline,
+            )
+            for score_log_ref_id, period, timeline in keys
+        ]
+        result = await self._connection.execute(
+            select(self._score_stats_table).where(or_(*conditions))
+        )
+        return [self._row_to_entity(row) for row in result]
+
+    async def upsert_all(self, records: list[ScoreStats]) -> None:
+        """Upsert a batch of score stats in a single statement."""
+        if not records:
+            return
+        rows = [
+            db_encode_score_stats_row(self._realm_codec_registry, record)
+            for record in records
+        ]
+        insert_stmt = pg_insert(self._score_stats_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["score_log_ref_id", "period", "timeline"],
+            set_={
+                "total_score": insert_stmt.excluded.total_score,
+                "inbox_task_cnt": insert_stmt.excluded.inbox_task_cnt,
+                "big_plan_cnt": insert_stmt.excluded.big_plan_cnt,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
+
     def _row_to_entity(self, row: RowType) -> ScoreStats:
         return self._realm_codec_registry.db_decode(
             ScoreStats,
@@ -412,6 +454,52 @@ class PostgresScorePeriodBestRepository(
             )
         )
         return [self._row_to_entity(row) for row in result]
+
+    async def find_all_for_keys(
+        self,
+        keys: list[
+            tuple[EntityId, RecurringTaskPeriod | None, str, RecurringTaskPeriod]
+        ],
+    ) -> list[ScorePeriodBest]:
+        """Find all score period bests matching the given natural keys, in one query."""
+        if not keys:
+            return []
+        conditions = [
+            and_(
+                self._score_period_best_table.c.score_log_ref_id
+                == score_log_ref_id.as_int(),
+                optional_period_pk_match(
+                    self._score_period_best_table.c.period, period
+                ),
+                self._score_period_best_table.c.timeline == timeline,
+                self._score_period_best_table.c.sub_period == sub_period.value,
+            )
+            for score_log_ref_id, period, timeline, sub_period in keys
+        ]
+        result = await self._connection.execute(
+            select(self._score_period_best_table).where(or_(*conditions))
+        )
+        return [self._row_to_entity(row) for row in result]
+
+    async def upsert_all(self, records: list[ScorePeriodBest]) -> None:
+        """Upsert a batch of score period bests in a single statement."""
+        if not records:
+            return
+        rows = [
+            db_encode_score_period_best_row(self._realm_codec_registry, record)
+            for record in records
+        ]
+        insert_stmt = pg_insert(self._score_period_best_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["score_log_ref_id", "period", "timeline", "sub_period"],
+            set_={
+                "total_score": insert_stmt.excluded.total_score,
+                "inbox_task_cnt": insert_stmt.excluded.inbox_task_cnt,
+                "big_plan_cnt": insert_stmt.excluded.big_plan_cnt,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
 
     def _row_to_entity(self, row: RowType) -> ScorePeriodBest:
         return self._realm_codec_registry.db_decode(

--- a/src/core/jupiter/core/gamification/impl/sqlite_repository.py
+++ b/src/core/jupiter/core/gamification/impl/sqlite_repository.py
@@ -47,11 +47,14 @@ from sqlalchemy import (
     MetaData,
     String,
     Table,
+    and_,
     delete,
     insert,
+    or_,
     select,
     update,
 )
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -256,6 +259,45 @@ class SqliteScoreStatsRepository(
 
         return [self._row_to_entity(row) for row in result]
 
+    async def find_all_for_keys(
+        self, keys: list[tuple[EntityId, RecurringTaskPeriod | None, str]]
+    ) -> list[ScoreStats]:
+        """Find all score stats matching the given natural keys, in one query."""
+        if not keys:
+            return []
+        conditions = [
+            and_(
+                self._score_stats_table.c.score_log_ref_id == score_log_ref_id.as_int(),
+                optional_period_pk_match(self._score_stats_table.c.period, period),
+                self._score_stats_table.c.timeline == timeline,
+            )
+            for score_log_ref_id, period, timeline in keys
+        ]
+        result = await self._connection.execute(
+            select(self._score_stats_table).where(or_(*conditions))
+        )
+        return [self._row_to_entity(row) for row in result]
+
+    async def upsert_all(self, records: list[ScoreStats]) -> None:
+        """Upsert a batch of score stats in a single statement."""
+        if not records:
+            return
+        rows = [
+            db_encode_score_stats_row(self._realm_codec_registry, record)
+            for record in records
+        ]
+        insert_stmt = sqlite_insert(self._score_stats_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["score_log_ref_id", "period", "timeline"],
+            set_={
+                "total_score": insert_stmt.excluded.total_score,
+                "inbox_task_cnt": insert_stmt.excluded.inbox_task_cnt,
+                "big_plan_cnt": insert_stmt.excluded.big_plan_cnt,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
+
     def _row_to_entity(self, row: RowType) -> ScoreStats:
         return self._realm_codec_registry.db_decode(
             ScoreStats,
@@ -415,6 +457,52 @@ class SqliteScorePeriodBestRepository(
             )
         )
         return [self._row_to_entity(row) for row in result]
+
+    async def find_all_for_keys(
+        self,
+        keys: list[
+            tuple[EntityId, RecurringTaskPeriod | None, str, RecurringTaskPeriod]
+        ],
+    ) -> list[ScorePeriodBest]:
+        """Find all score period bests matching the given natural keys, in one query."""
+        if not keys:
+            return []
+        conditions = [
+            and_(
+                self._score_period_best_table.c.score_log_ref_id
+                == score_log_ref_id.as_int(),
+                optional_period_pk_match(
+                    self._score_period_best_table.c.period, period
+                ),
+                self._score_period_best_table.c.timeline == timeline,
+                self._score_period_best_table.c.sub_period == sub_period.value,
+            )
+            for score_log_ref_id, period, timeline, sub_period in keys
+        ]
+        result = await self._connection.execute(
+            select(self._score_period_best_table).where(or_(*conditions))
+        )
+        return [self._row_to_entity(row) for row in result]
+
+    async def upsert_all(self, records: list[ScorePeriodBest]) -> None:
+        """Upsert a batch of score period bests in a single statement."""
+        if not records:
+            return
+        rows = [
+            db_encode_score_period_best_row(self._realm_codec_registry, record)
+            for record in records
+        ]
+        insert_stmt = sqlite_insert(self._score_period_best_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["score_log_ref_id", "period", "timeline", "sub_period"],
+            set_={
+                "total_score": insert_stmt.excluded.total_score,
+                "inbox_task_cnt": insert_stmt.excluded.inbox_task_cnt,
+                "big_plan_cnt": insert_stmt.excluded.big_plan_cnt,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
 
     def _row_to_entity(self, row: RowType) -> ScorePeriodBest:
         return self._realm_codec_registry.db_decode(

--- a/src/core/jupiter/core/gamification/score_period_best.py
+++ b/src/core/jupiter/core/gamification/score_period_best.py
@@ -106,3 +106,16 @@ class ScorePeriodBestRepository(
     abc.ABC,
 ):
     """A repository of score period bests."""
+
+    @abc.abstractmethod
+    async def find_all_for_keys(
+        self,
+        keys: list[
+            tuple[EntityId, RecurringTaskPeriod | None, str, RecurringTaskPeriod]
+        ],
+    ) -> list[ScorePeriodBest]:
+        """Find all score period bests matching the given natural keys, in one query."""
+
+    @abc.abstractmethod
+    async def upsert_all(self, records: list[ScorePeriodBest]) -> None:
+        """Upsert a batch of score period bests in a single statement."""

--- a/src/core/jupiter/core/gamification/score_stats.py
+++ b/src/core/jupiter/core/gamification/score_stats.py
@@ -109,3 +109,13 @@ class ScoreStatsRepository(
         end_date: ADate,
     ) -> list[ScoreStats]:
         """Find all score stats in a given time range."""
+
+    @abc.abstractmethod
+    async def find_all_for_keys(
+        self, keys: list[tuple[EntityId, RecurringTaskPeriod | None, str]]
+    ) -> list[ScoreStats]:
+        """Find all score stats matching the given natural keys, in one query."""
+
+    @abc.abstractmethod
+    async def upsert_all(self, records: list[ScoreStats]) -> None:
+        """Upsert a batch of score stats in a single statement."""

--- a/src/core/jupiter/core/gamification/service/record_score.py
+++ b/src/core/jupiter/core/gamification/service/record_score.py
@@ -1,7 +1,5 @@
 """A service that records scores for various actions."""
 
-import asyncio
-
 from jupiter.core.big_plans.root import BigPlan
 from jupiter.core.common.recurring_task_period import RecurringTaskPeriod
 from jupiter.core.common.sub.inbox_tasks.root import InboxTask
@@ -75,246 +73,149 @@ class RecordScoreService:
             # or not done, and we won't do it again!
             return None
 
-        # Update statistics at write time.
+        # Update statistics at write time. All periods are read in one query,
+        # merged in memory, and written back in one query, instead of a
+        # read-then-write round trip per period.
 
-        (
-            daily_score_stats,
-            weekly_score_stats,
-            monthly_score_stats,
-            quarterly_score_stats,
-            yearly_score_stats,
-            lifetime_score_stats,
-        ) = await asyncio.gather(
-            self._update_current_stats(
-                ctx, RecurringTaskPeriod.DAILY, uow, score_log, new_score_log_entry
-            ),
-            self._update_current_stats(
-                ctx, RecurringTaskPeriod.WEEKLY, uow, score_log, new_score_log_entry
-            ),
-            self._update_current_stats(
-                ctx, RecurringTaskPeriod.MONTHLY, uow, score_log, new_score_log_entry
-            ),
-            self._update_current_stats(
-                ctx, RecurringTaskPeriod.QUARTERLY, uow, score_log, new_score_log_entry
-            ),
-            self._update_current_stats(
-                ctx, RecurringTaskPeriod.YEARLY, uow, score_log, new_score_log_entry
-            ),
-            self._update_current_stats(ctx, None, uow, score_log, new_score_log_entry),
-        )
+        stats_periods: list[RecurringTaskPeriod | None] = [
+            RecurringTaskPeriod.DAILY,
+            RecurringTaskPeriod.WEEKLY,
+            RecurringTaskPeriod.MONTHLY,
+            RecurringTaskPeriod.QUARTERLY,
+            RecurringTaskPeriod.YEARLY,
+            None,
+        ]
+        stats_keys = [
+            (score_log.ref_id, period, infer_timeline(period, ctx.action_timestamp))
+            for period in stats_periods
+        ]
+        existing_stats_by_key = {
+            existing.key: existing
+            for existing in await uow.get(ScoreStatsRepository).find_all_for_keys(
+                stats_keys
+            )
+        }
 
-        # Update high scores at write time.
+        stats_by_period: dict[RecurringTaskPeriod | None, ScoreStats] = {}
+        for period, key in zip(stats_periods, stats_keys):
+            existing_stats = existing_stats_by_key.get(key)
+            if existing_stats is None:
+                stats_by_period[period] = ScoreStats.new_score_stats(
+                    ctx, score_log.ref_id, period, key[2]
+                ).merge_score(ctx, new_score_log_entry)
+            else:
+                stats_by_period[period] = existing_stats.merge_score(
+                    ctx, new_score_log_entry
+                )
 
-        (
-            best_quarterly_daily,
-            best_quarterly_weekly,
-            best_quarterly_monthly,
-        ) = await asyncio.gather(
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.QUARTERLY,
-                RecurringTaskPeriod.DAILY,
-                daily_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.QUARTERLY,
-                RecurringTaskPeriod.WEEKLY,
-                weekly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.QUARTERLY,
-                RecurringTaskPeriod.MONTHLY,
-                monthly_score_stats,
-                uow,
-                score_log,
-            ),
-        )
+        await uow.get(ScoreStatsRepository).upsert_all(list(stats_by_period.values()))
 
-        (
-            best_yearly_daily,
-            best_yearly_weekly,
-            best_yearly_monthly,
-            best_yearly_quarterly,
-        ) = await asyncio.gather(
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.YEARLY,
-                RecurringTaskPeriod.DAILY,
-                daily_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.YEARLY,
-                RecurringTaskPeriod.WEEKLY,
-                weekly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.YEARLY,
-                RecurringTaskPeriod.MONTHLY,
-                monthly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                RecurringTaskPeriod.YEARLY,
-                RecurringTaskPeriod.QUARTERLY,
-                quarterly_score_stats,
-                uow,
-                score_log,
-            ),
-        )
+        # Update high scores at write time, with the same batched read/write.
 
-        (
-            best_lifetime_daily,
-            best_lifetime_weekly,
-            best_lifetime_monthly,
-            best_lifetime_quarterly,
-            best_lifetime_yearly,
-        ) = await asyncio.gather(
-            self._update_best(
-                ctx,
-                None,
-                RecurringTaskPeriod.DAILY,
-                daily_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                None,
-                RecurringTaskPeriod.WEEKLY,
-                weekly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                None,
-                RecurringTaskPeriod.MONTHLY,
-                monthly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                None,
-                RecurringTaskPeriod.QUARTERLY,
-                quarterly_score_stats,
-                uow,
-                score_log,
-            ),
-            self._update_best(
-                ctx,
-                None,
-                RecurringTaskPeriod.YEARLY,
-                yearly_score_stats,
-                uow,
-                score_log,
-            ),
+        best_specs: list[tuple[RecurringTaskPeriod | None, RecurringTaskPeriod]] = [
+            (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.DAILY),
+            (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.WEEKLY),
+            (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.MONTHLY),
+            (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.DAILY),
+            (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.WEEKLY),
+            (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.MONTHLY),
+            (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.QUARTERLY),
+            (None, RecurringTaskPeriod.DAILY),
+            (None, RecurringTaskPeriod.WEEKLY),
+            (None, RecurringTaskPeriod.MONTHLY),
+            (None, RecurringTaskPeriod.QUARTERLY),
+            (None, RecurringTaskPeriod.YEARLY),
+        ]
+        best_keys = [
+            (
+                score_log.ref_id,
+                period,
+                infer_timeline(period, ctx.action_timestamp),
+                sub_period,
+            )
+            for period, sub_period in best_specs
+        ]
+        existing_best_by_key = {
+            existing.key: existing
+            for existing in await uow.get(
+                ScorePeriodBestRepository
+            ).find_all_for_keys(best_keys)
+        }
+
+        best_by_spec: dict[
+            tuple[RecurringTaskPeriod | None, RecurringTaskPeriod], ScorePeriodBest
+        ] = {}
+        for (period, sub_period), best_key in zip(best_specs, best_keys):
+            existing_best = existing_best_by_key.get(best_key)
+            sub_period_stats = stats_by_period[sub_period]
+            if existing_best is None:
+                best_by_spec[(period, sub_period)] = (
+                    ScorePeriodBest.new_score_period_best(
+                        ctx, score_log.ref_id, period, best_key[2], sub_period
+                    ).update_to_max(ctx, sub_period_stats)
+                )
+            else:
+                best_by_spec[(period, sub_period)] = existing_best.update_to_max(
+                    ctx, sub_period_stats
+                )
+
+        await uow.get(ScorePeriodBestRepository).upsert_all(
+            list(best_by_spec.values())
         )
 
         return RecordScoreResult(
             latest_task_score=new_score_log_entry.score,
             has_lucky_puppy_bonus=new_score_log_entry.has_lucky_puppy_bonus,
             score_overview=UserScoreOverview(
-                daily_score=daily_score_stats.to_user_score(),
-                weekly_score=weekly_score_stats.to_user_score(),
-                monthly_score=monthly_score_stats.to_user_score(),
-                quarterly_score=quarterly_score_stats.to_user_score(),
-                yearly_score=yearly_score_stats.to_user_score(),
-                lifetime_score=lifetime_score_stats.to_user_score(),
-                best_quarterly_daily_score=best_quarterly_daily.to_user_score(),
-                best_quarterly_weekly_score=best_quarterly_weekly.to_user_score(),
-                best_quarterly_monthly_score=best_quarterly_monthly.to_user_score(),
-                best_yearly_daily_score=best_yearly_daily.to_user_score(),
-                best_yearly_weekly_score=best_yearly_weekly.to_user_score(),
-                best_yearly_monthly_score=best_yearly_monthly.to_user_score(),
-                best_yearly_quarterly_score=best_yearly_quarterly.to_user_score(),
-                best_lifetime_daily_score=best_lifetime_daily.to_user_score(),
-                best_lifetime_weekly_score=best_lifetime_weekly.to_user_score(),
-                best_lifetime_monthly_score=best_lifetime_monthly.to_user_score(),
-                best_lifetime_quarterly_score=best_lifetime_quarterly.to_user_score(),
-                best_lifetime_yearly_score=best_lifetime_yearly.to_user_score(),
+                daily_score=stats_by_period[RecurringTaskPeriod.DAILY].to_user_score(),
+                weekly_score=stats_by_period[
+                    RecurringTaskPeriod.WEEKLY
+                ].to_user_score(),
+                monthly_score=stats_by_period[
+                    RecurringTaskPeriod.MONTHLY
+                ].to_user_score(),
+                quarterly_score=stats_by_period[
+                    RecurringTaskPeriod.QUARTERLY
+                ].to_user_score(),
+                yearly_score=stats_by_period[
+                    RecurringTaskPeriod.YEARLY
+                ].to_user_score(),
+                lifetime_score=stats_by_period[None].to_user_score(),
+                best_quarterly_daily_score=best_by_spec[
+                    (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.DAILY)
+                ].to_user_score(),
+                best_quarterly_weekly_score=best_by_spec[
+                    (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.WEEKLY)
+                ].to_user_score(),
+                best_quarterly_monthly_score=best_by_spec[
+                    (RecurringTaskPeriod.QUARTERLY, RecurringTaskPeriod.MONTHLY)
+                ].to_user_score(),
+                best_yearly_daily_score=best_by_spec[
+                    (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.DAILY)
+                ].to_user_score(),
+                best_yearly_weekly_score=best_by_spec[
+                    (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.WEEKLY)
+                ].to_user_score(),
+                best_yearly_monthly_score=best_by_spec[
+                    (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.MONTHLY)
+                ].to_user_score(),
+                best_yearly_quarterly_score=best_by_spec[
+                    (RecurringTaskPeriod.YEARLY, RecurringTaskPeriod.QUARTERLY)
+                ].to_user_score(),
+                best_lifetime_daily_score=best_by_spec[
+                    (None, RecurringTaskPeriod.DAILY)
+                ].to_user_score(),
+                best_lifetime_weekly_score=best_by_spec[
+                    (None, RecurringTaskPeriod.WEEKLY)
+                ].to_user_score(),
+                best_lifetime_monthly_score=best_by_spec[
+                    (None, RecurringTaskPeriod.MONTHLY)
+                ].to_user_score(),
+                best_lifetime_quarterly_score=best_by_spec[
+                    (None, RecurringTaskPeriod.QUARTERLY)
+                ].to_user_score(),
+                best_lifetime_yearly_score=best_by_spec[
+                    (None, RecurringTaskPeriod.YEARLY)
+                ].to_user_score(),
             ),
         )
-
-    async def _update_current_stats(
-        self,
-        ctx: DomainContext,
-        period: RecurringTaskPeriod | None,
-        uow: DomainUnitOfWork,
-        score_log: ScoreLog,
-        score_log_entry: ScoreLogEntry,
-    ) -> ScoreStats:
-        timeline = infer_timeline(period, ctx.action_timestamp)
-        score_stats = await uow.get(ScoreStatsRepository).load_by_key_optional(
-            (score_log.ref_id, period, timeline)
-        )
-
-        if score_stats is None:
-            score_stats = ScoreStats.new_score_stats(
-                ctx,
-                score_log.ref_id,
-                period,
-                timeline,
-            ).merge_score(
-                ctx,
-                score_log_entry,
-            )
-            score_stats = await uow.get(ScoreStatsRepository).create(score_stats)
-        else:
-            score_stats = score_stats.merge_score(
-                ctx,
-                score_log_entry,
-            )
-            score_stats = await uow.get(ScoreStatsRepository).save(score_stats)
-
-        return score_stats
-
-    async def _update_best(
-        self,
-        ctx: DomainContext,
-        period: RecurringTaskPeriod | None,
-        sub_period: RecurringTaskPeriod,
-        score_stats: ScoreStats,
-        uow: DomainUnitOfWork,
-        score_log: ScoreLog,
-    ) -> ScorePeriodBest:
-        timeline = infer_timeline(period, ctx.action_timestamp)
-        score_period_best = await uow.get(
-            ScorePeriodBestRepository
-        ).load_by_key_optional((score_log.ref_id, period, timeline, sub_period))
-
-        if score_period_best is None:
-            score_period_best = ScorePeriodBest.new_score_period_best(
-                ctx,
-                score_log.ref_id,
-                period,
-                timeline,
-                sub_period,
-            ).update_to_max(ctx, score_stats)
-            score_period_best = await uow.get(ScorePeriodBestRepository).create(
-                score_period_best
-            )
-        else:
-            score_period_best = score_period_best.update_to_max(
-                ctx,
-                score_stats,
-            )
-            score_period_best = await uow.get(ScorePeriodBestRepository).save(
-                score_period_best
-            )
-
-        return score_period_best

--- a/src/core/jupiter/core/habits/impl/postgres_repository.py
+++ b/src/core/jupiter/core/habits/impl/postgres_repository.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     select,
     update,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -177,6 +178,27 @@ class PostgresHabitStreakMarkRepository(
         result = await self._connection.execute(query)
         if result.rowcount == 0:
             await self.create(habit_streak_mark)
+
+    async def upsert_all(self, habit_streak_marks: list[HabitStreakMark]) -> None:
+        """Upsert a batch of habit streak marks in a single statement."""
+        if not habit_streak_marks:
+            return
+        rows = [
+            cast(
+                Mapping[str, RealmThing],
+                self._realm_codec_registry.db_encode(habit_streak_mark),
+            )
+            for habit_streak_mark in habit_streak_marks
+        ]
+        insert_stmt = pg_insert(self._habit_streak_mark_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["habit_ref_id", "date"],
+            set_={
+                "statuses": insert_stmt.excluded.statuses,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
 
     async def find_all_between_dates(
         self, habit_ref_id: EntityId, start_date: ADate, end_date: ADate

--- a/src/core/jupiter/core/habits/impl/sqlite_repository.py
+++ b/src/core/jupiter/core/habits/impl/sqlite_repository.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     select,
     update,
 )
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 
@@ -177,6 +178,27 @@ class SqliteHabitStreakMarkRepository(
         result = await self._connection.execute(query)
         if result.rowcount == 0:
             await self.create(habit_streak_mark)
+
+    async def upsert_all(self, habit_streak_marks: list[HabitStreakMark]) -> None:
+        """Upsert a batch of habit streak marks in a single statement."""
+        if not habit_streak_marks:
+            return
+        rows = [
+            cast(
+                Mapping[str, RealmThing],
+                self._realm_codec_registry.db_encode(habit_streak_mark),
+            )
+            for habit_streak_mark in habit_streak_marks
+        ]
+        insert_stmt = sqlite_insert(self._habit_streak_mark_table).values(rows)
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["habit_ref_id", "date"],
+            set_={
+                "statuses": insert_stmt.excluded.statuses,
+                "last_modified_time": insert_stmt.excluded.last_modified_time,
+            },
+        )
+        await self._connection.execute(upsert_stmt)
 
     async def find_all_between_dates(
         self, habit_ref_id: EntityId, start_date: ADate, end_date: ADate

--- a/src/core/jupiter/core/habits/service/streak_recorder.py
+++ b/src/core/jupiter/core/habits/service/streak_recorder.py
@@ -36,16 +36,20 @@ class HabitStreakRecorderService:
 
         statuses = {inbox_task.ref_id: inbox_task.status for inbox_task in inbox_tasks}
 
+        habit_streak_marks = []
         start_date = schedule.first_day
         while start_date <= schedule.end_day:
-            habit_streak_mark = HabitStreakMark.new_mark(
-                ctx=ctx,
-                habit_ref_id=habit.ref_id,
-                date=start_date,
-                statuses=statuses,
+            habit_streak_marks.append(
+                HabitStreakMark.new_mark(
+                    ctx=ctx,
+                    habit_ref_id=habit.ref_id,
+                    date=start_date,
+                    statuses=statuses,
+                )
             )
-            await uow.get(HabitStreakMarkRepository).upsert(habit_streak_mark)
             start_date = start_date.add_days(1)
+
+        await uow.get(HabitStreakMarkRepository).upsert_all(habit_streak_marks)
 
     async def update_with_status(
         self,
@@ -61,25 +65,37 @@ class HabitStreakRecorderService:
             right_now=cast(Timestamp, inbox_task.recurring_gen_right_now),
         )
 
+        existing_marks_by_date = {
+            habit_streak_mark.date: habit_streak_mark
+            for habit_streak_mark in await uow.get(
+                HabitStreakMarkRepository
+            ).find_all_between_dates(
+                habit.ref_id, schedule.first_day, schedule.end_day
+            )
+        }
+
+        habit_streak_marks = []
         start_date = schedule.first_day
         while start_date <= schedule.end_day:
-            habit_streak_mark = await uow.get(
-                HabitStreakMarkRepository
-            ).load_by_key_optional((habit.ref_id, start_date))
-            if habit_streak_mark is None:
-                habit_streak_mark = HabitStreakMark.new_mark(
-                    ctx=ctx,
-                    habit_ref_id=habit.ref_id,
-                    date=start_date,
-                    statuses={inbox_task.ref_id: inbox_task.status},
+            existing_mark = existing_marks_by_date.get(start_date)
+            if existing_mark is None:
+                habit_streak_marks.append(
+                    HabitStreakMark.new_mark(
+                        ctx=ctx,
+                        habit_ref_id=habit.ref_id,
+                        date=start_date,
+                        statuses={inbox_task.ref_id: inbox_task.status},
+                    )
                 )
             else:
-                habit_streak_mark = habit_streak_mark.update_status(
-                    ctx, inbox_task.ref_id, inbox_task.status
+                habit_streak_marks.append(
+                    existing_mark.update_status(
+                        ctx, inbox_task.ref_id, inbox_task.status
+                    )
                 )
-
-            await uow.get(HabitStreakMarkRepository).upsert(habit_streak_mark)
             start_date = start_date.add_days(1)
+
+        await uow.get(HabitStreakMarkRepository).upsert_all(habit_streak_marks)
 
     async def remove_with_status(
         self,
@@ -95,20 +111,16 @@ class HabitStreakRecorderService:
             right_now=cast(Timestamp, inbox_task.recurring_gen_right_now),
         )
 
-        start_date = schedule.first_day
-        while start_date <= schedule.end_day:
-            habit_streak_mark = await uow.get(
-                HabitStreakMarkRepository
-            ).load_by_key_optional((habit.ref_id, start_date))
-            if habit_streak_mark is None:
-                continue
-            else:
-                habit_streak_mark = habit_streak_mark.remove_status(
-                    ctx, inbox_task.ref_id
-                )
+        existing_marks = await uow.get(HabitStreakMarkRepository).find_all_between_dates(
+            habit.ref_id, schedule.first_day, schedule.end_day
+        )
 
-            await uow.get(HabitStreakMarkRepository).upsert(habit_streak_mark)
-            start_date = start_date.add_days(1)
+        habit_streak_marks = [
+            existing_mark.remove_status(ctx, inbox_task.ref_id)
+            for existing_mark in existing_marks
+        ]
+
+        await uow.get(HabitStreakMarkRepository).upsert_all(habit_streak_marks)
 
     async def remove_all(
         self,

--- a/src/core/jupiter/core/habits/streak_mark.py
+++ b/src/core/jupiter/core/habits/streak_mark.py
@@ -76,6 +76,10 @@ class HabitStreakMarkRepository(
         """Upsert a habit streak mark."""
 
     @abc.abstractmethod
+    async def upsert_all(self, habit_streak_marks: list[HabitStreakMark]) -> None:
+        """Upsert a batch of habit streak marks in a single statement."""
+
+    @abc.abstractmethod
     async def find_all_between_dates(
         self, habit_ref_id: EntityId, start_date: ADate, end_date: ADate
     ) -> list[HabitStreakMark]:


### PR DESCRIPTION
## Summary
This PR optimizes database operations in the gamification and habits modules by replacing multiple individual read-then-write operations with batched queries. This reduces the number of database round trips and improves performance when recording scores and updating habit streak marks.

## Key Changes

### Gamification Score Recording
- **Removed `asyncio.gather()` pattern**: Eliminated the use of `asyncio.gather()` for concurrent individual stat updates in `record_task()`, which was performing separate read-then-write operations per period
- **Implemented batch reads**: Added `find_all_for_keys()` method to `ScoreStatsRepository` and `ScorePeriodBestRepository` to fetch all required records in a single query
- **Implemented batch writes**: Added `upsert_all()` method to both repositories to update multiple records in a single statement using database-native upsert operations
- **Refactored service logic**: Consolidated the update logic in `record_task()` to build dictionaries of stats and best scores in memory, then perform single batch operations
- **Removed helper methods**: Deleted `_update_current_stats()` and `_update_best()` methods as their logic is now inlined in the main method

### Habit Streak Mark Updates
- **Batch upsert operations**: Modified `streak_recorder.py` to collect all `HabitStreakMark` objects before upserting them in a single batch operation
- **Optimized `upsert()` method**: Added `upsert_all()` to `HabitStreakMarkRepository` for batch operations
- **Refactored update methods**: Updated `upsert()`, `update_with_status()`, and `remove_with_status()` to use batch operations instead of per-item updates

### Repository Implementations
- **PostgreSQL**: Added `find_all_for_keys()` and `upsert_all()` implementations using PostgreSQL's native `ON CONFLICT DO UPDATE` syntax
- **SQLite**: Added equivalent implementations using SQLite's `ON CONFLICT DO UPDATE` syntax
- **Abstract interfaces**: Updated repository abstract base classes to define the new batch operation methods

## Implementation Details
- Batch reads use `OR` conditions to fetch multiple records matching different natural keys in a single query
- Batch writes use database-native upsert operations (PostgreSQL's `pg_insert` and SQLite's `sqlite_insert`) for atomic updates
- The refactored code maintains the same business logic while reducing database round trips from O(n) to O(1) for both reads and writes
- Removed unused `asyncio` import from `record_score.py`

https://claude.ai/code/session_017yCitJGdDS6sQrmSPqw78u