### PR TITLE
Add index on inbox_task.owner column for query performance

### DIFF
--- a/src/core/migrations/postgres/versions/2026_08_11_16_30_inbox_task_owner_index.py
+++ b/src/core/migrations/postgres/versions/2026_08_11_16_30_inbox_task_owner_index.py
@@ -1,0 +1,26 @@
+"""inbox task owner index
+
+Revision ID: d70d07199f1d
+Revises: 59b73a997ea0
+Create Date: 2026-08-11 16:30:00.000000
+
+"""
+
+from alembic import op
+
+revision = "d70d07199f1d"
+down_revision = "59b73a997ea0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX ix_inbox_task_owner ON inbox_task (owner)
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX ix_inbox_task_owner")

--- a/src/core/migrations/sqlite/versions/2026_08_11_16_30_inbox_task_owner_index.py
+++ b/src/core/migrations/sqlite/versions/2026_08_11_16_30_inbox_task_owner_index.py
@@ -1,0 +1,26 @@
+"""inbox task owner index
+
+Revision ID: d70d07199f1d
+Revises: 59b73a997ea0
+Create Date: 2026-08-11 16:30:00.000000
+
+"""
+
+from alembic import op
+
+revision = "d70d07199f1d"
+down_revision = "59b73a997ea0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX ix_inbox_task_owner ON inbox_task (owner)
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX ix_inbox_task_owner")


### PR DESCRIPTION
## Summary
This PR adds a database index on the `owner` column of the `inbox_task` table to improve query performance for lookups and filtering by task owner.

## Key Changes
- Created new database migration for both PostgreSQL and SQLite with revision ID `d70d07199f1d`
- Added `ix_inbox_task_owner` index on the `inbox_task(owner)` column
- Included corresponding downgrade logic to drop the index if needed

## Implementation Details
- Migration files are created for both supported database backends (PostgreSQL and SQLite) with identical index creation logic
- The index follows the naming convention `ix_<table>_<column>`
- Upgrade path creates the index; downgrade path safely removes it
- This change should improve performance for queries filtering or joining on the `owner` field

https://claude.ai/code/session_01CCZUhvbzp2KsXhCgzXYPDJ