### PR TITLE
Add peek panel for viewing overlapping calendar events

### DIFF
--- a/src/core/jupiter/core/calendar/component/overlapping-events-peek.tsx
+++ b/src/core/jupiter/core/calendar/component/overlapping-events-peek.tsx
@@ -1,0 +1,243 @@
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  ClickAwayListener,
+  Divider,
+  IconButton,
+  Paper,
+  Popper,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+// How long you need to hover over an event before the peek panel shows up.
+const PEEK_HOVER_OPEN_DELAY_MS = 700;
+// How long the peek panel lingers after the mouse leaves it or its event.
+const PEEK_HOVER_CLOSE_DELAY_MS = 300;
+
+export interface OverlappingEventsPeekTriggerProps {
+  onContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseLeave: () => void;
+}
+
+export interface OverlappingEventsPeekPanelHoverProps {
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+export interface OverlappingEventsPeek {
+  isOpen: boolean;
+  anchorEl: HTMLElement | null;
+  triggerProps: OverlappingEventsPeekTriggerProps;
+  panelHoverProps: OverlappingEventsPeekPanelHoverProps;
+  close: () => void;
+}
+
+interface UseOverlappingEventsPeekProps {
+  enabled: boolean;
+}
+
+// Drives the peek panel of an event: opens it on a right click, or on a long
+// enough hover, and closes it on a click away, on Escape, or when the mouse
+// wanders off - unless it was opened via a right click, in which case it sticks
+// around until it's explicitly dismissed.
+export function useOverlappingEventsPeek(
+  props: UseOverlappingEventsPeekProps,
+): OverlappingEventsPeek {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [isSticky, setIsSticky] = useState(false);
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelOpen = useCallback(() => {
+    if (openTimeoutRef.current !== null) {
+      clearTimeout(openTimeoutRef.current);
+      openTimeoutRef.current = null;
+    }
+  }, []);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimeoutRef.current !== null) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    cancelOpen();
+    cancelClose();
+    setAnchorEl(null);
+    setIsSticky(false);
+  }, [cancelOpen, cancelClose]);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimeoutRef.current = setTimeout(() => {
+      closeTimeoutRef.current = null;
+      setAnchorEl(null);
+      setIsSticky(false);
+    }, PEEK_HOVER_CLOSE_DELAY_MS);
+  }, [cancelClose]);
+
+  useEffect(() => {
+    return () => {
+      cancelOpen();
+      cancelClose();
+    };
+  }, [cancelOpen, cancelClose]);
+
+  useEffect(() => {
+    if (!props.enabled) {
+      close();
+    }
+  }, [props.enabled, close]);
+
+  useEffect(() => {
+    if (anchorEl === null) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        close();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [anchorEl, close]);
+
+  return {
+    isOpen: anchorEl !== null,
+    anchorEl: anchorEl,
+    close: close,
+    triggerProps: {
+      onContextMenu: (event) => {
+        if (!props.enabled) {
+          return;
+        }
+
+        event.preventDefault();
+        cancelOpen();
+        cancelClose();
+        setAnchorEl(event.currentTarget);
+        setIsSticky(true);
+      },
+      onMouseEnter: (event) => {
+        if (!props.enabled) {
+          return;
+        }
+
+        cancelClose();
+        if (anchorEl !== null) {
+          return;
+        }
+
+        const target = event.currentTarget;
+        cancelOpen();
+        openTimeoutRef.current = setTimeout(() => {
+          openTimeoutRef.current = null;
+          setAnchorEl(target);
+        }, PEEK_HOVER_OPEN_DELAY_MS);
+      },
+      onMouseLeave: () => {
+        cancelOpen();
+        if (isSticky) {
+          return;
+        }
+
+        scheduleClose();
+      },
+    },
+    panelHoverProps: {
+      onMouseEnter: cancelClose,
+      onMouseLeave: () => {
+        if (isSticky) {
+          return;
+        }
+
+        scheduleClose();
+      },
+    },
+  };
+}
+
+interface OverlappingEventsPeekPanelProps {
+  peek: OverlappingEventsPeek;
+  title: string;
+  subtitle: string;
+}
+
+export function OverlappingEventsPeekPanel(
+  props: PropsWithChildren<OverlappingEventsPeekPanelProps>,
+) {
+  const theme = useTheme();
+
+  if (props.peek.anchorEl === null) {
+    return null;
+  }
+
+  return (
+    <Popper
+      open={props.peek.isOpen}
+      anchorEl={props.peek.anchorEl}
+      placement="right-start"
+      sx={{ zIndex: theme.zIndex.tooltip }}
+      modifiers={[
+        { name: "offset", options: { offset: [0, 8] } },
+        { name: "preventOverflow", options: { padding: 8 } },
+      ]}
+    >
+      <ClickAwayListener
+        mouseEvent="onMouseDown"
+        onClickAway={props.peek.close}
+      >
+        <Paper
+          elevation={8}
+          onMouseEnter={props.peek.panelHoverProps.onMouseEnter}
+          onMouseLeave={props.peek.panelHoverProps.onMouseLeave}
+          onClick={props.peek.close}
+          sx={{
+            minWidth: "20rem",
+            maxWidth: "28rem",
+            maxHeight: "60vh",
+            overflowY: "auto",
+            padding: "0.5rem",
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="subtitle2">{props.title}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                {props.subtitle}
+              </Typography>
+            </Box>
+
+            <IconButton size="small" onClick={props.peek.close}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+
+          <Divider sx={{ marginBottom: "0.25rem" }} />
+
+          {props.children}
+        </Paper>
+      </ClickAwayListener>
+    </Popper>
+  );
+}

--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -28,7 +28,10 @@ import {
   Box,
   Button,
   styled,
+  Table,
+  TableBody,
   TableCell,
+  TableRow,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -37,6 +40,7 @@ import {
   useRef,
   useState,
   useEffect,
+  useMemo,
   Fragment,
   useContext,
 } from "react";
@@ -67,6 +71,8 @@ import {
   buildTimeBlockOffsetsMap,
   clipTimeEventInDayNameToWhatFits,
   timeEventInDayBlockOwnerTheType,
+  findNearbyTimeEventInDayEntries,
+  NEARBY_TIME_EVENT_WINDOW_MINS,
 } from "#/core/common/sub/time_events/time-event";
 import {
   scheduleStreamColorContrastingHex,
@@ -79,6 +85,11 @@ import {
   CalendarEventLink,
   useCalendarStatsPath,
 } from "#/core/calendar/component/calendar-navigation";
+import {
+  OverlappingEventsPeekPanel,
+  OverlappingEventsPeekTriggerProps,
+  useOverlappingEventsPeek,
+} from "#/core/calendar/component/overlapping-events-peek";
 import { TimeEventParamsNewPlaceholder } from "#/core/common/sub/time_events/component/params-new-placeholder";
 import { timePlanActivityNameForEvent } from "#/core/time_plans/sub/activity/root";
 
@@ -624,6 +635,7 @@ export function ViewAsCalendarTimeEventInDayColumn(
             offset={timeBlockOffsetsMap.get(entry.time_event_in_tz.ref_id) || 0}
             startOfDay={startOfDay}
             entry={entry}
+            allEntriesInDay={props.timeEventsInDay}
             isAdding={props.isAdding}
             deltaHour={deltaHour}
           />
@@ -637,12 +649,87 @@ interface ViewAsCalendarTimeEventInDayCellProps {
   offset: number;
   startOfDay: DateTime;
   entry: CombinedTimeEventInDayEntry;
+  allEntriesInDay: Array<CombinedTimeEventInDayEntry>;
   isAdding: boolean;
   deltaHour: number;
 }
 
 export function ViewAsCalendarTimeEventInDayCell(
   props: ViewAsCalendarTimeEventInDayCellProps,
+) {
+  const theme = useTheme();
+  const isBigScreen = useBigScreen();
+
+  const nearbyEntries = useMemo(
+    () => findNearbyTimeEventInDayEntries(props.allEntriesInDay, props.entry),
+    [props.allEntriesInDay, props.entry],
+  );
+
+  // There's nothing worth peeking at when the event stands on its own.
+  const otherNearbyEntriesCnt = nearbyEntries.length - 1;
+  const peek = useOverlappingEventsPeek({
+    enabled: isBigScreen && otherNearbyEntriesCnt > 0,
+  });
+
+  const startTime = calculateStartTimeForTimeEvent(
+    props.entry.time_event_in_tz,
+  );
+  const endTime = calculateEndTimeForTimeEvent(props.entry.time_event_in_tz);
+
+  return (
+    <Fragment>
+      <ViewAsCalendarTimeEventInDayCellContent
+        {...props}
+        peekTriggerProps={peek.triggerProps}
+      />
+
+      <OverlappingEventsPeekPanel
+        peek={peek}
+        title={`Around [${startTime.toFormat("HH:mm")} - ${endTime.toFormat(
+          "HH:mm",
+        )}]`}
+        subtitle={`${otherNearbyEntriesCnt} other event${
+          otherNearbyEntriesCnt === 1 ? "" : "s"
+        } overlapping it, or within ${NEARBY_TIME_EVENT_WINDOW_MINS} minutes before or after`}
+      >
+        <Table
+          size="small"
+          sx={{ borderCollapse: "separate", borderSpacing: "0.2rem" }}
+        >
+          <TableBody>
+            {nearbyEntries.map((nearbyEntry, index) => (
+              <TableRow
+                key={index}
+                sx={{
+                  "& td": {
+                    border:
+                      nearbyEntry.time_event_in_tz.ref_id ===
+                      props.entry.time_event_in_tz.ref_id
+                        ? `2px solid ${theme.palette.info.main}`
+                        : "2px solid transparent",
+                  },
+                }}
+              >
+                <ViewAsScheduleTimeEventInDaysRows
+                  period={RecurringTaskPeriod.DAILY}
+                  entry={nearbyEntry}
+                  isAdding={props.isAdding}
+                />
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </OverlappingEventsPeekPanel>
+    </Fragment>
+  );
+}
+
+interface ViewAsCalendarTimeEventInDayCellContentProps extends ViewAsCalendarTimeEventInDayCellProps {
+  peekTriggerProps: OverlappingEventsPeekTriggerProps;
+}
+
+function ViewAsCalendarTimeEventInDayCellContent(
+  props: ViewAsCalendarTimeEventInDayCellContentProps,
 ) {
   const theme = useTheme();
   const topLevelInfo = useContext(TopLevelInfoContext);
@@ -690,6 +777,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`schedule-event-in-day-block-${(props.entry.entry as ScheduleInDayEventEntry).event.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",
@@ -780,6 +868,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`big-plan-event-in-day-block-${bigPlanEntry.big_plan.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",
@@ -875,6 +964,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`todo-task-event-in-day-block-${todoTaskEntry.todo_task.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",
@@ -967,6 +1057,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`habit-event-in-day-block-${habitEntry.habit.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",
@@ -1052,6 +1143,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`chore-event-in-day-block-${choreEntry.chore.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",
@@ -1137,6 +1229,7 @@ export function ViewAsCalendarTimeEventInDayCell(
         <Box
           ref={containerRef}
           id={`time-plan-activity-event-in-day-block-${activityEntry.time_plan_activity.ref_id}`}
+          {...props.peekTriggerProps}
           sx={{
             fontSize: "10px",
             position: "absolute",

--- a/src/core/jupiter/core/common/sub/time_events/time-event.ts
+++ b/src/core/jupiter/core/common/sub/time_events/time-event.ts
@@ -562,6 +562,36 @@ export function sortTimeEventInDayByStartTimeAndEndTime(
   });
 }
 
+// How much before the start and after the end of an event we look for
+// other events when peeking at the events overlapping a certain one.
+export const NEARBY_TIME_EVENT_WINDOW_MINS = 30;
+
+export function findNearbyTimeEventInDayEntries(
+  entries: Array<CombinedTimeEventInDayEntry>,
+  focusEntry: CombinedTimeEventInDayEntry,
+  windowMins: number = NEARBY_TIME_EVENT_WINDOW_MINS,
+): Array<CombinedTimeEventInDayEntry> {
+  const focusStartTime = calculateStartTimeForTimeEvent(
+    focusEntry.time_event_in_tz,
+  );
+  const focusEndTime = calculateEndTimeForTimeEvent(
+    focusEntry.time_event_in_tz,
+  );
+  const windowStartTime = focusStartTime.minus({ minutes: windowMins });
+  const windowEndTime = focusEndTime.plus({ minutes: windowMins });
+
+  // Events merely touching the window - ending exactly when it starts, or
+  // starting exactly when it ends - are far enough away to be left out. The
+  // focus event itself always makes the cut.
+  const nearbyEntries = entries.filter((entry) => {
+    const startTime = calculateStartTimeForTimeEvent(entry.time_event_in_tz);
+    const endTime = calculateEndTimeForTimeEvent(entry.time_event_in_tz);
+    return startTime < windowEndTime && endTime > windowStartTime;
+  });
+
+  return sortTimeEventInDayByStartTimeAndEndTime(nearbyEntries);
+}
+
 export function buildTimeBlockOffsetsMap(
   entries: Array<CombinedTimeEventInDayEntry>,
   startOfDay: DateTime,

--- a/src/docs/material/concepts/calendar.md
+++ b/src/docs/material/concepts/calendar.md
@@ -99,3 +99,18 @@ Here's a peek at some views:
 ![Monthly Calendar](../assets/calendar-view-calendar-monthly.png)
 
 ![Yearly Schedule](../assets/calendar-view-schedule-yearly.png)
+
+### Peeking At Overlapping Events
+
+In the daily and weekly calendar views on a big screen, events that happen at
+the same time are drawn one on top of the other, so their names get clipped and
+hard to read.
+
+Right click on such an event - or just hover over it for a moment - and a panel
+pops up with a schedule view of everything happening around it: every event
+overlapping it, plus everything within half an hour before it starts or half an
+hour after it ends. The event you're peeking from is highlighted, and each entry
+in the panel links to its own event.
+
+The panel goes away when you press `Escape`, when you click elsewhere, or - if
+you opened it by hovering - when you move the mouse away from it.


### PR DESCRIPTION
## Summary
This PR adds a new "peek panel" feature that allows users to view all events overlapping or near a specific calendar event. When hovering over or right-clicking an event in the daily/weekly calendar views, a panel appears showing a schedule view of all nearby events within a 30-minute window before and after.

## Key Changes

- **New component: `OverlappingEventsPeekPanel`** (`overlapping-events-peek.tsx`)
  - Implements a reusable hook `useOverlappingEventsPeek()` that manages the peek panel state and interactions
  - Handles opening via right-click (sticky) or hover (auto-closing)
  - Supports closing via Escape key, click-away, or mouse leaving the panel
  - Configurable open/close delays (700ms hover delay, 300ms close delay)

- **New utility function: `findNearbyTimeEventInDayEntries()`** (`time-event.ts`)
  - Finds all events overlapping or within 30 minutes of a given event
  - Exports `NEARBY_TIME_EVENT_WINDOW_MINS` constant for the search window

- **Updated calendar event rendering** (`shared.tsx`)
  - Refactored `ViewAsCalendarTimeEventInDayCell` to use the new peek functionality
  - Extracted rendering logic into `ViewAsCalendarTimeEventInDayCellContent`
  - Peek panel only enabled on big screens when there are overlapping events
  - Panel displays a table of nearby events with the current event highlighted
  - Integrated peek trigger props (context menu, mouse enter/leave) into all event type boxes

- **Documentation** (`calendar.md`)
  - Added section explaining the peek panel feature and how to use it

## Implementation Details

- The peek panel uses Material-UI's `Popper` component for positioning relative to the trigger event
- Hover-opened panels auto-close after 300ms when the mouse leaves, while right-click-opened panels remain sticky until explicitly dismissed
- The panel shows event details in a compact table format with the focused event highlighted with a blue border
- Feature is only available on big screens to avoid cluttering mobile/tablet interfaces

https://claude.ai/code/session_01N8yER3LUgLX18e5djpnAn3