### PR TITLE
Add time plan activity association for habits, chores, and todo tasks

### DIFF
--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_chore_with_plan.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_chore_with_plan.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_chore_with_plan_args import TimePlanAssociateChoreWithPlanArgs
+from ...models.time_plan_associate_chore_with_plan_result import TimePlanAssociateChoreWithPlanResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateChoreWithPlanArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-chore-with-plan",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateChoreWithPlanResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateChoreWithPlanResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateChoreWithPlanResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateChoreWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateChoreWithPlanResult]:
+    """Use case for creating activities starting from a chore.
+
+    Args:
+        body (TimePlanAssociateChoreWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateChoreWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateChoreWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateChoreWithPlanResult | None:
+    """Use case for creating activities starting from a chore.
+
+    Args:
+        body (TimePlanAssociateChoreWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateChoreWithPlanResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateChoreWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateChoreWithPlanResult]:
+    """Use case for creating activities starting from a chore.
+
+    Args:
+        body (TimePlanAssociateChoreWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateChoreWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateChoreWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateChoreWithPlanResult | None:
+    """Use case for creating activities starting from a chore.
+
+    Args:
+        body (TimePlanAssociateChoreWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateChoreWithPlanResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_habit_with_plan.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_habit_with_plan.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_habit_with_plan_args import TimePlanAssociateHabitWithPlanArgs
+from ...models.time_plan_associate_habit_with_plan_result import TimePlanAssociateHabitWithPlanResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateHabitWithPlanArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-habit-with-plan",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateHabitWithPlanResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateHabitWithPlanResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateHabitWithPlanResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateHabitWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateHabitWithPlanResult]:
+    """Use case for creating activities starting from a habit.
+
+    Args:
+        body (TimePlanAssociateHabitWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateHabitWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateHabitWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateHabitWithPlanResult | None:
+    """Use case for creating activities starting from a habit.
+
+    Args:
+        body (TimePlanAssociateHabitWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateHabitWithPlanResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateHabitWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateHabitWithPlanResult]:
+    """Use case for creating activities starting from a habit.
+
+    Args:
+        body (TimePlanAssociateHabitWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateHabitWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateHabitWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateHabitWithPlanResult | None:
+    """Use case for creating activities starting from a habit.
+
+    Args:
+        body (TimePlanAssociateHabitWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateHabitWithPlanResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_todo_task_with_plan.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_todo_task_with_plan.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_todo_task_with_plan_args import TimePlanAssociateTodoTaskWithPlanArgs
+from ...models.time_plan_associate_todo_task_with_plan_result import TimePlanAssociateTodoTaskWithPlanResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateTodoTaskWithPlanArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-todo-task-with-plan",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateTodoTaskWithPlanResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateTodoTaskWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult]:
+    """Use case for creating activities starting from a todo task.
+
+    Args:
+        body (TimePlanAssociateTodoTaskWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateTodoTaskWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult | None:
+    """Use case for creating activities starting from a todo task.
+
+    Args:
+        body (TimePlanAssociateTodoTaskWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateTodoTaskWithPlanArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult]:
+    """Use case for creating activities starting from a todo task.
+
+    Args:
+        body (TimePlanAssociateTodoTaskWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateTodoTaskWithPlanArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult | None:
+    """Use case for creating activities starting from a todo task.
+
+    Args:
+        body (TimePlanAssociateTodoTaskWithPlanArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateTodoTaskWithPlanResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_chores.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_chores.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_with_chores_args import TimePlanAssociateWithChoresArgs
+from ...models.time_plan_associate_with_chores_result import TimePlanAssociateWithChoresResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateWithChoresArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-with-chores",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateWithChoresResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateWithChoresResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateWithChoresResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithChoresArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithChoresResult]:
+    """Use case for creating activities starting from chores.
+
+    Args:
+        body (TimePlanAssociateWithChoresArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithChoresResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithChoresArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithChoresResult | None:
+    """Use case for creating activities starting from chores.
+
+    Args:
+        body (TimePlanAssociateWithChoresArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithChoresResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithChoresArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithChoresResult]:
+    """Use case for creating activities starting from chores.
+
+    Args:
+        body (TimePlanAssociateWithChoresArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithChoresResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithChoresArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithChoresResult | None:
+    """Use case for creating activities starting from chores.
+
+    Args:
+        body (TimePlanAssociateWithChoresArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithChoresResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_habits.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_habits.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_with_habits_args import TimePlanAssociateWithHabitsArgs
+from ...models.time_plan_associate_with_habits_result import TimePlanAssociateWithHabitsResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateWithHabitsArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-with-habits",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateWithHabitsResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateWithHabitsResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateWithHabitsResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithHabitsArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithHabitsResult]:
+    """Use case for creating activities starting from habits.
+
+    Args:
+        body (TimePlanAssociateWithHabitsArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithHabitsResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithHabitsArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithHabitsResult | None:
+    """Use case for creating activities starting from habits.
+
+    Args:
+        body (TimePlanAssociateWithHabitsArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithHabitsResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithHabitsArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithHabitsResult]:
+    """Use case for creating activities starting from habits.
+
+    Args:
+        body (TimePlanAssociateWithHabitsArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithHabitsResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithHabitsArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithHabitsResult | None:
+    """Use case for creating activities starting from habits.
+
+    Args:
+        body (TimePlanAssociateWithHabitsArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithHabitsResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_todo_tasks.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/api/time_plans/time_plan_associate_with_todo_tasks.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.time_plan_associate_with_todo_tasks_args import TimePlanAssociateWithTodoTasksArgs
+from ...models.time_plan_associate_with_todo_tasks_result import TimePlanAssociateWithTodoTasksResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TimePlanAssociateWithTodoTasksArgs | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/time-plan-associate-with-todo-tasks",
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | TimePlanAssociateWithTodoTasksResult | None:
+    if response.status_code == 200:
+        response_200 = TimePlanAssociateWithTodoTasksResult.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 406:
+        response_406 = ErrorResponse.from_dict(response.json())
+
+        return response_406
+
+    if response.status_code == 409:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 410:
+        response_410 = ErrorResponse.from_dict(response.json())
+
+        return response_410
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 426:
+        response_426 = ErrorResponse.from_dict(response.json())
+
+        return response_426
+
+    if response.status_code == 429:
+        response_429 = ErrorResponse.from_dict(response.json())
+
+        return response_429
+
+    if response.status_code == 502:
+        response_502 = ErrorResponse.from_dict(response.json())
+
+        return response_502
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | TimePlanAssociateWithTodoTasksResult]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithTodoTasksArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithTodoTasksResult]:
+    """Use case for creating activities starting from todo tasks.
+
+    Args:
+        body (TimePlanAssociateWithTodoTasksArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithTodoTasksResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithTodoTasksArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithTodoTasksResult | None:
+    """Use case for creating activities starting from todo tasks.
+
+    Args:
+        body (TimePlanAssociateWithTodoTasksArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithTodoTasksResult
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithTodoTasksArgs | Unset = UNSET,
+) -> Response[ErrorResponse | TimePlanAssociateWithTodoTasksResult]:
+    """Use case for creating activities starting from todo tasks.
+
+    Args:
+        body (TimePlanAssociateWithTodoTasksArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | TimePlanAssociateWithTodoTasksResult]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: TimePlanAssociateWithTodoTasksArgs | Unset = UNSET,
+) -> ErrorResponse | TimePlanAssociateWithTodoTasksResult | None:
+    """Use case for creating activities starting from todo tasks.
+
+    Args:
+        body (TimePlanAssociateWithTodoTasksArgs | Unset): Args.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | TimePlanAssociateWithTodoTasksResult
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_activity_target.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_activity_target.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class TimePlanActivityTarget(str, Enum):
+    BIG_PLAN = "big-plan"
+    CHORE = "chore"
+    HABIT = "habit"
+    INBOX_TASK = "inbox-task"
+    TODO_TASK = "todo-task"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_chore_with_plan_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_chore_with_plan_args.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateChoreWithPlanArgs")
+
+
+@_attrs_define
+class TimePlanAssociateChoreWithPlanArgs:
+    """Args.
+
+    Attributes:
+        chore_ref_id (str): A generic entity id.
+        time_plan_ref_ids (list[str]):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    chore_ref_id: str
+    time_plan_ref_ids: list[str]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        chore_ref_id = self.chore_ref_id
+
+        time_plan_ref_ids = self.time_plan_ref_ids
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "chore_ref_id": chore_ref_id,
+                "time_plan_ref_ids": time_plan_ref_ids,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        chore_ref_id = d.pop("chore_ref_id")
+
+        time_plan_ref_ids = cast(list[str], d.pop("time_plan_ref_ids"))
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_chore_with_plan_args = cls(
+            chore_ref_id=chore_ref_id,
+            time_plan_ref_ids=time_plan_ref_ids,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_chore_with_plan_args.additional_properties = d
+        return time_plan_associate_chore_with_plan_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_chore_with_plan_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_chore_with_plan_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateChoreWithPlanResult")
+
+
+@_attrs_define
+class TimePlanAssociateChoreWithPlanResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_chore_with_plan_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_chore_with_plan_result.additional_properties = d
+        return time_plan_associate_chore_with_plan_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_habit_with_plan_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_habit_with_plan_args.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateHabitWithPlanArgs")
+
+
+@_attrs_define
+class TimePlanAssociateHabitWithPlanArgs:
+    """Args.
+
+    Attributes:
+        habit_ref_id (str): A generic entity id.
+        time_plan_ref_ids (list[str]):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    habit_ref_id: str
+    time_plan_ref_ids: list[str]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        habit_ref_id = self.habit_ref_id
+
+        time_plan_ref_ids = self.time_plan_ref_ids
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "habit_ref_id": habit_ref_id,
+                "time_plan_ref_ids": time_plan_ref_ids,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        habit_ref_id = d.pop("habit_ref_id")
+
+        time_plan_ref_ids = cast(list[str], d.pop("time_plan_ref_ids"))
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_habit_with_plan_args = cls(
+            habit_ref_id=habit_ref_id,
+            time_plan_ref_ids=time_plan_ref_ids,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_habit_with_plan_args.additional_properties = d
+        return time_plan_associate_habit_with_plan_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_habit_with_plan_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_habit_with_plan_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateHabitWithPlanResult")
+
+
+@_attrs_define
+class TimePlanAssociateHabitWithPlanResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_habit_with_plan_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_habit_with_plan_result.additional_properties = d
+        return time_plan_associate_habit_with_plan_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_todo_task_with_plan_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_todo_task_with_plan_args.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateTodoTaskWithPlanArgs")
+
+
+@_attrs_define
+class TimePlanAssociateTodoTaskWithPlanArgs:
+    """Args.
+
+    Attributes:
+        todo_task_ref_id (str): A generic entity id.
+        time_plan_ref_ids (list[str]):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    todo_task_ref_id: str
+    time_plan_ref_ids: list[str]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        todo_task_ref_id = self.todo_task_ref_id
+
+        time_plan_ref_ids = self.time_plan_ref_ids
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "todo_task_ref_id": todo_task_ref_id,
+                "time_plan_ref_ids": time_plan_ref_ids,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        todo_task_ref_id = d.pop("todo_task_ref_id")
+
+        time_plan_ref_ids = cast(list[str], d.pop("time_plan_ref_ids"))
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_todo_task_with_plan_args = cls(
+            todo_task_ref_id=todo_task_ref_id,
+            time_plan_ref_ids=time_plan_ref_ids,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_todo_task_with_plan_args.additional_properties = d
+        return time_plan_associate_todo_task_with_plan_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_todo_task_with_plan_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_todo_task_with_plan_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateTodoTaskWithPlanResult")
+
+
+@_attrs_define
+class TimePlanAssociateTodoTaskWithPlanResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_todo_task_with_plan_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_todo_task_with_plan_result.additional_properties = d
+        return time_plan_associate_todo_task_with_plan_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_chores_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_chores_args.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateWithChoresArgs")
+
+
+@_attrs_define
+class TimePlanAssociateWithChoresArgs:
+    """Args.
+
+    Attributes:
+        ref_id (str): A generic entity id.
+        chore_ref_ids (list[str]):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    ref_id: str
+    chore_ref_ids: list[str]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        ref_id = self.ref_id
+
+        chore_ref_ids = self.chore_ref_ids
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "ref_id": ref_id,
+                "chore_ref_ids": chore_ref_ids,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        ref_id = d.pop("ref_id")
+
+        chore_ref_ids = cast(list[str], d.pop("chore_ref_ids"))
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_with_chores_args = cls(
+            ref_id=ref_id,
+            chore_ref_ids=chore_ref_ids,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_with_chores_args.additional_properties = d
+        return time_plan_associate_with_chores_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_chores_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_chores_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateWithChoresResult")
+
+
+@_attrs_define
+class TimePlanAssociateWithChoresResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_with_chores_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_with_chores_result.additional_properties = d
+        return time_plan_associate_with_chores_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_habits_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_habits_args.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateWithHabitsArgs")
+
+
+@_attrs_define
+class TimePlanAssociateWithHabitsArgs:
+    """Args.
+
+    Attributes:
+        ref_id (str): A generic entity id.
+        habit_ref_ids (list[str]):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    ref_id: str
+    habit_ref_ids: list[str]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        ref_id = self.ref_id
+
+        habit_ref_ids = self.habit_ref_ids
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "ref_id": ref_id,
+                "habit_ref_ids": habit_ref_ids,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        ref_id = d.pop("ref_id")
+
+        habit_ref_ids = cast(list[str], d.pop("habit_ref_ids"))
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_with_habits_args = cls(
+            ref_id=ref_id,
+            habit_ref_ids=habit_ref_ids,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_with_habits_args.additional_properties = d
+        return time_plan_associate_with_habits_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_habits_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_habits_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateWithHabitsResult")
+
+
+@_attrs_define
+class TimePlanAssociateWithHabitsResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_with_habits_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_with_habits_result.additional_properties = d
+        return time_plan_associate_with_habits_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_todo_tasks_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_todo_tasks_args.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_plan_activity_feasability import TimePlanActivityFeasability
+from ..models.time_plan_activity_kind import TimePlanActivityKind
+
+T = TypeVar("T", bound="TimePlanAssociateWithTodoTasksArgs")
+
+
+@_attrs_define
+class TimePlanAssociateWithTodoTasksArgs:
+    """Args.
+
+    Attributes:
+        ref_id (str): A generic entity id.
+        todo_task_ref_ids (list[str]):
+        override_existing_dates (bool):
+        kind (TimePlanActivityKind): The kind of a time plan activity.
+        feasability (TimePlanActivityFeasability): The feasability of a particular activity within a plan.
+    """
+
+    ref_id: str
+    todo_task_ref_ids: list[str]
+    override_existing_dates: bool
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        ref_id = self.ref_id
+
+        todo_task_ref_ids = self.todo_task_ref_ids
+
+        override_existing_dates = self.override_existing_dates
+
+        kind = self.kind.value
+
+        feasability = self.feasability.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "ref_id": ref_id,
+                "todo_task_ref_ids": todo_task_ref_ids,
+                "override_existing_dates": override_existing_dates,
+                "kind": kind,
+                "feasability": feasability,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        ref_id = d.pop("ref_id")
+
+        todo_task_ref_ids = cast(list[str], d.pop("todo_task_ref_ids"))
+
+        override_existing_dates = d.pop("override_existing_dates")
+
+        kind = TimePlanActivityKind(d.pop("kind"))
+
+        feasability = TimePlanActivityFeasability(d.pop("feasability"))
+
+        time_plan_associate_with_todo_tasks_args = cls(
+            ref_id=ref_id,
+            todo_task_ref_ids=todo_task_ref_ids,
+            override_existing_dates=override_existing_dates,
+            kind=kind,
+            feasability=feasability,
+        )
+
+        time_plan_associate_with_todo_tasks_args.additional_properties = d
+        return time_plan_associate_with_todo_tasks_args
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_todo_tasks_result.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_plan_associate_with_todo_tasks_result.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.time_plan_activity import TimePlanActivity
+
+
+T = TypeVar("T", bound="TimePlanAssociateWithTodoTasksResult")
+
+
+@_attrs_define
+class TimePlanAssociateWithTodoTasksResult:
+    """Result.
+
+    Attributes:
+        new_time_plan_activities (list[TimePlanActivity]):
+    """
+
+    new_time_plan_activities: list[TimePlanActivity]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        new_time_plan_activities = []
+        for new_time_plan_activities_item_data in self.new_time_plan_activities:
+            new_time_plan_activities_item = new_time_plan_activities_item_data.to_dict()
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "new_time_plan_activities": new_time_plan_activities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_plan_activity import TimePlanActivity
+
+        d = dict(src_dict)
+        new_time_plan_activities = []
+        _new_time_plan_activities = d.pop("new_time_plan_activities")
+        for new_time_plan_activities_item_data in _new_time_plan_activities:
+            new_time_plan_activities_item = TimePlanActivity.from_dict(new_time_plan_activities_item_data)
+
+            new_time_plan_activities.append(new_time_plan_activities_item)
+
+        time_plan_associate_with_todo_tasks_result = cls(
+            new_time_plan_activities=new_time_plan_activities,
+        )
+
+        time_plan_associate_with_todo_tasks_result.additional_properties = d
+        return time_plan_associate_with_todo_tasks_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/ts/webapi-client/gen/models/TimePlanActivityTarget.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanActivityTarget.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * The kind of entity a time plan activity is aimed at.
+ */
+export enum TimePlanActivityTarget {
+    INBOX_TASK = 'inbox-task',
+    TODO_TASK = 'todo-task',
+    HABIT = 'habit',
+    CHORE = 'chore',
+    BIG_PLAN = 'big-plan',
+}
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateChoreWithPlanArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateChoreWithPlanArgs.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateChoreWithPlanArgs = {
+    chore_ref_id: EntityId;
+    time_plan_ref_ids: Array<EntityId>;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateChoreWithPlanResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateChoreWithPlanResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateChoreWithPlanResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateHabitWithPlanArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateHabitWithPlanArgs.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateHabitWithPlanArgs = {
+    habit_ref_id: EntityId;
+    time_plan_ref_ids: Array<EntityId>;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateHabitWithPlanResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateHabitWithPlanResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateHabitWithPlanResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateTodoTaskWithPlanArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateTodoTaskWithPlanArgs.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateTodoTaskWithPlanArgs = {
+    todo_task_ref_id: EntityId;
+    time_plan_ref_ids: Array<EntityId>;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateTodoTaskWithPlanResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateTodoTaskWithPlanResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateTodoTaskWithPlanResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithChoresArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithChoresArgs.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateWithChoresArgs = {
+    ref_id: EntityId;
+    chore_ref_ids: Array<EntityId>;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithChoresResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithChoresResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateWithChoresResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithHabitsArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithHabitsArgs.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateWithHabitsArgs = {
+    ref_id: EntityId;
+    habit_ref_ids: Array<EntityId>;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithHabitsResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithHabitsResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateWithHabitsResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithTodoTasksArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithTodoTasksArgs.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EntityId } from './EntityId';
+import type { TimePlanActivityFeasability } from './TimePlanActivityFeasability';
+import type { TimePlanActivityKind } from './TimePlanActivityKind';
+/**
+ * Args.
+ */
+export type TimePlanAssociateWithTodoTasksArgs = {
+    ref_id: EntityId;
+    todo_task_ref_ids: Array<EntityId>;
+    override_existing_dates: boolean;
+    kind: TimePlanActivityKind;
+    feasability: TimePlanActivityFeasability;
+};
+

--- a/gen/ts/webapi-client/gen/models/TimePlanAssociateWithTodoTasksResult.ts
+++ b/gen/ts/webapi-client/gen/models/TimePlanAssociateWithTodoTasksResult.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TimePlanActivity } from './TimePlanActivity';
+/**
+ * Result.
+ */
+export type TimePlanAssociateWithTodoTasksResult = {
+    new_time_plan_activities: Array<TimePlanActivity>;
+};
+

--- a/src/core/jupiter/core/chores/component/properties-editor.tsx
+++ b/src/core/jupiter/core/chores/component/properties-editor.tsx
@@ -1,0 +1,429 @@
+import type {
+  Aspect,
+  AspectSummary,
+  Chapter,
+  ChapterSummary,
+  Chore,
+  Contact,
+  Goal,
+  GoalSummary,
+  LifePlan,
+  MilestoneSummary,
+  Tag,
+  UserLight,
+} from "@jupiter/webapi-client";
+import { NamedEntityTag, WorkspaceFeature } from "@jupiter/webapi-client";
+import {
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+  Switch,
+} from "@mui/material";
+import { useMemo, useState } from "react";
+import { Launch as LaunchIcon } from "@mui/icons-material";
+
+import { aDateToDate } from "#/core/common/adate";
+import { entityLinkStd } from "#/core/common/entity-link";
+import { IsKeySelect } from "#/core/common/component/is-key-select";
+import { RecurringTaskGenParamsBlock } from "#/core/common/component/recurring-task-gen-params-block";
+import { ContactsEditor } from "#/core/common/sub/contacts/component/contacts-editor";
+import { TagsEditor } from "#/core/common/sub/tags/component/tags-editor";
+import type { SomeErrorNoData } from "#/core/infra/action-result";
+import { FieldError } from "#/core/infra/component/errors";
+import {
+  ActionSingle,
+  NavSingle,
+  SectionActions,
+} from "#/core/infra/component/section-actions";
+import { SectionCard } from "#/core/infra/component/section-card";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
+import { constructFieldName } from "#/core/infra/field-names";
+import type { TopLevelInfo } from "#/core/infra/top-level-context";
+import { LifePlanAssociations } from "#/core/life_plan/components/life-plan-associations";
+import { lifePlanBirthdayDate } from "#/core/life_plan/root";
+import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
+
+interface ChorePropertiesEditorProps {
+  title: string;
+  showLinkToChore?: boolean;
+  showGen?: boolean;
+  intentPrefix?: string;
+  namePrefix?: string;
+  topLevelInfo: TopLevelInfo;
+  lifePlan: LifePlan | null;
+  allAspects: AspectSummary[];
+  allChapters: ChapterSummary[];
+  allGoals: GoalSummary[];
+  allMilestones: MilestoneSummary[];
+  aspect?: Aspect | null;
+  chapter?: Chapter | null;
+  goal?: Goal | null;
+  allTags: Array<Tag>;
+  tags: Array<Tag>;
+  allContacts: Array<Contact>;
+  contacts: Array<Contact>;
+  inputsEnabled: boolean;
+  entityOwner?: UserLight;
+  chore: Chore;
+  actionData?: SomeErrorNoData;
+}
+
+export function ChorePropertiesEditor(props: ChorePropertiesEditorProps) {
+  const isBigScreen = useBigScreen();
+  const birthdayDate = props.lifePlan
+    ? lifePlanBirthdayDate(props.lifePlan)
+    : null;
+  const [selectedAspectRefId, setSelectedAspectRefId] = useState(
+    props.chore.aspect_ref_id,
+  );
+  const showGen = props.showGen ?? true;
+
+  // Shared chores may reference life-plan entities from another workspace.
+  // Include those for display, but keep associations read-only.
+  const lifePlanAssociationsInWorkspace = props.allAspects.some(
+    (aspect) => aspect.ref_id === props.chore.aspect_ref_id,
+  );
+  const allAspects = useMemo(
+    () =>
+      mergeForeignAspectSummary(
+        props.allAspects,
+        props.aspect,
+        props.chore.aspect_ref_id,
+      ),
+    [props.allAspects, props.aspect, props.chore.aspect_ref_id],
+  );
+  const allChapters = useMemo(
+    () =>
+      mergeForeignChapterSummary(
+        props.allChapters,
+        props.chapter,
+        props.chore.chapter_ref_id,
+      ),
+    [props.allChapters, props.chapter, props.chore.chapter_ref_id],
+  );
+  const allGoals = useMemo(
+    () =>
+      mergeForeignGoalSummary(
+        props.allGoals,
+        props.goal,
+        props.chore.goal_ref_id,
+      ),
+    [props.allGoals, props.goal, props.chore.goal_ref_id],
+  );
+
+  return (
+    <SectionCard
+      title={props.title}
+      actions={
+        <SectionActions
+          id="chore-properties"
+          topLevelInfo={props.topLevelInfo}
+          inputsEnabled={props.inputsEnabled}
+          actions={[
+            ActionSingle({
+              id: "chore-update",
+              text: "Save",
+              value: constructIntentName(props.intentPrefix, "update"),
+              highlight: true,
+            }),
+            ...(showGen
+              ? [
+                  ActionSingle({
+                    text: "Gen",
+                    value: constructIntentName(props.intentPrefix, "gen"),
+                    highlight: false,
+                  }),
+                ]
+              : []),
+          ]}
+          extraActions={
+            props.showLinkToChore
+              ? [
+                  NavSingle({
+                    text: "Chore",
+                    link: `/app/workspace/chores/${props.chore.ref_id}`,
+                    icon: <LaunchIcon />,
+                  }),
+                ]
+              : undefined
+          }
+        />
+      }
+    >
+      <input
+        type="hidden"
+        name={constructFieldName(props.namePrefix, "refId")}
+        value={props.chore.ref_id}
+      />
+
+      <Stack direction="row" useFlexGap spacing={1}>
+        <FormControl fullWidth sx={{ flexGrow: 3 }}>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput
+            label="Name"
+            name={constructFieldName(props.namePrefix, "name")}
+            readOnly={!props.inputsEnabled}
+            disabled={!props.inputsEnabled}
+            defaultValue={props.chore.name}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/name" />
+        </FormControl>
+
+        <FormControl sx={{ flexGrow: 1 }}>
+          <IsKeySelect
+            name={constructFieldName(props.namePrefix, "isKey")}
+            defaultValue={props.chore.is_key}
+            inputsEnabled={props.inputsEnabled}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/is_key" />
+        </FormControl>
+      </Stack>
+
+      <Stack direction={isBigScreen ? "row" : "column"} useFlexGap spacing={1}>
+        <FormControl fullWidth sx={{ flexGrow: 2 }}>
+          <TagsEditor
+            name="tags"
+            aloneOnLine
+            allTags={props.allTags}
+            linkedTags={props.tags}
+            defaultValue={props.tags.map((tag) => tag.ref_id)}
+            inputsEnabled={props.inputsEnabled}
+            entityOwnerRefId={props.entityOwner?.ref_id}
+            owner={entityLinkStd(NamedEntityTag.CHORE, props.chore.ref_id)}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/tags_names" />
+        </FormControl>
+
+        <FormControl fullWidth sx={{ flexGrow: 2 }}>
+          <ContactsEditor
+            name="contacts_names"
+            aloneOnLine
+            allContacts={props.allContacts}
+            linkedContacts={props.contacts}
+            defaultValue={props.contacts.map((contact) => contact.ref_id)}
+            inputsEnabled={props.inputsEnabled}
+            entityOwnerRefId={props.entityOwner?.ref_id}
+            owner={entityLinkStd(NamedEntityTag.CHORE, props.chore.ref_id)}
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/contacts_names"
+          />
+        </FormControl>
+      </Stack>
+
+      {isWorkspaceFeatureAvailable(
+        props.topLevelInfo.workspace,
+        WorkspaceFeature.LIFE_PLAN,
+      ) && (
+        <FormControl fullWidth>
+          <LifePlanAssociations
+            inputsEnabled={
+              props.inputsEnabled && lifePlanAssociationsInWorkspace
+            }
+            aspectName={constructFieldName(props.namePrefix, "aspect")}
+            chapterName={constructFieldName(props.namePrefix, "chapter")}
+            goalName={constructFieldName(props.namePrefix, "goal")}
+            allAspects={allAspects}
+            aspectValue={selectedAspectRefId}
+            onAspectChange={setSelectedAspectRefId}
+            aspectDefaultValue={props.chore.aspect_ref_id}
+            allChapters={allChapters}
+            chapterDefaultValue={props.chore.chapter_ref_id}
+            allGoals={allGoals}
+            goalDefaultValue={props.chore.goal_ref_id}
+            birthday={birthdayDate!}
+            today={aDateToDate(props.topLevelInfo.today)}
+            allMilestones={props.allMilestones}
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/aspect_ref_id"
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/chapter_ref_id"
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/goal_ref_id"
+          />
+        </FormControl>
+      )}
+
+      <RecurringTaskGenParamsBlock
+        inputsEnabled={props.inputsEnabled}
+        allowSkipRule
+        namePrefix={props.namePrefix}
+        period={props.chore.gen_params.period}
+        eisen={props.chore.gen_params.eisen}
+        difficulty={props.chore.gen_params.difficulty}
+        actionableFromDay={props.chore.gen_params.actionable_from_day}
+        actionableFromMonth={props.chore.gen_params.actionable_from_month}
+        dueAtDay={props.chore.gen_params.due_at_day}
+        dueAtMonth={props.chore.gen_params.due_at_month}
+        skipRule={props.chore.gen_params.skip_rule}
+        actionData={props.actionData}
+      />
+
+      <FormControl fullWidth>
+        <FormControlLabel
+          control={
+            <Switch
+              name={constructFieldName(props.namePrefix, "mustDo")}
+              readOnly={!props.inputsEnabled}
+              disabled={!props.inputsEnabled}
+              defaultChecked={props.chore.must_do}
+            />
+          }
+          label="Must Do In Vacation"
+        />
+        <FieldError actionResult={props.actionData} fieldName="/must_do" />
+      </FormControl>
+
+      <Stack spacing={2} direction={isBigScreen ? "row" : "column"}>
+        <FormControl fullWidth>
+          <InputLabel id="startAtDate" shrink>
+            Start At Date [Optional]
+          </InputLabel>
+          <OutlinedInput
+            type="date"
+            notched
+            label="startAtDate"
+            name={constructFieldName(props.namePrefix, "startAtDate")}
+            readOnly={!props.inputsEnabled}
+            disabled={!props.inputsEnabled}
+            defaultValue={
+              props.chore.start_at_date
+                ? aDateToDate(props.chore.start_at_date).toFormat("yyyy-MM-dd")
+                : undefined
+            }
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/start_at_date"
+          />
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel id="endAtDate" shrink>
+            End At Date [Optional]
+          </InputLabel>
+          <OutlinedInput
+            type="date"
+            notched
+            label="endAtDate"
+            name={constructFieldName(props.namePrefix, "endAtDate")}
+            readOnly={!props.inputsEnabled}
+            disabled={!props.inputsEnabled}
+            defaultValue={
+              props.chore.end_at_date
+                ? aDateToDate(props.chore.end_at_date).toFormat("yyyy-MM-dd")
+                : undefined
+            }
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/end_at_date"
+          />
+        </FormControl>
+      </Stack>
+    </SectionCard>
+  );
+}
+
+function constructIntentName(
+  intentPrefix: string | undefined,
+  intent: string,
+): string {
+  if (!intentPrefix) {
+    return intent;
+  }
+  return `${intentPrefix}-${intent}`;
+}
+
+function mergeForeignAspectSummary(
+  allAspects: AspectSummary[],
+  aspect: Aspect | null | undefined,
+  aspectRefId: string,
+): AspectSummary[] {
+  if (allAspects.some((entry) => entry.ref_id === aspectRefId)) {
+    return allAspects;
+  }
+  if (
+    aspect === undefined ||
+    aspect === null ||
+    aspect.ref_id !== aspectRefId
+  ) {
+    return allAspects;
+  }
+  // Detach from the foreign parent chain so tree helpers can still render it.
+  return [
+    ...allAspects,
+    {
+      ref_id: aspect.ref_id,
+      parent_aspect_ref_id: null,
+      name: aspect.name,
+      order_of_child_aspects: [],
+    },
+  ];
+}
+
+function mergeForeignChapterSummary(
+  allChapters: ChapterSummary[],
+  chapter: Chapter | null | undefined,
+  chapterRefId: string | null | undefined,
+): ChapterSummary[] {
+  if (
+    chapterRefId === undefined ||
+    chapterRefId === null ||
+    allChapters.some((entry) => entry.ref_id === chapterRefId)
+  ) {
+    return allChapters;
+  }
+  if (
+    chapter === undefined ||
+    chapter === null ||
+    chapter.ref_id !== chapterRefId
+  ) {
+    return allChapters;
+  }
+  return [
+    ...allChapters,
+    {
+      ref_id: chapter.ref_id,
+      name: chapter.name,
+      start_date: chapter.start_date,
+      end_date: chapter.end_date,
+      aspect_ref_id: chapter.aspect_ref_id,
+    },
+  ];
+}
+
+function mergeForeignGoalSummary(
+  allGoals: GoalSummary[],
+  goal: Goal | null | undefined,
+  goalRefId: string | null | undefined,
+): GoalSummary[] {
+  if (
+    goalRefId === undefined ||
+    goalRefId === null ||
+    allGoals.some((entry) => entry.ref_id === goalRefId)
+  ) {
+    return allGoals;
+  }
+  if (goal === undefined || goal === null || goal.ref_id !== goalRefId) {
+    return allGoals;
+  }
+  return [
+    ...allGoals,
+    {
+      ref_id: goal.ref_id,
+      name: goal.name,
+      aspect_ref_id: goal.aspect_ref_id,
+      parent_goal_ref_id: goal.parent_goal_ref_id,
+    },
+  ];
+}

--- a/src/core/jupiter/core/habits/component/properties-editor.tsx
+++ b/src/core/jupiter/core/habits/component/properties-editor.tsx
@@ -1,0 +1,421 @@
+import type {
+  Aspect,
+  AspectSummary,
+  Chapter,
+  ChapterSummary,
+  Contact,
+  Goal,
+  GoalSummary,
+  Habit,
+  HabitRepeatsStrategy,
+  LifePlan,
+  MilestoneSummary,
+  Tag,
+  UserLight,
+} from "@jupiter/webapi-client";
+import {
+  NamedEntityTag,
+  RecurringTaskPeriod,
+  WorkspaceFeature,
+} from "@jupiter/webapi-client";
+import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
+import { useMemo, useState } from "react";
+import { Launch as LaunchIcon } from "@mui/icons-material";
+
+import { aDateToDate } from "#/core/common/adate";
+import { entityLinkStd } from "#/core/common/entity-link";
+import { IsKeySelect } from "#/core/common/component/is-key-select";
+import { RecurringTaskGenParamsBlock } from "#/core/common/component/recurring-task-gen-params-block";
+import { ContactsEditor } from "#/core/common/sub/contacts/component/contacts-editor";
+import { TagsEditor } from "#/core/common/sub/tags/component/tags-editor";
+import { HabitRepeatStrategySelect } from "#/core/habits/component/repeat-strategy-select";
+import type { SomeErrorNoData } from "#/core/infra/action-result";
+import { FieldError } from "#/core/infra/component/errors";
+import {
+  ActionSingle,
+  NavSingle,
+  SectionActions,
+} from "#/core/infra/component/section-actions";
+import { SectionCard } from "#/core/infra/component/section-card";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
+import { constructFieldName } from "#/core/infra/field-names";
+import type { TopLevelInfo } from "#/core/infra/top-level-context";
+import { LifePlanAssociations } from "#/core/life_plan/components/life-plan-associations";
+import { lifePlanBirthdayDate } from "#/core/life_plan/root";
+import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
+
+interface HabitPropertiesEditorProps {
+  title: string;
+  showLinkToHabit?: boolean;
+  showGen?: boolean;
+  intentPrefix?: string;
+  namePrefix?: string;
+  topLevelInfo: TopLevelInfo;
+  lifePlan: LifePlan | null;
+  allAspects: AspectSummary[];
+  allChapters: ChapterSummary[];
+  allGoals: GoalSummary[];
+  allMilestones: MilestoneSummary[];
+  aspect?: Aspect | null;
+  chapter?: Chapter | null;
+  goal?: Goal | null;
+  allTags: Array<Tag>;
+  tags: Array<Tag>;
+  allContacts: Array<Contact>;
+  contacts: Array<Contact>;
+  inputsEnabled: boolean;
+  entityOwner?: UserLight;
+  habit: Habit;
+  actionData?: SomeErrorNoData;
+}
+
+export function HabitPropertiesEditor(props: HabitPropertiesEditorProps) {
+  const isBigScreen = useBigScreen();
+  const birthdayDate = props.lifePlan
+    ? lifePlanBirthdayDate(props.lifePlan)
+    : null;
+  const [selectedAspectRefId, setSelectedAspectRefId] = useState(
+    props.habit.aspect_ref_id,
+  );
+  const [selectedPeriod, setSelectedPeriod] = useState(
+    props.habit.gen_params.period,
+  );
+  const [selectedRepeatsStrategy, setSelectedRepeatsStrategy] = useState<
+    HabitRepeatsStrategy | "none"
+  >(props.habit.repeats_strategy ?? "none");
+  const showGen = props.showGen ?? true;
+
+  // Shared habits may reference life-plan entities from another workspace.
+  // Include those for display, but keep associations read-only.
+  const lifePlanAssociationsInWorkspace = props.allAspects.some(
+    (aspect) => aspect.ref_id === props.habit.aspect_ref_id,
+  );
+  const allAspects = useMemo(
+    () =>
+      mergeForeignAspectSummary(
+        props.allAspects,
+        props.aspect,
+        props.habit.aspect_ref_id,
+      ),
+    [props.allAspects, props.aspect, props.habit.aspect_ref_id],
+  );
+  const allChapters = useMemo(
+    () =>
+      mergeForeignChapterSummary(
+        props.allChapters,
+        props.chapter,
+        props.habit.chapter_ref_id,
+      ),
+    [props.allChapters, props.chapter, props.habit.chapter_ref_id],
+  );
+  const allGoals = useMemo(
+    () =>
+      mergeForeignGoalSummary(
+        props.allGoals,
+        props.goal,
+        props.habit.goal_ref_id,
+      ),
+    [props.allGoals, props.goal, props.habit.goal_ref_id],
+  );
+
+  return (
+    <SectionCard
+      title={props.title}
+      actions={
+        <SectionActions
+          id="habit-properties"
+          topLevelInfo={props.topLevelInfo}
+          inputsEnabled={props.inputsEnabled}
+          actions={[
+            ActionSingle({
+              id: "habit-update",
+              text: "Save",
+              value: constructIntentName(props.intentPrefix, "update"),
+              highlight: true,
+            }),
+            ...(showGen
+              ? [
+                  ActionSingle({
+                    text: "Gen",
+                    value: constructIntentName(props.intentPrefix, "gen"),
+                    highlight: false,
+                  }),
+                ]
+              : []),
+          ]}
+          extraActions={
+            props.showLinkToHabit
+              ? [
+                  NavSingle({
+                    text: "Habit",
+                    link: `/app/workspace/habits/${props.habit.ref_id}`,
+                    icon: <LaunchIcon />,
+                  }),
+                ]
+              : undefined
+          }
+        />
+      }
+    >
+      <input
+        type="hidden"
+        name={constructFieldName(props.namePrefix, "refId")}
+        value={props.habit.ref_id}
+      />
+
+      <Stack direction="row" useFlexGap spacing={1}>
+        <FormControl fullWidth sx={{ flexGrow: 3 }}>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput
+            label="Name"
+            name={constructFieldName(props.namePrefix, "name")}
+            readOnly={!props.inputsEnabled}
+            disabled={!props.inputsEnabled}
+            defaultValue={props.habit.name}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/name" />
+        </FormControl>
+
+        <FormControl sx={{ flexGrow: 1 }}>
+          <IsKeySelect
+            name={constructFieldName(props.namePrefix, "isKey")}
+            defaultValue={props.habit.is_key}
+            inputsEnabled={props.inputsEnabled}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/is_key" />
+        </FormControl>
+      </Stack>
+
+      <Stack direction={isBigScreen ? "row" : "column"} useFlexGap spacing={1}>
+        <FormControl fullWidth sx={{ flexGrow: 2 }}>
+          <TagsEditor
+            name="tags"
+            aloneOnLine
+            allTags={props.allTags}
+            linkedTags={props.tags}
+            defaultValue={props.tags.map((tag) => tag.ref_id)}
+            inputsEnabled={props.inputsEnabled}
+            entityOwnerRefId={props.entityOwner?.ref_id}
+            owner={entityLinkStd(NamedEntityTag.HABIT, props.habit.ref_id)}
+          />
+          <FieldError actionResult={props.actionData} fieldName="/tags_names" />
+        </FormControl>
+
+        <FormControl fullWidth sx={{ flexGrow: 2 }}>
+          <ContactsEditor
+            name="contacts_names"
+            aloneOnLine
+            allContacts={props.allContacts}
+            linkedContacts={props.contacts}
+            defaultValue={props.contacts.map((contact) => contact.ref_id)}
+            inputsEnabled={props.inputsEnabled}
+            entityOwnerRefId={props.entityOwner?.ref_id}
+            owner={entityLinkStd(NamedEntityTag.HABIT, props.habit.ref_id)}
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/contacts_names"
+          />
+        </FormControl>
+      </Stack>
+
+      {isWorkspaceFeatureAvailable(
+        props.topLevelInfo.workspace,
+        WorkspaceFeature.LIFE_PLAN,
+      ) && (
+        <FormControl fullWidth>
+          <LifePlanAssociations
+            inputsEnabled={
+              props.inputsEnabled && lifePlanAssociationsInWorkspace
+            }
+            aspectName={constructFieldName(props.namePrefix, "aspect")}
+            chapterName={constructFieldName(props.namePrefix, "chapter")}
+            goalName={constructFieldName(props.namePrefix, "goal")}
+            allAspects={allAspects}
+            aspectValue={selectedAspectRefId}
+            onAspectChange={setSelectedAspectRefId}
+            aspectDefaultValue={props.habit.aspect_ref_id}
+            allChapters={allChapters}
+            chapterDefaultValue={props.habit.chapter_ref_id}
+            allGoals={allGoals}
+            goalDefaultValue={props.habit.goal_ref_id}
+            birthday={birthdayDate!}
+            today={aDateToDate(props.topLevelInfo.today)}
+            allMilestones={props.allMilestones}
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/aspect_ref_id"
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/chapter_ref_id"
+          />
+          <FieldError
+            actionResult={props.actionData}
+            fieldName="/goal_ref_id"
+          />
+        </FormControl>
+      )}
+
+      <RecurringTaskGenParamsBlock
+        inputsEnabled={props.inputsEnabled}
+        allowSkipRule
+        namePrefix={props.namePrefix}
+        period={selectedPeriod}
+        onChangePeriod={(newPeriod) => {
+          if (newPeriod === "none") {
+            setSelectedPeriod(RecurringTaskPeriod.DAILY);
+          } else {
+            setSelectedPeriod(newPeriod);
+          }
+        }}
+        eisen={props.habit.gen_params.eisen}
+        difficulty={props.habit.gen_params.difficulty}
+        actionableFromDay={props.habit.gen_params.actionable_from_day}
+        actionableFromMonth={props.habit.gen_params.actionable_from_month}
+        dueAtDay={props.habit.gen_params.due_at_day}
+        dueAtMonth={props.habit.gen_params.due_at_month}
+        skipRule={props.habit.gen_params.skip_rule}
+        actionData={props.actionData}
+      />
+
+      {selectedPeriod !== RecurringTaskPeriod.DAILY && (
+        <Stack direction="row" spacing={2}>
+          <FormControl sx={{ flexGrow: 3 }}>
+            <HabitRepeatStrategySelect
+              name={constructFieldName(props.namePrefix, "repeatsStrategy")}
+              inputsEnabled={props.inputsEnabled}
+              allowNone
+              value={selectedRepeatsStrategy}
+              onChange={(newStrategy) =>
+                setSelectedRepeatsStrategy(newStrategy)
+              }
+            />
+            <FieldError
+              actionResult={props.actionData}
+              fieldName="/repeats_strategy"
+            />
+          </FormControl>
+
+          {selectedRepeatsStrategy !== "none" && (
+            <FormControl sx={{ flexGrow: 1 }}>
+              <InputLabel id="repeatsInPeriodCount">
+                Repeats In Period [Optional]
+              </InputLabel>
+              <OutlinedInput
+                label="Repeats In Period"
+                name={constructFieldName(
+                  props.namePrefix,
+                  "repeatsInPeriodCount",
+                )}
+                readOnly={!props.inputsEnabled}
+                disabled={!props.inputsEnabled}
+                defaultValue={props.habit.repeats_in_period_count}
+                sx={{ height: "100%" }}
+              />
+              <FieldError
+                actionResult={props.actionData}
+                fieldName="/repeats_in_period_count"
+              />
+            </FormControl>
+          )}
+        </Stack>
+      )}
+    </SectionCard>
+  );
+}
+
+function constructIntentName(
+  intentPrefix: string | undefined,
+  intent: string,
+): string {
+  if (!intentPrefix) {
+    return intent;
+  }
+  return `${intentPrefix}-${intent}`;
+}
+
+function mergeForeignAspectSummary(
+  allAspects: AspectSummary[],
+  aspect: Aspect | null | undefined,
+  aspectRefId: string,
+): AspectSummary[] {
+  if (allAspects.some((entry) => entry.ref_id === aspectRefId)) {
+    return allAspects;
+  }
+  if (
+    aspect === undefined ||
+    aspect === null ||
+    aspect.ref_id !== aspectRefId
+  ) {
+    return allAspects;
+  }
+  // Detach from the foreign parent chain so tree helpers can still render it.
+  return [
+    ...allAspects,
+    {
+      ref_id: aspect.ref_id,
+      parent_aspect_ref_id: null,
+      name: aspect.name,
+      order_of_child_aspects: [],
+    },
+  ];
+}
+
+function mergeForeignChapterSummary(
+  allChapters: ChapterSummary[],
+  chapter: Chapter | null | undefined,
+  chapterRefId: string | null | undefined,
+): ChapterSummary[] {
+  if (
+    chapterRefId === undefined ||
+    chapterRefId === null ||
+    allChapters.some((entry) => entry.ref_id === chapterRefId)
+  ) {
+    return allChapters;
+  }
+  if (
+    chapter === undefined ||
+    chapter === null ||
+    chapter.ref_id !== chapterRefId
+  ) {
+    return allChapters;
+  }
+  return [
+    ...allChapters,
+    {
+      ref_id: chapter.ref_id,
+      name: chapter.name,
+      start_date: chapter.start_date,
+      end_date: chapter.end_date,
+      aspect_ref_id: chapter.aspect_ref_id,
+    },
+  ];
+}
+
+function mergeForeignGoalSummary(
+  allGoals: GoalSummary[],
+  goal: Goal | null | undefined,
+  goalRefId: string | null | undefined,
+): GoalSummary[] {
+  if (
+    goalRefId === undefined ||
+    goalRefId === null ||
+    allGoals.some((entry) => entry.ref_id === goalRefId)
+  ) {
+    return allGoals;
+  }
+  if (goal === undefined || goal === null || goal.ref_id !== goalRefId) {
+    return allGoals;
+  }
+  return [
+    ...allGoals,
+    {
+      ref_id: goal.ref_id,
+      name: goal.name,
+      aspect_ref_id: goal.aspect_ref_id,
+      parent_goal_ref_id: goal.parent_goal_ref_id,
+    },
+  ];
+}

--- a/src/core/jupiter/core/time_plans/sub/activity/component/target-type-chip.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/target-type-chip.tsx
@@ -1,0 +1,65 @@
+import type { EntityLink } from "@jupiter/webapi-client";
+
+import { CornerChip } from "#/core/infra/component/chips";
+import {
+  isTimePlanActivityBigPlanTarget,
+  isTimePlanActivityChoreTarget,
+  isTimePlanActivityHabitTarget,
+  isTimePlanActivityInboxTaskTarget,
+  isTimePlanActivityTodoTaskTarget,
+} from "#/core/time_plans/sub/activity/target-wire";
+
+interface TimePlanActivityTargetTypeChipProps {
+  target: EntityLink;
+}
+
+export function TimePlanActivityTargetTypeChip(
+  props: TimePlanActivityTargetTypeChipProps,
+) {
+  return (
+    <CornerChip
+      label={targetTypeName(props.target)}
+      color={targetTypeToColor(props.target)}
+    />
+  );
+}
+
+function targetTypeName(target: EntityLink): string {
+  if (isTimePlanActivityTodoTaskTarget(target)) {
+    return "Todo";
+  }
+  if (isTimePlanActivityHabitTarget(target)) {
+    return "Habit";
+  }
+  if (isTimePlanActivityChoreTarget(target)) {
+    return "Chore";
+  }
+  if (isTimePlanActivityBigPlanTarget(target)) {
+    return "Big Plan";
+  }
+  if (isTimePlanActivityInboxTaskTarget(target)) {
+    return "Task";
+  }
+  return "Activity";
+}
+
+function targetTypeToColor(
+  target: EntityLink,
+): "info" | "warning" | "success" | "default" {
+  if (isTimePlanActivityTodoTaskTarget(target)) {
+    return "info";
+  }
+  if (isTimePlanActivityHabitTarget(target)) {
+    return "warning";
+  }
+  if (isTimePlanActivityChoreTarget(target)) {
+    return "warning";
+  }
+  if (isTimePlanActivityBigPlanTarget(target)) {
+    return "success";
+  }
+  if (isTimePlanActivityInboxTaskTarget(target)) {
+    return "info";
+  }
+  return "default";
+}

--- a/src/core/jupiter/core/time_plans/sub/activity/group-by-parent.ts
+++ b/src/core/jupiter/core/time_plans/sub/activity/group-by-parent.ts
@@ -1,0 +1,164 @@
+import type {
+  AspectSummary,
+  BigPlan,
+  Chore,
+  EntityId,
+  Habit,
+  InboxTask,
+  TimePlanActivity,
+  TodoTask,
+} from "@jupiter/webapi-client";
+
+import {
+  BIG_PLAN,
+  CHORE,
+  entityLinkRefIdFromWire,
+  HABIT,
+  parentLinkNamespaceFromEntityLinkWire,
+  TODO_TASK,
+} from "#/core/common/sub/inbox_tasks/parent-link-namespace";
+import {
+  isTimePlanActivityBigPlanTarget,
+  isTimePlanActivityChoreTarget,
+  isTimePlanActivityHabitTarget,
+  isTimePlanActivityInboxTaskTarget,
+  isTimePlanActivityTodoTaskTarget,
+} from "#/core/time_plans/sub/activity/target-wire";
+
+/** The entities an activity can be grouped under - they carry the aspect and goal. */
+export interface TimePlanActivityGroupingMaps {
+  targetInboxTasksByRefId: Map<string, InboxTask>;
+  targetBigPlansByRefId: Map<string, BigPlan>;
+  targetTodoTasksByRefId: Map<string, TodoTask>;
+  targetHabitsByRefId: Map<string, Habit>;
+  targetChoresByRefId: Map<string, Chore>;
+}
+
+interface ActivityParent {
+  aspectRefId: EntityId;
+  goalRefId?: EntityId | null;
+}
+
+/**
+ * Index the activities which can act as a parent for other activities.
+ *
+ * Activities aimed at a big plan, a habit, a chore or a todo task are the
+ * parents of the activities aimed at the inbox tasks these entities own. The
+ * index is keyed by the ref id of the target, since that is what an inbox
+ * task's owner link carries.
+ */
+export function parentActivitiesByTargetRefId(
+  activities: TimePlanActivity[],
+): Map<string, TimePlanActivity> {
+  const parentActivities = new Map<string, TimePlanActivity>();
+
+  for (const activity of activities) {
+    if (
+      !isTimePlanActivityBigPlanTarget(activity.target) &&
+      !isTimePlanActivityHabitTarget(activity.target) &&
+      !isTimePlanActivityChoreTarget(activity.target) &&
+      !isTimePlanActivityTodoTaskTarget(activity.target)
+    ) {
+      continue;
+    }
+
+    parentActivities.set(entityLinkRefIdFromWire(activity.target), activity);
+  }
+
+  return parentActivities;
+}
+
+/** Keep just the activities whose target belongs to a certain aspect. */
+export function filterActivitiesForAspect(
+  activities: TimePlanActivity[],
+  aspect: AspectSummary,
+  maps: TimePlanActivityGroupingMaps,
+): TimePlanActivity[] {
+  return activities.filter((activity) => {
+    const parent = parentForActivity(activity, maps);
+    if (!parent) {
+      return false;
+    }
+    return parent.aspectRefId === aspect.ref_id;
+  });
+}
+
+/** The goal an activity works towards, via its target, if there is one. */
+export function goalRefIdForActivity(
+  activity: TimePlanActivity,
+  targetInboxTasksByRefId: Map<string, InboxTask>,
+  targetBigPlansByRefId: Map<string, BigPlan>,
+  targetTodoTasksByRefId: Map<string, TodoTask>,
+  targetHabitsByRefId: Map<string, Habit>,
+  targetChoresByRefId: Map<string, Chore>,
+): EntityId | null {
+  const parent = parentForActivity(activity, {
+    targetInboxTasksByRefId,
+    targetBigPlansByRefId,
+    targetTodoTasksByRefId,
+    targetHabitsByRefId,
+    targetChoresByRefId,
+  });
+  if (!parent) {
+    return null;
+  }
+  return parent.goalRefId ?? null;
+}
+
+function parentForActivity(
+  activity: TimePlanActivity,
+  maps: TimePlanActivityGroupingMaps,
+): ActivityParent | null {
+  const targetRefId = entityLinkRefIdFromWire(activity.target);
+
+  if (isTimePlanActivityBigPlanTarget(activity.target)) {
+    return parentForEntity(maps.targetBigPlansByRefId.get(targetRefId));
+  }
+  if (isTimePlanActivityTodoTaskTarget(activity.target)) {
+    return parentForEntity(maps.targetTodoTasksByRefId.get(targetRefId));
+  }
+  if (isTimePlanActivityHabitTarget(activity.target)) {
+    return parentForEntity(maps.targetHabitsByRefId.get(targetRefId));
+  }
+  if (isTimePlanActivityChoreTarget(activity.target)) {
+    return parentForEntity(maps.targetChoresByRefId.get(targetRefId));
+  }
+  if (!isTimePlanActivityInboxTaskTarget(activity.target)) {
+    return null;
+  }
+
+  // An inbox task does not carry an aspect or goal itself, so we look at the
+  // entity which generated it.
+  const inboxTask = maps.targetInboxTasksByRefId.get(targetRefId);
+  if (!inboxTask) {
+    return null;
+  }
+
+  const ownerNamespace = parentLinkNamespaceFromEntityLinkWire(inboxTask.owner);
+  const ownerRefId = entityLinkRefIdFromWire(inboxTask.owner);
+
+  switch (ownerNamespace) {
+    case BIG_PLAN:
+      return parentForEntity(maps.targetBigPlansByRefId.get(ownerRefId));
+    case TODO_TASK:
+      return parentForEntity(maps.targetTodoTasksByRefId.get(ownerRefId));
+    case HABIT:
+      return parentForEntity(maps.targetHabitsByRefId.get(ownerRefId));
+    case CHORE:
+      return parentForEntity(maps.targetChoresByRefId.get(ownerRefId));
+    default:
+      return null;
+  }
+}
+
+function parentForEntity(
+  entity: BigPlan | Chore | Habit | TodoTask | undefined,
+): ActivityParent | null {
+  if (!entity) {
+    return null;
+  }
+  return {
+    aspectRefId: entity.aspect_ref_id,
+    goalRefId: entity.goal_ref_id,
+  };
+}

--- a/src/core/jupiter/core/time_plans/sub/activity/target.py
+++ b/src/core/jupiter/core/time_plans/sub/activity/target.py
@@ -1,0 +1,14 @@
+"""The kind of target of an activity."""
+
+from jupiter.framework.value import EnumValue, enum_value
+
+
+@enum_value
+class TimePlanActivityTarget(EnumValue):
+    """The kind of entity a time plan activity is aimed at."""
+
+    INBOX_TASK = "inbox-task"
+    TODO_TASK = "todo-task"
+    HABIT = "habit"
+    CHORE = "chore"
+    BIG_PLAN = "big-plan"

--- a/src/core/jupiter/core/time_plans/use_case/associate_chore_with_plan.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_chore_with_plan.py
@@ -1,0 +1,167 @@
+"""Use case for creating time plan activities for a chore."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.chores.root import Chore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.access.sub.status.service.load_for_acl import (
+    LoadForAclService,
+)
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterCreateCrownEntityArgs,
+    JupiterCreateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.core.time_plans.use_case.associate_with_habits import (
+    inbox_task_overlaps_time_plan,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class TimePlanAssociateChoreWithPlanArgs(JupiterCreateCrownEntityArgs):
+    """Args."""
+
+    chore_ref_id: EntityId
+    time_plan_ref_ids: list[EntityId]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateChoreWithPlanResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateChoreWithPlanUseCase(
+    JupiterCreateCrownEntityUseCase[
+        TimePlanAssociateChoreWithPlanArgs, TimePlanAssociateChoreWithPlanResult
+    ]
+):
+    """Use case for creating activities starting from a chore."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateChoreWithPlanArgs,
+    ) -> TimePlanAssociateChoreWithPlanResult:
+        """Execute the command's actions."""
+        if len(args.time_plan_ref_ids) == 0:
+            raise InputValidationError("You must specify some time plans")
+
+        chore = await LoadForAclService().do_it(
+            uow,
+            Chore,
+            args.chore_ref_id,
+            context.user.ref_id,
+            AccessLevel.READER,
+        )
+
+        time_plans = await self.find_all_entities(
+            uow,
+            context.user.ref_id,
+            TimePlan,
+            args.time_plan_ref_ids,
+            allow_archived=False,
+        )
+
+        for time_plan in time_plans:
+            if not time_plan.allows_inbox_tasks:
+                raise InputValidationError(
+                    f"Time plan {time_plan.name} does not allow chore activities"
+                )
+
+        inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+            parent_ref_id=None,
+            allow_archived=False,
+            owner=EntityLink.std(NamedEntityTag.CHORE.value, chore.ref_id),
+        )
+
+        new_time_plan_activities = []
+
+        for time_plan in time_plans:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_chore(
+                    context.domain_context,
+                    time_plan_ref_id=time_plan.ref_id,
+                    chore_ref_id=chore.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_activities.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this plan, no need to panic
+                pass
+
+            # The inbox tasks the chore already generated in the interval of the
+            # time plan become activities of their own.
+            for inbox_task in inbox_tasks:
+                if not inbox_task_overlaps_time_plan(inbox_task, time_plan):
+                    continue
+
+                try:
+                    new_inbox_task_activity = (
+                        TimePlanActivity.new_activity_for_inbox_task(
+                            context.domain_context,
+                            time_plan_ref_id=time_plan.ref_id,
+                            inbox_task_ref_id=inbox_task.ref_id,
+                            kind=args.kind,
+                            feasability=args.feasability,
+                        )
+                    )
+                    new_inbox_task_activity = await self.create_entity(
+                        context.domain_context,
+                        uow,
+                        progress_reporter,
+                        context.user.ref_id,
+                        new_inbox_task_activity,
+                    )
+                    new_time_plan_activities.append(new_inbox_task_activity)
+                except TimePlanAlreadyAssociatedWithTargetError:
+                    # We were already working on this task, no need to panic
+                    pass
+
+        return TimePlanAssociateChoreWithPlanResult(
+            new_time_plan_activities=new_time_plan_activities
+        )

--- a/src/core/jupiter/core/time_plans/use_case/associate_habit_with_plan.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_habit_with_plan.py
@@ -1,0 +1,167 @@
+"""Use case for creating time plan activities for a habit."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.access.sub.status.service.load_for_acl import (
+    LoadForAclService,
+)
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterCreateCrownEntityArgs,
+    JupiterCreateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.habits.root import Habit
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.core.time_plans.use_case.associate_with_habits import (
+    inbox_task_overlaps_time_plan,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class TimePlanAssociateHabitWithPlanArgs(JupiterCreateCrownEntityArgs):
+    """Args."""
+
+    habit_ref_id: EntityId
+    time_plan_ref_ids: list[EntityId]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateHabitWithPlanResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateHabitWithPlanUseCase(
+    JupiterCreateCrownEntityUseCase[
+        TimePlanAssociateHabitWithPlanArgs, TimePlanAssociateHabitWithPlanResult
+    ]
+):
+    """Use case for creating activities starting from a habit."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateHabitWithPlanArgs,
+    ) -> TimePlanAssociateHabitWithPlanResult:
+        """Execute the command's actions."""
+        if len(args.time_plan_ref_ids) == 0:
+            raise InputValidationError("You must specify some time plans")
+
+        habit = await LoadForAclService().do_it(
+            uow,
+            Habit,
+            args.habit_ref_id,
+            context.user.ref_id,
+            AccessLevel.READER,
+        )
+
+        time_plans = await self.find_all_entities(
+            uow,
+            context.user.ref_id,
+            TimePlan,
+            args.time_plan_ref_ids,
+            allow_archived=False,
+        )
+
+        for time_plan in time_plans:
+            if not time_plan.allows_inbox_tasks:
+                raise InputValidationError(
+                    f"Time plan {time_plan.name} does not allow habit activities"
+                )
+
+        inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+            parent_ref_id=None,
+            allow_archived=False,
+            owner=EntityLink.std(NamedEntityTag.HABIT.value, habit.ref_id),
+        )
+
+        new_time_plan_activities = []
+
+        for time_plan in time_plans:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_habit(
+                    context.domain_context,
+                    time_plan_ref_id=time_plan.ref_id,
+                    habit_ref_id=habit.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_activities.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this plan, no need to panic
+                pass
+
+            # The inbox tasks the habit already generated in the interval of the
+            # time plan become activities of their own.
+            for inbox_task in inbox_tasks:
+                if not inbox_task_overlaps_time_plan(inbox_task, time_plan):
+                    continue
+
+                try:
+                    new_inbox_task_activity = (
+                        TimePlanActivity.new_activity_for_inbox_task(
+                            context.domain_context,
+                            time_plan_ref_id=time_plan.ref_id,
+                            inbox_task_ref_id=inbox_task.ref_id,
+                            kind=args.kind,
+                            feasability=args.feasability,
+                        )
+                    )
+                    new_inbox_task_activity = await self.create_entity(
+                        context.domain_context,
+                        uow,
+                        progress_reporter,
+                        context.user.ref_id,
+                        new_inbox_task_activity,
+                    )
+                    new_time_plan_activities.append(new_inbox_task_activity)
+                except TimePlanAlreadyAssociatedWithTargetError:
+                    # We were already working on this task, no need to panic
+                    pass
+
+        return TimePlanAssociateHabitWithPlanResult(
+            new_time_plan_activities=new_time_plan_activities
+        )

--- a/src/core/jupiter/core/time_plans/use_case/associate_todo_task_with_plan.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_todo_task_with_plan.py
@@ -1,0 +1,146 @@
+"""Use case for creating time plan activities for a todo task."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.access.sub.status.service.load_for_acl import (
+    LoadForAclService,
+)
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterCreateCrownEntityArgs,
+    JupiterCreateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.core.todo.root import TodoTask
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class TimePlanAssociateTodoTaskWithPlanArgs(JupiterCreateCrownEntityArgs):
+    """Args."""
+
+    todo_task_ref_id: EntityId
+    time_plan_ref_ids: list[EntityId]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateTodoTaskWithPlanResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateTodoTaskWithPlanUseCase(
+    JupiterCreateCrownEntityUseCase[
+        TimePlanAssociateTodoTaskWithPlanArgs, TimePlanAssociateTodoTaskWithPlanResult
+    ]
+):
+    """Use case for creating activities starting from a todo task."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateTodoTaskWithPlanArgs,
+    ) -> TimePlanAssociateTodoTaskWithPlanResult:
+        """Execute the command's actions."""
+        if len(args.time_plan_ref_ids) == 0:
+            raise InputValidationError("You must specify some time plans")
+
+        todo_task = await LoadForAclService().do_it(
+            uow,
+            TodoTask,
+            args.todo_task_ref_id,
+            context.user.ref_id,
+            AccessLevel.READER,
+        )
+
+        time_plans = await self.find_all_entities(
+            uow,
+            context.user.ref_id,
+            TimePlan,
+            args.time_plan_ref_ids,
+            allow_archived=False,
+        )
+
+        for time_plan in time_plans:
+            if not time_plan.allows_inbox_tasks:
+                raise InputValidationError(
+                    f"Time plan {time_plan.name} does not allow todo task activities"
+                )
+
+        latest_time_plan = max(time_plans, key=lambda x: x.end_date)
+
+        new_time_plan_activities = []
+
+        for time_plan in time_plans:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_todo_task(
+                    context.domain_context,
+                    time_plan_ref_id=time_plan.ref_id,
+                    todo_task_ref_id=todo_task.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_activities.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this plan, no need to panic
+                pass
+
+        inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+            parent_ref_id=None,
+            allow_archived=False,
+            owner=EntityLink.std(NamedEntityTag.TODO_TASK.value, todo_task.ref_id),
+        )
+
+        if len(inbox_tasks) > 0:
+            inbox_task = inbox_tasks[0]
+            if inbox_task.allow_user_changes and inbox_task.due_date is None:
+                inbox_task = inbox_task.change_due_date_via_time_plan(
+                    context.domain_context, due_date=latest_time_plan.end_date
+                )
+                await uow.get_for(InboxTask).save(inbox_task)
+
+        return TimePlanAssociateTodoTaskWithPlanResult(
+            new_time_plan_activities=new_time_plan_activities
+        )

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_chores.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_chores.py
@@ -1,0 +1,160 @@
+"""Use case for creating time plan actitivities for chores."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.chores.root import Chore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterUpdateCrownEntityArgs,
+    JupiterUpdateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.core.time_plans.use_case.associate_with_habits import (
+    inbox_task_overlaps_time_plan,
+)
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class TimePlanAssociateWithChoresArgs(JupiterUpdateCrownEntityArgs):
+    """Args."""
+
+    ref_id: EntityId
+    chore_ref_ids: list[EntityId]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateWithChoresResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateWithChoresUseCase(
+    JupiterUpdateCrownEntityUseCase[
+        TimePlanAssociateWithChoresArgs, TimePlanAssociateWithChoresResult
+    ]
+):
+    """Use case for creating activities starting from chores."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateWithChoresArgs,
+    ) -> TimePlanAssociateWithChoresResult:
+        """Execute the command's actions."""
+        if len(args.chore_ref_ids) == 0:
+            raise InputValidationError("You must specifiy some chores")
+
+        time_plan = await self.load_entity(
+            uow, context.user.ref_id, TimePlan, args.ref_id
+        )
+
+        if not time_plan.allows_inbox_tasks:
+            raise InputValidationError(
+                "Chores can only be added to daily or weekly time plans"
+            )
+
+        chores = await self.find_all_generic(
+            uow,
+            context.user.ref_id,
+            Chore,
+            allow_archived=False,
+            ref_id=args.chore_ref_ids,
+            minimum_access_level=AccessLevel.READER,
+        )
+
+        new_time_plan_actitivies = []
+
+        for chore in chores:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_chore(
+                    context.domain_context,
+                    time_plan_ref_id=args.ref_id,
+                    chore_ref_id=chore.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_actitivies.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this chore, no need to panic
+                pass
+
+            # The inbox tasks the chore already generated in the interval of the
+            # time plan become activities of their own.
+            inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+                parent_ref_id=None,
+                allow_archived=False,
+                owner=EntityLink.std(NamedEntityTag.CHORE.value, chore.ref_id),
+            )
+
+            for inbox_task in inbox_tasks:
+                if not inbox_task_overlaps_time_plan(inbox_task, time_plan):
+                    continue
+
+                try:
+                    new_inbox_task_activity = (
+                        TimePlanActivity.new_activity_for_inbox_task(
+                            context.domain_context,
+                            time_plan_ref_id=args.ref_id,
+                            inbox_task_ref_id=inbox_task.ref_id,
+                            kind=args.kind,
+                            feasability=args.feasability,
+                        )
+                    )
+                    new_inbox_task_activity = await self.create_entity(
+                        context.domain_context,
+                        uow,
+                        progress_reporter,
+                        context.user.ref_id,
+                        new_inbox_task_activity,
+                    )
+                    new_time_plan_actitivies.append(new_inbox_task_activity)
+                except TimePlanAlreadyAssociatedWithTargetError:
+                    # We were already working on this task, no need to panic
+                    pass
+
+        return TimePlanAssociateWithChoresResult(
+            new_time_plan_activities=new_time_plan_actitivies
+        )

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_habits.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_habits.py
@@ -1,0 +1,183 @@
+"""Use case for creating time plan actitivities for habits."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterUpdateCrownEntityArgs,
+    JupiterUpdateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.habits.root import Habit
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.framework.base.adate import ADate
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+def dates_in_inclusive_range(start_date: ADate, end_date: ADate) -> list[ADate]:
+    """All the days between two dates, with both ends included."""
+    if end_date < start_date:
+        return []
+
+    all_dates = []
+    current_date = start_date
+    while current_date <= end_date:
+        all_dates.append(current_date)
+        current_date = current_date.next_day()
+
+    return all_dates
+
+
+def inbox_task_overlaps_time_plan(inbox_task: InboxTask, time_plan: TimePlan) -> bool:
+    """Whether the dates of an inbox task place it inside a time plan's interval."""
+    start_date = inbox_task.actionable_date or inbox_task.due_date
+    end_date = inbox_task.due_date or inbox_task.actionable_date
+
+    if start_date is None or end_date is None:
+        return False
+
+    return start_date <= time_plan.end_date and time_plan.start_date <= end_date
+
+
+@use_case_args
+class TimePlanAssociateWithHabitsArgs(JupiterUpdateCrownEntityArgs):
+    """Args."""
+
+    ref_id: EntityId
+    habit_ref_ids: list[EntityId]
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateWithHabitsResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateWithHabitsUseCase(
+    JupiterUpdateCrownEntityUseCase[
+        TimePlanAssociateWithHabitsArgs, TimePlanAssociateWithHabitsResult
+    ]
+):
+    """Use case for creating activities starting from habits."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateWithHabitsArgs,
+    ) -> TimePlanAssociateWithHabitsResult:
+        """Execute the command's actions."""
+        if len(args.habit_ref_ids) == 0:
+            raise InputValidationError("You must specifiy some habits")
+
+        time_plan = await self.load_entity(
+            uow, context.user.ref_id, TimePlan, args.ref_id
+        )
+
+        if not time_plan.allows_inbox_tasks:
+            raise InputValidationError(
+                "Habits can only be added to daily or weekly time plans"
+            )
+
+        habits = await self.find_all_generic(
+            uow,
+            context.user.ref_id,
+            Habit,
+            allow_archived=False,
+            ref_id=args.habit_ref_ids,
+            minimum_access_level=AccessLevel.READER,
+        )
+
+        new_time_plan_actitivies = []
+
+        for habit in habits:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_habit(
+                    context.domain_context,
+                    time_plan_ref_id=args.ref_id,
+                    habit_ref_id=habit.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_actitivies.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this habit, no need to panic
+                pass
+
+            # The inbox tasks the habit already generated in the interval of the
+            # time plan become activities of their own.
+            inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+                parent_ref_id=None,
+                allow_archived=False,
+                owner=EntityLink.std(NamedEntityTag.HABIT.value, habit.ref_id),
+            )
+
+            for inbox_task in inbox_tasks:
+                if not inbox_task_overlaps_time_plan(inbox_task, time_plan):
+                    continue
+
+                try:
+                    new_inbox_task_activity = (
+                        TimePlanActivity.new_activity_for_inbox_task(
+                            context.domain_context,
+                            time_plan_ref_id=args.ref_id,
+                            inbox_task_ref_id=inbox_task.ref_id,
+                            kind=args.kind,
+                            feasability=args.feasability,
+                        )
+                    )
+                    new_inbox_task_activity = await self.create_entity(
+                        context.domain_context,
+                        uow,
+                        progress_reporter,
+                        context.user.ref_id,
+                        new_inbox_task_activity,
+                    )
+                    new_time_plan_actitivies.append(new_inbox_task_activity)
+                except TimePlanAlreadyAssociatedWithTargetError:
+                    # We were already working on this task, no need to panic
+                    pass
+
+        return TimePlanAssociateWithHabitsResult(
+            new_time_plan_activities=new_time_plan_actitivies
+        )

--- a/src/core/jupiter/core/time_plans/use_case/associate_with_todo_tasks.py
+++ b/src/core/jupiter/core/time_plans/use_case/associate_with_todo_tasks.py
@@ -1,0 +1,141 @@
+"""Use case for creating time plan actitivities for todo tasks."""
+
+from jupiter.core.app import AppCore
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.inbox_tasks.root import InboxTask
+from jupiter.core.config import (
+    JupiterLoggedInMutationContext,
+)
+from jupiter.core.crown_entity_support import (
+    JupiterUpdateCrownEntityArgs,
+    JupiterUpdateCrownEntityUseCase,
+)
+from jupiter.core.features import WorkspaceFeature
+from jupiter.core.named_entity_tag import NamedEntityTag
+from jupiter.core.time_plans.root import TimePlan
+from jupiter.core.time_plans.sub.activity.feasability import (
+    TimePlanActivityFeasability,
+)
+from jupiter.core.time_plans.sub.activity.kind import (
+    TimePlanActivityKind,
+)
+from jupiter.core.time_plans.sub.activity.root import (
+    TimePlanActivity,
+    TimePlanAlreadyAssociatedWithTargetError,
+)
+from jupiter.core.todo.root import TodoTask
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.entity_link import EntityLink
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.use_case import (
+    mutation_use_case,
+)
+from jupiter.framework.use_case_io import (
+    UseCaseResultBase,
+    use_case_args,
+    use_case_result,
+)
+
+
+@use_case_args
+class TimePlanAssociateWithTodoTasksArgs(JupiterUpdateCrownEntityArgs):
+    """Args."""
+
+    ref_id: EntityId
+    todo_task_ref_ids: list[EntityId]
+    override_existing_dates: bool
+    kind: TimePlanActivityKind
+    feasability: TimePlanActivityFeasability
+
+
+@use_case_result
+class TimePlanAssociateWithTodoTasksResult(UseCaseResultBase):
+    """Result."""
+
+    new_time_plan_activities: list[TimePlanActivity]
+
+
+@mutation_use_case(
+    WorkspaceFeature.TIME_PLANS, only_for_component=[AppCore.WEBUI, AppCore.API]
+)
+class TimePlanAssociateWithTodoTasksUseCase(
+    JupiterUpdateCrownEntityUseCase[
+        TimePlanAssociateWithTodoTasksArgs, TimePlanAssociateWithTodoTasksResult
+    ]
+):
+    """Use case for creating activities starting from todo tasks."""
+
+    async def _perform_transactional_mutation(
+        self,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        context: JupiterLoggedInMutationContext,
+        args: TimePlanAssociateWithTodoTasksArgs,
+    ) -> TimePlanAssociateWithTodoTasksResult:
+        """Execute the command's actions."""
+        if len(args.todo_task_ref_ids) == 0:
+            raise InputValidationError("You must specifiy some todo tasks")
+
+        time_plan = await self.load_entity(
+            uow, context.user.ref_id, TimePlan, args.ref_id
+        )
+
+        if not time_plan.allows_inbox_tasks:
+            raise InputValidationError(
+                "Todo tasks can only be added to daily or weekly time plans"
+            )
+
+        todo_tasks = await self.find_all_generic(
+            uow,
+            context.user.ref_id,
+            TodoTask,
+            allow_archived=False,
+            ref_id=args.todo_task_ref_ids,
+            minimum_access_level=AccessLevel.READER,
+        )
+
+        new_time_plan_actitivies = []
+
+        for todo_task in todo_tasks:
+            try:
+                new_time_plan_activity = TimePlanActivity.new_activity_for_todo_task(
+                    context.domain_context,
+                    time_plan_ref_id=args.ref_id,
+                    todo_task_ref_id=todo_task.ref_id,
+                    kind=args.kind,
+                    feasability=args.feasability,
+                )
+                new_time_plan_activity = await self.create_entity(
+                    context.domain_context,
+                    uow,
+                    progress_reporter,
+                    context.user.ref_id,
+                    new_time_plan_activity,
+                )
+                new_time_plan_actitivies.append(new_time_plan_activity)
+            except TimePlanAlreadyAssociatedWithTargetError:
+                # We were already working on this todo task, no need to panic
+                pass
+
+            inbox_tasks = await uow.get_for(InboxTask).find_all_generic(
+                parent_ref_id=None,
+                allow_archived=False,
+                owner=EntityLink.std(NamedEntityTag.TODO_TASK.value, todo_task.ref_id),
+            )
+            if len(inbox_tasks) == 0:
+                continue
+
+            inbox_task = inbox_tasks[0]
+            if inbox_task.allow_user_changes and (
+                inbox_task.due_date is None or args.override_existing_dates
+            ):
+                inbox_task = inbox_task.change_due_date_via_time_plan(
+                    context.domain_context, due_date=time_plan.end_date
+                )
+                await uow.get_for(InboxTask).save(inbox_task)
+
+        return TimePlanAssociateWithTodoTasksResult(
+            new_time_plan_activities=new_time_plan_actitivies
+        )


### PR DESCRIPTION
## Summary
This PR adds functionality to associate habits, chores, and todo tasks with time plans by creating time plan activities. It includes new use cases for bulk and individual associations, UI components for properties editors, and generated API client code.

## Key Changes

### Backend Use Cases (Python)
- **`associate_with_habits.py`**: Bulk associate multiple habits with time plans, generating activities for each habit and its inbox tasks
- **`associate_habit_with_plan.py`**: Associate a single habit with specific time plans
- **`associate_with_chores.py`**: Bulk associate multiple chores with time plans
- **`associate_chore_with_plan.py`**: Associate a single chore with specific time plans
- **`associate_with_todo_tasks.py`**: Bulk associate multiple todo tasks with time plans
- **`associate_todo_task_with_plan.py`**: Associate a single todo task with specific time plans

All use cases handle:
- Access control validation
- Overlap detection between inbox tasks and time plan date ranges
- Activity feasibility and kind configuration
- Proper error handling for already-associated entities

### Frontend Components (TypeScript/React)
- **`properties-editor.tsx` (Chores & Habits)**: New property editors for chores and habits with support for:
  - Life plan entity associations (aspects, chapters, goals)
  - Tags and contacts management
  - Recurring task generation parameters
  - Save and generation actions
  - Handling of shared entities from other workspaces

- **`group-by-parent.ts`**: Utility to index and group time plan activities by their parent entities (big plans, habits, chores, todo tasks)

- **`target-type-chip.tsx`**: UI component to display the target type of a time plan activity

### Generated API Client Code
- **Python Models**: Request/response argument and result classes for all association endpoints
- **TypeScript Models**: Type definitions for association arguments and results
- **Python API Functions**: HTTP client functions for all six association endpoints with proper error handling

### New Enums
- **`TimePlanActivityTarget`**: Enum defining possible targets for time plan activities (big-plan, chore, habit, inbox-task, todo-task)

## Implementation Details
- Activities are created for both the target entity and any associated inbox tasks that overlap with the time plan date range
- Shared entities from other workspaces are included for display but associations remain read-only
- The implementation follows existing patterns for crown entity support and access control
- Bulk operations use update semantics while individual associations use create semantics

https://claude.ai/code/session_012WPNzUp6TjYS6iswsLqSc1