### PR TITLE
Add calendar view to time plans for daily and weekly periods

### DIFF
--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -1,4 +1,4 @@
-import { ADate, EntityId, RecurringTaskPeriod } from "@jupiter/webapi-client";
+import { EntityId, RecurringTaskPeriod } from "@jupiter/webapi-client";
 import { Box } from "@mui/material";
 import { createContext, PropsWithChildren, ReactNode, useContext } from "react";
 import { useSearchParams } from "@remix-run/react";
@@ -84,18 +84,10 @@ function workspaceCalendarNavigation(): CalendarNavigationValue {
 // details leaf here, with a way through to the original in the calendar.
 export function timePlanCalendarNavigation(
   timePlanRefId: EntityId,
-  date: ADate,
-  period: RecurringTaskPeriod,
   activityRefIdByEvent: Map<string, string>,
 ): CalendarNavigationValue {
   const calendarBasePath = "/app/workspace/calendar";
   const timePlanBasePath = `/app/workspace/time-plans/${encodeURIComponent(timePlanRefId)}`;
-  const params = new URLSearchParams({
-    date: date,
-    period: period,
-    view: "calendar",
-    timePlanRefId: timePlanRefId,
-  });
 
   return {
     eventPath: (kind, refId) => {
@@ -108,13 +100,8 @@ export function timePlanCalendarNavigation(
 
       return `${timePlanBasePath}/calendar-event/${kind}/${encodeURIComponent(refId)}`;
     },
-    newInDayEventPath: (query) => {
-      const withTimePlan = new URLSearchParams(query);
-      for (const [key, value] of params) {
-        withTimePlan.set(key, value);
-      }
-      return `${calendarBasePath}/schedule/event-in-day/new?${withTimePlan}`;
-    },
+    newInDayEventPath: (query) =>
+      `${timePlanBasePath}/new-schedule-event-in-day?${query}`,
     statsPath: (calendarLocation, periodStartDate, statsPeriod, view) =>
       `${calendarBasePath}${calendarLocation}?date=${periodStartDate}&period=${statsPeriod}&view=${view}`,
   };

--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -4,6 +4,10 @@ import { createContext, PropsWithChildren, ReactNode, useContext } from "react";
 import { useSearchParams } from "@remix-run/react";
 
 import { EntityLink } from "#/core/infra/component/entity-card";
+import {
+  TimePlanViewMode,
+  withTimePlanView,
+} from "#/core/time_plans/view-mode";
 
 export type CalendarEventLinkKind =
   | "schedule-event-in-day"
@@ -95,7 +99,13 @@ export function calendarLeafReturnLocation(
 ): string {
   const timePlanRefId = searchParams.get("timePlanRefId");
   if (timePlanRefId !== null && timePlanRefId !== "") {
-    return `/app/workspace/time-plans/${encodeURIComponent(timePlanRefId)}`;
+    // Only the calendar view of a time plan opens these panels, so that's the
+    // view to come back to - said out loud rather than read off the query,
+    // where "view" belongs to the calendar.
+    return withTimePlanView(
+      `/app/workspace/time-plans/${encodeURIComponent(timePlanRefId)}`,
+      TimePlanViewMode.CALENDAR,
+    );
   }
 
   return `/app/workspace/calendar?${searchParams}`;

--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -9,11 +9,38 @@ import {
   withTimePlanView,
 } from "#/core/time_plans/view-mode";
 
-export type CalendarEventLinkKind =
-  | "schedule-event-in-day"
-  | "schedule-event-full-days"
-  | "time-event-in-day-block"
-  | "time-event-full-days-block";
+export const CALENDAR_EVENT_LINK_KINDS = [
+  "schedule-event-in-day",
+  "schedule-event-full-days",
+  "time-event-in-day-block",
+  "time-event-full-days-block",
+] as const;
+
+export type CalendarEventLinkKind = (typeof CALENDAR_EVENT_LINK_KINDS)[number];
+
+export function calendarEventLinkKey(
+  kind: CalendarEventLinkKind,
+  refId: string,
+): string {
+  return `${kind}:${refId}`;
+}
+
+export function calendarEventWorkspacePath(
+  kind: CalendarEventLinkKind,
+  refId: string,
+): string {
+  const calendarBasePath = "/app/workspace/calendar";
+  switch (kind) {
+    case "schedule-event-in-day":
+      return `${calendarBasePath}/schedule/event-in-day/${refId}`;
+    case "schedule-event-full-days":
+      return `${calendarBasePath}/schedule/event-full-days/${refId}`;
+    case "time-event-in-day-block":
+      return `${calendarBasePath}/time-event/in-day-block/${refId}`;
+    case "time-event-full-days-block":
+      return `${calendarBasePath}/time-event/full-days-block/${refId}`;
+  }
+}
 
 export interface CalendarNavigationValue {
   eventPath: (kind: CalendarEventLinkKind, refId: string) => string | undefined;
@@ -31,18 +58,7 @@ export interface CalendarNavigationValue {
 function workspaceCalendarNavigation(): CalendarNavigationValue {
   const calendarBasePath = "/app/workspace/calendar";
   return {
-    eventPath: (kind, refId) => {
-      switch (kind) {
-        case "schedule-event-in-day":
-          return `${calendarBasePath}/schedule/event-in-day/${refId}`;
-        case "schedule-event-full-days":
-          return `${calendarBasePath}/schedule/event-full-days/${refId}`;
-        case "time-event-in-day-block":
-          return `${calendarBasePath}/time-event/in-day-block/${refId}`;
-        case "time-event-full-days-block":
-          return `${calendarBasePath}/time-event/full-days-block/${refId}`;
-      }
-    },
+    eventPath: calendarEventWorkspacePath,
     newInDayEventPath: (query) =>
       `${calendarBasePath}/schedule/event-in-day/new?${query}`,
     statsPath: (calendarLocation, periodStartDate, period, view) =>
@@ -50,15 +66,17 @@ function workspaceCalendarNavigation(): CalendarNavigationValue {
   };
 }
 
-// The calendar view inside a time plan. The events themselves live in the
-// calendar, so their panels are the calendar's own - they just know to come
-// back to the time plan they were opened from, rather than to the calendar.
+// The calendar view inside a time plan. Events that belong to an activity
+// open that activity as a leaf on this same plan. Other events open a small
+// details leaf here, with a way through to the original in the calendar.
 export function timePlanCalendarNavigation(
   timePlanRefId: EntityId,
   date: ADate,
   period: RecurringTaskPeriod,
+  activityRefIdByEvent: Map<string, string>,
 ): CalendarNavigationValue {
   const calendarBasePath = "/app/workspace/calendar";
+  const timePlanBasePath = `/app/workspace/time-plans/${encodeURIComponent(timePlanRefId)}`;
   const params = new URLSearchParams({
     date: date,
     period: period,
@@ -68,16 +86,14 @@ export function timePlanCalendarNavigation(
 
   return {
     eventPath: (kind, refId) => {
-      switch (kind) {
-        case "schedule-event-in-day":
-          return `${calendarBasePath}/schedule/event-in-day/${refId}?${params}`;
-        case "schedule-event-full-days":
-          return `${calendarBasePath}/schedule/event-full-days/${refId}?${params}`;
-        case "time-event-in-day-block":
-          return `${calendarBasePath}/time-event/in-day-block/${refId}?${params}`;
-        case "time-event-full-days-block":
-          return `${calendarBasePath}/time-event/full-days-block/${refId}?${params}`;
+      const activityRefId = activityRefIdByEvent.get(
+        calendarEventLinkKey(kind, refId),
+      );
+      if (activityRefId !== undefined) {
+        return `${timePlanBasePath}/${encodeURIComponent(activityRefId)}`;
       }
+
+      return `${timePlanBasePath}/calendar-event/${kind}/${encodeURIComponent(refId)}`;
     },
     newInDayEventPath: (query) => {
       const withTimePlan = new URLSearchParams(query);
@@ -182,8 +198,8 @@ export function CalendarEventLink(props: CalendarEventLinkProps) {
   }
 
   // The calendar keeps the date it's looking at in the query, and the event
-  // panels need it to come back to. A page without one of its own - the time
-  // plan calendar view - leaves the path the navigation built alone.
+  // panels need it to come back to. The time plan calendar view already put
+  // the leaf path together, and this just carries the view along.
   const queryString = query.toString();
   const path =
     queryString === ""

--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -42,6 +42,19 @@ export function calendarEventWorkspacePath(
   }
 }
 
+// The calendar event as it lives in the workspace, with enough on the query
+// that closing the panel comes back to the time plan's calendar view.
+export function calendarEventWorkspacePathFromTimePlan(
+  kind: CalendarEventLinkKind,
+  refId: string,
+  timePlanRefId: string,
+): string {
+  const params = new URLSearchParams({
+    timePlanRefId: timePlanRefId,
+  });
+  return `${calendarEventWorkspacePath(kind, refId)}?${params.toString()}`;
+}
+
 export interface CalendarNavigationValue {
   eventPath: (kind: CalendarEventLinkKind, refId: string) => string | undefined;
   // Where a double click on an empty patch of a day goes to make a new event
@@ -113,7 +126,12 @@ export function timePlanCalendarNavigation(
 export function calendarLeafReturnLocation(
   searchParams: URLSearchParams,
 ): string {
-  const timePlanRefId = searchParams.get("timePlanRefId");
+  const cleaned = new URLSearchParams(searchParams);
+  cleaned.delete("sourceStartDate");
+  cleaned.delete("sourceStartTimeInDay");
+  cleaned.delete("sourceDurationMins");
+
+  const timePlanRefId = cleaned.get("timePlanRefId");
   if (timePlanRefId !== null && timePlanRefId !== "") {
     // Only the calendar view of a time plan opens these panels, so that's the
     // view to come back to - said out loud rather than read off the query,
@@ -124,7 +142,7 @@ export function calendarLeafReturnLocation(
     );
   }
 
-  return `/app/workspace/calendar?${searchParams}`;
+  return `/app/workspace/calendar?${cleaned}`;
 }
 
 export function publishedScheduleStreamCalendarNavigation(

--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -1,4 +1,4 @@
-import { RecurringTaskPeriod } from "@jupiter/webapi-client";
+import { ADate, EntityId, RecurringTaskPeriod } from "@jupiter/webapi-client";
 import { Box } from "@mui/material";
 import { createContext, PropsWithChildren, ReactNode, useContext } from "react";
 import { useSearchParams } from "@remix-run/react";
@@ -13,6 +13,9 @@ export type CalendarEventLinkKind =
 
 export interface CalendarNavigationValue {
   eventPath: (kind: CalendarEventLinkKind, refId: string) => string | undefined;
+  // Where a double click on an empty patch of a day goes to make a new event
+  // out of it. Nowhere, on a calendar that's only there to be looked at.
+  newInDayEventPath: (query: URLSearchParams) => string | undefined;
   statsPath: (
     calendarLocation: string,
     periodStartDate: string,
@@ -36,9 +39,66 @@ function workspaceCalendarNavigation(): CalendarNavigationValue {
           return `${calendarBasePath}/time-event/full-days-block/${refId}`;
       }
     },
+    newInDayEventPath: (query) =>
+      `${calendarBasePath}/schedule/event-in-day/new?${query}`,
     statsPath: (calendarLocation, periodStartDate, period, view) =>
       `${calendarBasePath}${calendarLocation}?date=${periodStartDate}&period=${period}&view=${view}`,
   };
+}
+
+// The calendar view inside a time plan. The events themselves live in the
+// calendar, so their panels are the calendar's own - they just know to come
+// back to the time plan they were opened from, rather than to the calendar.
+export function timePlanCalendarNavigation(
+  timePlanRefId: EntityId,
+  date: ADate,
+  period: RecurringTaskPeriod,
+): CalendarNavigationValue {
+  const calendarBasePath = "/app/workspace/calendar";
+  const params = new URLSearchParams({
+    date: date,
+    period: period,
+    view: "calendar",
+    timePlanRefId: timePlanRefId,
+  });
+
+  return {
+    eventPath: (kind, refId) => {
+      switch (kind) {
+        case "schedule-event-in-day":
+          return `${calendarBasePath}/schedule/event-in-day/${refId}?${params}`;
+        case "schedule-event-full-days":
+          return `${calendarBasePath}/schedule/event-full-days/${refId}?${params}`;
+        case "time-event-in-day-block":
+          return `${calendarBasePath}/time-event/in-day-block/${refId}?${params}`;
+        case "time-event-full-days-block":
+          return `${calendarBasePath}/time-event/full-days-block/${refId}?${params}`;
+      }
+    },
+    newInDayEventPath: (query) => {
+      const withTimePlan = new URLSearchParams(query);
+      for (const [key, value] of params) {
+        withTimePlan.set(key, value);
+      }
+      return `${calendarBasePath}/schedule/event-in-day/new?${withTimePlan}`;
+    },
+    statsPath: (calendarLocation, periodStartDate, statsPeriod, view) =>
+      `${calendarBasePath}${calendarLocation}?date=${periodStartDate}&period=${statsPeriod}&view=${view}`,
+  };
+}
+
+// Where the panel of an event goes back to when it's closed. An event opened
+// from a time plan's calendar view returns to that time plan, anything else
+// to the calendar it came from.
+export function calendarLeafReturnLocation(
+  searchParams: URLSearchParams,
+): string {
+  const timePlanRefId = searchParams.get("timePlanRefId");
+  if (timePlanRefId !== null && timePlanRefId !== "") {
+    return `/app/workspace/time-plans/${encodeURIComponent(timePlanRefId)}`;
+  }
+
+  return `/app/workspace/calendar?${searchParams}`;
 }
 
 export function publishedScheduleStreamCalendarNavigation(
@@ -56,6 +116,9 @@ export function publishedScheduleStreamCalendarNavigation(
           return undefined;
       }
     },
+    // A published calendar belongs to whoever published it - a visitor has
+    // nothing to add to it.
+    newInDayEventPath: () => undefined,
     statsPath: (calendarLocation, periodStartDate, period, view) =>
       `${calendarBasePath}${calendarLocation}?date=${periodStartDate}&period=${period}&view=${view}`,
   };
@@ -108,9 +171,16 @@ export function CalendarEventLink(props: CalendarEventLinkProps) {
     );
   }
 
-  const path = basePath.includes("?")
-    ? `${basePath}&${query}`
-    : `${basePath}?${query}`;
+  // The calendar keeps the date it's looking at in the query, and the event
+  // panels need it to come back to. A page without one of its own - the time
+  // plan calendar view - leaves the path the navigation built alone.
+  const queryString = query.toString();
+  const path =
+    queryString === ""
+      ? basePath
+      : basePath.includes("?")
+        ? `${basePath}&${queryString}`
+        : `${basePath}?${queryString}`;
 
   return (
     <EntityLink

--- a/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
+++ b/src/core/jupiter/core/calendar/component/calendar-navigation.tsx
@@ -16,6 +16,10 @@ export const CALENDAR_EVENT_LINK_KINDS = [
   "time-event-full-days-block",
 ] as const;
 
+// Which time event on the calendar opened this activity, so the activity
+// leaf can take that event off without taking the activity with it.
+export const TIME_PLAN_ACTIVITY_TIME_EVENT_PARAM = "timeEventRefId";
+
 export type CalendarEventLinkKind = (typeof CALENDAR_EVENT_LINK_KINDS)[number];
 
 export function calendarEventLinkKey(
@@ -95,7 +99,11 @@ export function timePlanCalendarNavigation(
         calendarEventLinkKey(kind, refId),
       );
       if (activityRefId !== undefined) {
-        return `${timePlanBasePath}/${encodeURIComponent(activityRefId)}`;
+        const activityPath = `${timePlanBasePath}/${encodeURIComponent(activityRefId)}`;
+        if (kind === "time-event-in-day-block") {
+          return `${activityPath}?${TIME_PLAN_ACTIVITY_TIME_EVENT_PARAM}=${encodeURIComponent(refId)}`;
+        }
+        return activityPath;
       }
 
       return `${timePlanBasePath}/calendar-event/${kind}/${encodeURIComponent(refId)}`;

--- a/src/core/jupiter/core/calendar/component/event-drag.tsx
+++ b/src/core/jupiter/core/calendar/component/event-drag.tsx
@@ -1255,11 +1255,7 @@ export function CalendarPlaceGhost(props: CalendarPlaceGhostProps) {
   let startTimeInDay: TimeInDay | null = null;
   let durationMins = PLACE_ACTIVITY_DURATION_MINS;
 
-  if (
-    snapshot !== null &&
-    snapshot.mode === "place" &&
-    snapshot.overCalendar
-  ) {
+  if (snapshot !== null && snapshot.mode === "place" && snapshot.overCalendar) {
     startDate = snapshot.newStartTime.toFormat("yyyy-MM-dd") as ADate;
     startTimeInDay = snapshot.newStartTime.toFormat("HH:mm") as TimeInDay;
     durationMins = snapshot.durationMins;
@@ -1269,7 +1265,11 @@ export function CalendarPlaceGhost(props: CalendarPlaceGhostProps) {
     durationMins = pendingPlace.durationMins;
   }
 
-  if (startDate === null || startTimeInDay === null || startDate !== props.date) {
+  if (
+    startDate === null ||
+    startTimeInDay === null ||
+    startDate !== props.date
+  ) {
     return null;
   }
 

--- a/src/core/jupiter/core/calendar/component/event-drag.tsx
+++ b/src/core/jupiter/core/calendar/component/event-drag.tsx
@@ -24,13 +24,23 @@ import {
 import { ActionResult } from "#/core/infra/action-result";
 import {
   CombinedTimeEventInDayEntry,
+  calendarTimeEventInDayDurationToRems,
+  calendarTimeEventInDayStartMinutesToRems,
   isTimeEventInDayBlockEditable,
+  TIME_PLAN_ACTIVITY_TIME_EVENT_COLOR,
   timeEventInDayBlockOwnerTheType,
 } from "#/core/common/sub/time_events/time-event";
 import { isCorePropertyEditable } from "#/core/schedule/sub/event_in_day/root";
+import { scheduleStreamColorHex } from "#/core/schedule/sub/stream/color";
 
 // Where a dropped event goes to be saved.
 export const CALENDAR_RESCHEDULE_ACTION = "/app/workspace/calendar/reschedule";
+// Where dropping an activity from the time plan list onto the calendar goes
+// to make a time event of it.
+export const CALENDAR_PLACE_ACTIVITY_ACTION =
+  "/app/workspace/time-plans/place-activity-time-event";
+// How long a newly placed activity event lasts, matching the add-event form.
+export const PLACE_ACTIVITY_DURATION_MINS = 60;
 
 // How long you need to keep holding an event before it comes loose and starts
 // following the pointer around.
@@ -69,6 +79,16 @@ export interface CalendarEventDragTarget {
   startDate: ADate;
   startTimeInDay: TimeInDay;
   durationMins: number;
+}
+
+export interface CalendarPlaceActivitySource {
+  activityRefId: EntityId;
+  timePlanRefId: EntityId;
+  durationMins: number;
+}
+
+function placeBlockRefId(activityRefId: EntityId): EntityId {
+  return `place:${activityRefId}`;
 }
 
 // Works out what a drag of this entry would move, or nothing at all when the
@@ -141,13 +161,21 @@ interface CalendarEventDragSnapshot extends CalendarEventDragStatus {
   pointerY: number;
   newStartTime: DateTime;
   durationMins: number;
+  // Moving an event already on the calendar, or placing an activity onto it.
+  mode: "reschedule" | "place";
+  // For a place, whether the pointer is over a day column. Dropping off the
+  // grid does nothing.
+  overCalendar: boolean;
 }
 
 interface CalendarEventDragPress {
   pointerId: number;
-  target: CalendarEventDragTarget;
+  mode: "reschedule" | "place";
+  target: CalendarEventDragTarget | null;
+  place: CalendarPlaceActivitySource | null;
   // The day column the gesture started in - which is the day of the piece
-  // being dragged, not necessarily the day the event starts in.
+  // being dragged, not necessarily the day the event starts in. Unused when
+  // placing an activity, which has no column of its own yet.
   sourceDate: ADate;
   startX: number;
   startY: number;
@@ -163,6 +191,12 @@ interface CalendarPendingReschedule {
   startTimeInDay: TimeInDay;
 }
 
+interface CalendarPendingPlace {
+  startDate: ADate;
+  startTimeInDay: TimeInDay;
+  durationMins: number;
+}
+
 interface CalendarEventDragBeginArgs {
   target: CalendarEventDragTarget;
   sourceDate: ADate;
@@ -172,6 +206,10 @@ export interface CalendarEventDragController {
   beginPress(
     event: React.PointerEvent<HTMLElement>,
     args: CalendarEventDragBeginArgs,
+  ): void;
+  beginPlacePress(
+    event: React.PointerEvent<HTMLElement>,
+    source: CalendarPlaceActivitySource,
   ): void;
   consumeClickSuppression(blockRefId: EntityId): boolean;
   isPressing(): boolean;
@@ -185,6 +223,9 @@ interface CalendarEventDragContextValue {
   controller: CalendarEventDragController;
   // The move waiting on the server, shown in place while it's in flight.
   pending: CalendarPendingReschedule | null;
+  // An activity just dropped on the calendar, shown where it will land until
+  // the new event comes back.
+  pendingPlace: CalendarPendingPlace | null;
 }
 
 const CalendarEventDragContext =
@@ -298,12 +339,22 @@ export function CalendarEventDragProvider(
       pressRef.current = null;
     }
 
+    function suppressionBlockRefId(press: CalendarEventDragPress): EntityId {
+      if (press.target !== null) {
+        return press.target.blockRefId;
+      }
+      if (press.place !== null) {
+        return placeBlockRefId(press.place.activityRefId);
+      }
+      return "";
+    }
+
     function abandonPress() {
       // An event that came loose and then went back where it was shouldn't
       // open on the click coming after the gesture either.
       if (pressRef.current?.armed) {
         suppressClickRef.current = {
-          blockRefId: pressRef.current.target.blockRefId,
+          blockRefId: suppressionBlockRefId(pressRef.current),
           until: Date.now() + CLICK_SUPPRESSION_MS,
         };
       }
@@ -342,11 +393,29 @@ export function CalendarEventDragProvider(
       pointerX: number,
       pointerY: number,
     ): CalendarEventDragSnapshot {
+      if (press.mode === "place" && press.place !== null) {
+        return computePlaceSnapshot(press, press.place, pointerX, pointerY);
+      }
+
+      const target = press.target;
+      if (target === null) {
+        return computePlaceSnapshot(
+          press,
+          {
+            activityRefId: "",
+            timePlanRefId: "",
+            durationMins: PLACE_ACTIVITY_DURATION_MINS,
+          },
+          pointerX,
+          pointerY,
+        );
+      }
+
       const scrollTop = press.scroller?.scrollTop ?? 0;
       const contentDy =
         pointerY - press.startY + (scrollTop - press.startScrollTop);
 
-      const startMinutes = minutesSinceStartOfDay(press.target.startTimeInDay);
+      const startMinutes = minutesSinceStartOfDay(target.startTimeInDay);
       const minutesDelta = clamp(
         Math.round(contentDy / press.remPx) * MINUTES_PER_REM,
         -startMinutes,
@@ -356,13 +425,13 @@ export function CalendarEventDragProvider(
       const { dayDelta, dxPx } = resolveColumn(press, pointerX);
 
       const startTime = DateTime.fromISO(
-        `${press.target.startDate}T${press.target.startTimeInDay}`,
+        `${target.startDate}T${target.startTimeInDay}`,
         { zone: "UTC" },
       );
 
       return {
         phase: dayDelta === 0 && minutesDelta === 0 ? "holding" : "moving",
-        blockRefId: press.target.blockRefId,
+        blockRefId: target.blockRefId,
         dxPx: dxPx,
         dyPx: (minutesDelta / MINUTES_PER_REM) * press.remPx,
         dayDelta: dayDelta,
@@ -373,8 +442,76 @@ export function CalendarEventDragProvider(
           days: dayDelta,
           minutes: minutesDelta,
         }),
-        durationMins: press.target.durationMins,
+        durationMins: target.durationMins,
+        mode: "reschedule",
+        overCalendar: true,
       };
+    }
+
+    function computePlaceSnapshot(
+      press: CalendarEventDragPress,
+      place: CalendarPlaceActivitySource,
+      pointerX: number,
+      pointerY: number,
+    ): CalendarEventDragSnapshot {
+      const hit = hitTestColumn(pointerX);
+      const durationMins = place.durationMins;
+      const blockRefId = placeBlockRefId(place.activityRefId);
+
+      if (hit === undefined) {
+        return {
+          phase: "holding",
+          blockRefId: blockRefId,
+          dxPx: 0,
+          dyPx: 0,
+          dayDelta: 0,
+          minutesDelta: 0,
+          pointerX: pointerX,
+          pointerY: pointerY,
+          newStartTime: DateTime.fromISO("1987-09-18T00:00:00", {
+            zone: "UTC",
+          }),
+          durationMins: durationMins,
+          mode: "place",
+          overCalendar: false,
+        };
+      }
+
+      const minutes = clamp(
+        Math.round((pointerY - hit.rect.top) / press.remPx) * MINUTES_PER_REM,
+        0,
+        LAST_START_MINUTE_OF_DAY,
+      );
+      const newStartTime = DateTime.fromISO(`${hit.date}T00:00:00`, {
+        zone: "UTC",
+      }).plus({ minutes: minutes });
+
+      return {
+        phase: "moving",
+        blockRefId: blockRefId,
+        dxPx: 0,
+        dyPx: 0,
+        dayDelta: 0,
+        minutesDelta: minutes,
+        pointerX: pointerX,
+        pointerY: pointerY,
+        newStartTime: newStartTime,
+        durationMins: durationMins,
+        mode: "place",
+        overCalendar: true,
+      };
+    }
+
+    function hitTestColumn(
+      pointerX: number,
+    ): { date: ADate; rect: DOMRect } | undefined {
+      for (const [date, element] of columnsRef.current) {
+        const rect = element.getBoundingClientRect();
+        if (pointerX >= rect.left && pointerX < rect.right) {
+          return { date: date, rect: rect };
+        }
+      }
+      return undefined;
     }
 
     function trackPointer(pointerX: number, pointerY: number) {
@@ -440,13 +577,37 @@ export function CalendarEventDragProvider(
         return;
       }
 
+      const suppressionId = suppressionBlockRefId(press);
+      const place = press.place;
       const target = press.target;
       releasePress();
       suppressClickRef.current = {
-        blockRefId: target.blockRefId,
+        blockRefId: suppressionId,
         until: Date.now() + CLICK_SUPPRESSION_MS,
       };
       publish(null);
+
+      if (press.mode === "place") {
+        if (place === null || !snapshot.overCalendar) {
+          return;
+        }
+
+        submitRef.current(
+          {
+            timePlanActivityRefId: place.activityRefId,
+            startDate: snapshot.newStartTime.toFormat("yyyy-MM-dd"),
+            startTimeInDay: snapshot.newStartTime.toFormat("HH:mm"),
+            durationMins: String(place.durationMins),
+            userTimezone: timezoneRef.current,
+          },
+          { method: "post", action: CALENDAR_PLACE_ACTIVITY_ACTION },
+        );
+        return;
+      }
+
+      if (target === null) {
+        return;
+      }
 
       if (snapshot.dayDelta === 0 && snapshot.minutesDelta === 0) {
         return;
@@ -465,6 +626,106 @@ export function CalendarEventDragProvider(
       );
     }
 
+    function attachGesture(event: React.PointerEvent<HTMLElement>) {
+      function handlePointerMove(moveEvent: PointerEvent) {
+        const press = pressRef.current;
+        if (press === null || moveEvent.pointerId !== press.pointerId) {
+          return;
+        }
+
+        if (!press.armed) {
+          const distance = Math.hypot(
+            moveEvent.clientX - press.startX,
+            moveEvent.clientY - press.startY,
+          );
+          if (distance > HOLD_TOLERANCE_PX) {
+            // The gesture turned out to be a scroll or a text selection.
+            abandonPress();
+          }
+          return;
+        }
+
+        trackPointer(moveEvent.clientX, moveEvent.clientY);
+      }
+
+      function handlePointerUp(upEvent: PointerEvent) {
+        const press = pressRef.current;
+        if (press === null || upEvent.pointerId !== press.pointerId) {
+          return;
+        }
+
+        if (press.armed) {
+          commit();
+        } else {
+          abandonPress();
+        }
+      }
+
+      function handlePointerCancel(cancelEvent: PointerEvent) {
+        const press = pressRef.current;
+        if (press === null || cancelEvent.pointerId !== press.pointerId) {
+          return;
+        }
+        abandonPress();
+      }
+
+      function handleKeyDown(keyEvent: KeyboardEvent) {
+        if (keyEvent.key === "Escape") {
+          abandonPress();
+        }
+      }
+
+      // Once the event is loose, a finger moving over it drags it rather
+      // than scrolling the calendar underneath it.
+      function handleTouchMove(touchEvent: TouchEvent) {
+        if (pressRef.current?.armed) {
+          touchEvent.preventDefault();
+        }
+      }
+
+      function handleContextMenu(menuEvent: MouseEvent) {
+        if (pressRef.current !== null) {
+          menuEvent.preventDefault();
+        }
+      }
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+      window.addEventListener("pointercancel", handlePointerCancel);
+      window.addEventListener("keydown", handleKeyDown);
+      window.addEventListener("touchmove", handleTouchMove, {
+        passive: false,
+      });
+      window.addEventListener("contextmenu", handleContextMenu);
+
+      unlistenRef.current = () => {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerUp);
+        window.removeEventListener("pointercancel", handlePointerCancel);
+        window.removeEventListener("keydown", handleKeyDown);
+        window.removeEventListener("touchmove", handleTouchMove);
+        window.removeEventListener("contextmenu", handleContextMenu);
+      };
+
+      const startX = event.clientX;
+      const startY = event.clientY;
+      holdTimeoutRef.current = setTimeout(() => {
+        holdTimeoutRef.current = null;
+        const press = pressRef.current;
+        if (press === null) {
+          return;
+        }
+
+        press.armed = true;
+        document.body.style.userSelect = "none";
+        if (typeof navigator.vibrate === "function") {
+          navigator.vibrate(10);
+        }
+        trackPointer(startX, startY);
+        runAutoScroll();
+      }, DRAG_HOLD_MS);
+    }
+
     return {
       beginPress(event, args) {
         if (pressRef.current !== null) {
@@ -479,7 +740,9 @@ export function CalendarEventDragProvider(
 
         pressRef.current = {
           pointerId: event.pointerId,
+          mode: "reschedule",
           target: args.target,
+          place: null,
           sourceDate: args.sourceDate,
           startX: event.clientX,
           startY: event.clientY,
@@ -489,103 +752,40 @@ export function CalendarEventDragProvider(
           armed: false,
         };
 
-        function handlePointerMove(moveEvent: PointerEvent) {
-          const press = pressRef.current;
-          if (press === null || moveEvent.pointerId !== press.pointerId) {
-            return;
-          }
+        attachGesture(event);
+      },
 
-          if (!press.armed) {
-            const distance = Math.hypot(
-              moveEvent.clientX - press.startX,
-              moveEvent.clientY - press.startY,
-            );
-            if (distance > HOLD_TOLERANCE_PX) {
-              // The gesture turned out to be a scroll or a text selection.
-              abandonPress();
-            }
-            return;
-          }
-
-          trackPointer(moveEvent.clientX, moveEvent.clientY);
+      beginPlacePress(event, source) {
+        if (pressRef.current !== null) {
+          return;
+        }
+        if (event.pointerType === "mouse" && event.button !== 0) {
+          return;
         }
 
-        function handlePointerUp(upEvent: PointerEvent) {
-          const press = pressRef.current;
-          if (press === null || upEvent.pointerId !== press.pointerId) {
-            return;
-          }
+        const firstColumn = [...columnsRef.current.values()][0];
+        const scroller =
+          firstColumn !== undefined
+            ? findScroller(firstColumn)
+            : findScroller(event.currentTarget);
+        const sourceDate =
+          [...columnsRef.current.keys()][0] ?? ("1970-01-01" as ADate);
 
-          if (press.armed) {
-            commit();
-          } else {
-            abandonPress();
-          }
-        }
-
-        function handlePointerCancel(cancelEvent: PointerEvent) {
-          const press = pressRef.current;
-          if (press === null || cancelEvent.pointerId !== press.pointerId) {
-            return;
-          }
-          abandonPress();
-        }
-
-        function handleKeyDown(keyEvent: KeyboardEvent) {
-          if (keyEvent.key === "Escape") {
-            abandonPress();
-          }
-        }
-
-        // Once the event is loose, a finger moving over it drags it rather
-        // than scrolling the calendar underneath it.
-        function handleTouchMove(touchEvent: TouchEvent) {
-          if (pressRef.current?.armed) {
-            touchEvent.preventDefault();
-          }
-        }
-
-        function handleContextMenu(menuEvent: MouseEvent) {
-          if (pressRef.current !== null) {
-            menuEvent.preventDefault();
-          }
-        }
-
-        window.addEventListener("pointermove", handlePointerMove);
-        window.addEventListener("pointerup", handlePointerUp);
-        window.addEventListener("pointercancel", handlePointerCancel);
-        window.addEventListener("keydown", handleKeyDown);
-        window.addEventListener("touchmove", handleTouchMove, {
-          passive: false,
-        });
-        window.addEventListener("contextmenu", handleContextMenu);
-
-        unlistenRef.current = () => {
-          window.removeEventListener("pointermove", handlePointerMove);
-          window.removeEventListener("pointerup", handlePointerUp);
-          window.removeEventListener("pointercancel", handlePointerCancel);
-          window.removeEventListener("keydown", handleKeyDown);
-          window.removeEventListener("touchmove", handleTouchMove);
-          window.removeEventListener("contextmenu", handleContextMenu);
+        pressRef.current = {
+          pointerId: event.pointerId,
+          mode: "place",
+          target: null,
+          place: source,
+          sourceDate: sourceDate,
+          startX: event.clientX,
+          startY: event.clientY,
+          startScrollTop: scroller?.scrollTop ?? 0,
+          remPx: rootFontSizePx(),
+          scroller: scroller,
+          armed: false,
         };
 
-        const startX = event.clientX;
-        const startY = event.clientY;
-        holdTimeoutRef.current = setTimeout(() => {
-          holdTimeoutRef.current = null;
-          const press = pressRef.current;
-          if (press === null) {
-            return;
-          }
-
-          press.armed = true;
-          document.body.style.userSelect = "none";
-          if (typeof navigator.vibrate === "function") {
-            navigator.vibrate(10);
-          }
-          trackPointer(startX, startY);
-          runAutoScroll();
-        }, DRAG_HOLD_MS);
+        attachGesture(event);
       },
 
       consumeClickSuppression(blockRefId) {
@@ -656,6 +856,37 @@ export function CalendarEventDragProvider(
     };
   }, []);
 
+  const pendingPlace = useMemo<CalendarPendingPlace | null>(() => {
+    const formData = fetcher.formData;
+    if (formData === undefined) {
+      return null;
+    }
+
+    const timePlanActivityRefId = formData.get("timePlanActivityRefId");
+    const startDate = formData.get("startDate");
+    const startTimeInDay = formData.get("startTimeInDay");
+    const durationMins = formData.get("durationMins");
+    if (
+      typeof timePlanActivityRefId !== "string" ||
+      typeof startDate !== "string" ||
+      typeof startTimeInDay !== "string" ||
+      typeof durationMins !== "string"
+    ) {
+      return null;
+    }
+
+    const duration = parseInt(durationMins, 10);
+    if (Number.isNaN(duration)) {
+      return null;
+    }
+
+    return {
+      startDate: startDate,
+      startTimeInDay: startTimeInDay,
+      durationMins: duration,
+    };
+  }, [fetcher.formData]);
+
   const pending = useMemo<CalendarPendingReschedule | null>(() => {
     const formData = fetcher.formData;
     if (formData === undefined) {
@@ -687,14 +918,18 @@ export function CalendarEventDragProvider(
     }
 
     enqueueSnackbar(
-      result.globalError ?? "Could not move the event! Please try again!",
+      result.globalError ?? "Could not save that! Please try again!",
       { variant: "error", autoHideDuration: 4000 },
     );
   }, [fetcher.data, enqueueSnackbar]);
 
   const contextValue = useMemo<CalendarEventDragContextValue>(
-    () => ({ controller: controller, pending: pending }),
-    [controller, pending],
+    () => ({
+      controller: controller,
+      pending: pending,
+      pendingPlace: pendingPlace,
+    }),
+    [controller, pending, pendingPlace],
   );
 
   return (
@@ -888,6 +1123,7 @@ function CalendarEventDragLabel(props: CalendarEventDragLabelProps) {
     return null;
   }
 
+  const overCalendar = snapshot.overCalendar;
   const startTime = snapshot.newStartTime;
   const endTime = startTime.plus({ minutes: snapshot.durationMins });
 
@@ -912,11 +1148,162 @@ function CalendarEventDragLabel(props: CalendarEventDragLabelProps) {
       >
         <Paper elevation={6} sx={{ padding: "0.25rem 0.5rem" }}>
           <Typography variant="caption">
-            {startTime.toFormat("ccc dd MMM")} [{startTime.toFormat("HH:mm")} -{" "}
-            {endTime.toFormat("HH:mm")}]
+            {snapshot.mode === "place" && !overCalendar
+              ? "Drop on the calendar"
+              : `${startTime.toFormat("ccc dd MMM")} [${startTime.toFormat("HH:mm")} - ${endTime.toFormat("HH:mm")}]`}
           </Typography>
         </Paper>
       </Box>
     </Portal>
+  );
+}
+
+// Makes an activity in the time plan list placeable on the calendar: hold it
+// for a moment and drag it onto a day, and a time event is made of it there.
+export function useCalendarPlaceActivity(args: {
+  activityRefId: EntityId;
+  timePlanRefId: EntityId;
+  archived: boolean;
+}): CalendarEventDragBinding {
+  const theme = useTheme();
+  const controller = useContext(CalendarEventDragContext)?.controller ?? null;
+  const blockRefId = placeBlockRefId(args.activityRefId);
+  const status = useCalendarEventDragStatus(controller, blockRefId);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (controller === null || args.archived) {
+        return;
+      }
+      controller.beginPlacePress(event, {
+        activityRefId: args.activityRefId,
+        timePlanRefId: args.timePlanRefId,
+        durationMins: PLACE_ACTIVITY_DURATION_MINS,
+      });
+    },
+    [controller, args.archived, args.activityRefId, args.timePlanRefId],
+  );
+
+  const onClickCapture = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (controller === null) {
+        return;
+      }
+      if (controller.consumeClickSuppression(blockRefId)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
+    [controller, blockRefId],
+  );
+
+  const isPressing = useCallback(
+    () => controller !== null && controller.isPressing(),
+    [controller],
+  );
+
+  if (controller === null || args.archived) {
+    return { isDragging: false, isPressing: isPressing, handleProps: {} };
+  }
+
+  return {
+    isDragging: status.phase !== "idle",
+    isPressing: isPressing,
+    handleProps: {
+      onPointerDown: onPointerDown,
+      onClickCapture: onClickCapture,
+      style:
+        status.phase === "idle"
+          ? { cursor: "grab" }
+          : {
+              opacity: 0.45,
+              cursor: "grabbing",
+              boxShadow: theme.shadows[8],
+            },
+    },
+  };
+}
+
+interface CalendarPlaceGhostProps {
+  date: ADate;
+  deltaHour: number;
+}
+
+// The slot an activity would land in while it's being dragged over this day,
+// and the same slot while the new event is still on its way back from the
+// server.
+export function CalendarPlaceGhost(props: CalendarPlaceGhostProps) {
+  const context = useContext(CalendarEventDragContext);
+  const controller = context?.controller ?? null;
+  const pendingPlace = context?.pendingPlace ?? null;
+  const [snapshot, setSnapshot] = useState<CalendarEventDragSnapshot | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (controller === null) {
+      return;
+    }
+    function sync() {
+      setSnapshot(controller?.snapshot() ?? null);
+    }
+    sync();
+    return controller.subscribe(sync);
+  }, [controller]);
+
+  let startDate: ADate | null = null;
+  let startTimeInDay: TimeInDay | null = null;
+  let durationMins = PLACE_ACTIVITY_DURATION_MINS;
+
+  if (
+    snapshot !== null &&
+    snapshot.mode === "place" &&
+    snapshot.overCalendar
+  ) {
+    startDate = snapshot.newStartTime.toFormat("yyyy-MM-dd") as ADate;
+    startTimeInDay = snapshot.newStartTime.toFormat("HH:mm") as TimeInDay;
+    durationMins = snapshot.durationMins;
+  } else if (pendingPlace !== null) {
+    startDate = pendingPlace.startDate;
+    startTimeInDay = pendingPlace.startTimeInDay;
+    durationMins = pendingPlace.durationMins;
+  }
+
+  if (startDate === null || startTimeInDay === null || startDate !== props.date) {
+    return null;
+  }
+
+  const [hours, minutes] = startTimeInDay.split(":");
+  const minutesSinceStartOfDay =
+    parseInt(hours, 10) * 60 + parseInt(minutes, 10);
+  const topRems = calendarTimeEventInDayStartMinutesToRems(
+    minutesSinceStartOfDay,
+    props.deltaHour,
+  );
+  if (topRems === undefined) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: topRems,
+        height: calendarTimeEventInDayDurationToRems(
+          minutesSinceStartOfDay,
+          durationMins,
+        ),
+        backgroundColor: scheduleStreamColorHex(
+          TIME_PLAN_ACTIVITY_TIME_EVENT_COLOR,
+        ),
+        opacity: 0.55,
+        borderRadius: "0.25rem",
+        border: "1px dashed black",
+        minWidth: "calc(7rem - 0.5rem)",
+        width: "calc(100% - 0.5rem)",
+        zIndex: 10,
+        pointerEvents: "none",
+      }}
+    />
   );
 }

--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -98,6 +98,7 @@ import {
 } from "#/core/calendar/component/event-drag";
 import { TimeEventParamsNewPlaceholder } from "#/core/common/sub/time_events/component/params-new-placeholder";
 import { timePlanActivityNameForEvent } from "#/core/time_plans/sub/activity/root";
+import { timePlanPathIsAddingTimeEvent } from "#/core/time_plans/view-mode";
 
 export const MAX_VISIBLE_TIME_EVENT_FULL_DAYS = 3;
 
@@ -547,7 +548,11 @@ export function ViewAsCalendarTimeEventInDayColumn(
     const newQuery = new URLSearchParams(query);
     newQuery.set("sourceStartDate", time.toFormat("yyyy-MM-dd"));
     newQuery.set("sourceStartTimeInDay", time.toFormat("HH:mm"));
-    if (
+    if (timePlanPathIsAddingTimeEvent(location.pathname)) {
+      navigate(`${location.pathname}?${newQuery}`, {
+        replace: true,
+      });
+    } else if (
       location.pathname === `/app/workspace/calendar/schedule/event-in-day/new`
     ) {
       navigate(

--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -93,6 +93,7 @@ import {
 } from "#/core/calendar/component/overlapping-events-peek";
 import {
   CalendarEventDragBinding,
+  CalendarPlaceGhost,
   useCalendarDayColumn,
   useCalendarEventDrag,
 } from "#/core/calendar/component/event-drag";
@@ -646,6 +647,7 @@ export function ViewAsCalendarTimeEventInDayColumn(
         date={props.date}
         deltaHour={deltaHour}
       />
+      <CalendarPlaceGhost date={props.date} deltaHour={deltaHour} />
 
       {props.timeEventsInDay.map((entry, index) => {
         return (

--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -83,6 +83,7 @@ import { EntityNameComponent } from "#/core/common/component/entity-name";
 import { EntityLink } from "#/core/infra/component/entity-card";
 import {
   CalendarEventLink,
+  useCalendarNavigation,
   useCalendarStatsPath,
 } from "#/core/calendar/component/calendar-navigation";
 import {
@@ -126,6 +127,9 @@ export interface ViewAsProps {
   calendarLocation: string;
   isAdding: boolean;
   showOnlyFromRightNowIfDaily?: boolean;
+  // Whether a single day spreads over whatever room it's been given, rather
+  // than keeping to the narrow column the calendar shows it in.
+  fillWidth?: boolean;
 }
 
 export function ViewAsCalendarDaysAndFullDaysContiner(
@@ -504,6 +508,7 @@ export function ViewAsCalendarTimeEventInDayColumn(
   const location = useLocation();
   const [query] = useSearchParams();
   const navigate = useNavigate();
+  const calendarNavigation = useCalendarNavigation();
   const wholeColumnRef = useRef<HTMLDivElement>(null);
   const deltaHour = props.showOnlyFromRightNowIfDaily ? props.rightNow.hour : 0;
   const heightInRem = 96 - deltaHour * 4;
@@ -568,12 +573,14 @@ export function ViewAsCalendarTimeEventInDayColumn(
         replace: true,
       });
     } else {
-      navigate(
-        `/app/workspace/calendar/schedule/event-in-day/new?${newQuery}`,
-        {
-          replace: true,
-        },
-      );
+      const newEventPath = calendarNavigation.newInDayEventPath(newQuery);
+      if (newEventPath === undefined) {
+        return;
+      }
+
+      navigate(newEventPath, {
+        replace: true,
+      });
     }
   }
 

--- a/src/core/jupiter/core/calendar/component/view-as-calendar-daily.tsx
+++ b/src/core/jupiter/core/calendar/component/view-as-calendar-daily.tsx
@@ -140,7 +140,7 @@ export function ViewAsCalendarDaily(props: ViewAsProps) {
       sx={{
         position: "relative",
         margin: isBigScreen ? "auto" : "initial",
-        width: isBigScreen ? "300px" : "100%",
+        width: isBigScreen && !props.fillWidth ? "300px" : "100%",
       }}
     >
       <ViewAsCalendarDaysAndFullDaysContiner>

--- a/src/core/jupiter/core/common/component/is-key-tag.tsx
+++ b/src/core/jupiter/core/common/component/is-key-tag.tsx
@@ -7,5 +7,11 @@ interface IsKeyTagProps {
 export function IsKeyTag({ isKey }: IsKeyTagProps) {
   if (!isKey) return null;
 
-  return <SlimChip label="🔑" color="default" />;
+  return (
+    <SlimChip
+      label="🔑"
+      color="default"
+      sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+    />
+  );
 }

--- a/src/core/jupiter/core/common/sub/inbox_tasks/component/status-tag.tsx
+++ b/src/core/jupiter/core/common/sub/inbox_tasks/component/status-tag.tsx
@@ -1,13 +1,27 @@
 import { InboxTaskStatus } from "@jupiter/webapi-client";
 
 import { SlimChip } from "#/core/infra/component/chips";
-import { inboxTaskStatusName } from "#/core/common/sub/inbox_tasks/status";
+import {
+  inboxTaskStatusIcon,
+  inboxTaskStatusName,
+} from "#/core/common/sub/inbox_tasks/status";
 
 interface Props {
   status: InboxTaskStatus;
+  format?: "name" | "icon";
 }
 
 export function InboxTaskStatusTag(props: Props) {
+  const format = props.format ?? "name";
+
+  if (format === "icon") {
+    return (
+      <span style={{ paddingRight: "0.5rem" }}>
+        {inboxTaskStatusIcon(props.status)}
+      </span>
+    );
+  }
+
   const tagName = inboxTaskStatusName(props.status);
   const tagClass = statusToClass(props.status);
   return <SlimChip label={tagName} color={tagClass} />;

--- a/src/core/jupiter/core/common/sub/time_events/component/params-source.tsx
+++ b/src/core/jupiter/core/common/sub/time_events/component/params-source.tsx
@@ -8,39 +8,70 @@ interface TimeEventParamsSourceParams {
   durationMins: number;
 }
 
+const SOURCE_START_DATE = "sourceStartDate";
+const SOURCE_START_TIME_IN_DAY = "sourceStartTimeInDay";
+const SOURCE_DURATION_MINS = "sourceDurationMins";
+
 export function TimeEventParamsSource(props: TimeEventParamsSourceParams) {
-  const [searchParams, setSearchParms] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   useEffect(() => {
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-    newSearchParams.set("sourceStartDate", props.startDate.toString());
-    newSearchParams.set(
-      "sourceStartTimeInDay",
-      props.startTimeInDay.toString(),
+    const startDate = props.startDate.toString();
+    const startTimeInDay = props.startTimeInDay.toString();
+    const durationMins = props.durationMins.toString();
+    // Remember which page put these in the query. On the way out Remix has
+    // often already moved, and writing the old query onto that next page
+    // would wipe whatever it was keeping there - a time plan's view among
+    // them.
+    const pathWhenWritten = window.location.pathname;
+
+    setSearchParams(
+      (prev) => {
+        if (
+          prev.get(SOURCE_START_DATE) === startDate &&
+          prev.get(SOURCE_START_TIME_IN_DAY) === startTimeInDay &&
+          prev.get(SOURCE_DURATION_MINS) === durationMins
+        ) {
+          return prev;
+        }
+        const next = new URLSearchParams(prev);
+        next.set(SOURCE_START_DATE, startDate);
+        next.set(SOURCE_START_TIME_IN_DAY, startTimeInDay);
+        next.set(SOURCE_DURATION_MINS, durationMins);
+        return next;
+      },
+      { replace: true },
     );
-    newSearchParams.set("sourceDurationMins", props.durationMins.toString());
-    setSearchParms(newSearchParams, {
-      replace: true,
-    });
+
+    return () => {
+      if (window.location.pathname !== pathWhenWritten) {
+        return;
+      }
+
+      setSearchParams(
+        (prev) => {
+          if (
+            !prev.has(SOURCE_START_DATE) &&
+            !prev.has(SOURCE_START_TIME_IN_DAY) &&
+            !prev.has(SOURCE_DURATION_MINS)
+          ) {
+            return prev;
+          }
+          const next = new URLSearchParams(prev);
+          next.delete(SOURCE_START_DATE);
+          next.delete(SOURCE_START_TIME_IN_DAY);
+          next.delete(SOURCE_DURATION_MINS);
+          return next;
+        },
+        { replace: true },
+      );
+    };
   }, [
-    searchParams,
-    setSearchParms,
+    setSearchParams,
     props.startDate,
     props.startTimeInDay,
     props.durationMins,
   ]);
-
-  useEffect(() => {
-    return () => {
-      const newSearchParams = new URLSearchParams(searchParams.toString());
-      newSearchParams.delete("sourceStartDate");
-      newSearchParams.delete("sourceStartTimeInDay");
-      newSearchParams.delete("sourceDurationMins");
-      setSearchParms(newSearchParams, {
-        replace: true,
-      });
-    };
-  }, [searchParams, setSearchParms]);
 
   return null;
 }

--- a/src/core/jupiter/core/infra/component/section-actions.tsx
+++ b/src/core/jupiter/core/infra/component/section-actions.tsx
@@ -874,7 +874,10 @@ function FilterFewOptionsView<K>(props: FilterFewOptionsViewProps<K>) {
 
 function FilterFewOptionsSpreadView<K>(props: FilterFewOptionsViewProps<K>) {
   const isBigScreen = useBigScreen();
-  const [selected, setSelected] = useState<K>(props.action.defaultOption);
+  // Whoever put these buttons here is the one keeping track of which one is
+  // on - so a choice made elsewhere, like going back to a page that was left
+  // on another one, shows up here too.
+  const selected = props.action.defaultOption;
 
   const realOptions: FilterOption<K>[] = [];
   for (const option of props.action.options) {
@@ -912,7 +915,6 @@ function FilterFewOptionsSpreadView<K>(props: FilterFewOptionsViewProps<K>) {
             disabled={!props.inputsEnabled || option.disabled}
             startIcon={option.icon}
             onClick={() => {
-              setSelected(option.value);
               props.action.onSelect(option.value);
             }}
           >

--- a/src/core/jupiter/core/schedule/sub/event_full_days/component/editor.tsx
+++ b/src/core/jupiter/core/schedule/sub/event_full_days/component/editor.tsx
@@ -45,6 +45,7 @@ interface ScheduleEventFullDaysEditorProps {
   entityOwnerRefId?: string;
   durationDays?: number;
   onDurationDaysChange?: (value: number) => void;
+  showActions?: boolean;
 }
 
 export function ScheduleEventFullDaysEditor(
@@ -70,35 +71,38 @@ export function ScheduleEventFullDaysEditor(
   const selectedScheduleStream = allScheduleStreamsByRefId.get(
     scheduleEventFullDays.schedule_stream_ref_id,
   );
+  const showActions = props.showActions ?? true;
 
   return (
     <SectionCard
       id="schedule-event-full-days-properties"
       title="Properties"
       actions={
-        <SectionActions
-          id="schedule-event-full-days-properties"
-          topLevelInfo={props.topLevelInfo}
-          inputsEnabled={props.inputsEnabled}
-          actions={[
-            ActionMultipleSpread({
-              actions: [
-                ActionSingle({
-                  id: "schedule-event-full-days-update",
-                  text: "Save",
-                  value: "update",
-                  highlight: true,
-                  disabled: !props.corePropertyEditable,
-                }),
-                ActionSingle({
-                  text: "Change Stream",
-                  value: "change-schedule-stream",
-                  disabled: !props.corePropertyEditable,
-                }),
-              ],
-            }),
-          ]}
-        />
+        showActions ? (
+          <SectionActions
+            id="schedule-event-full-days-properties"
+            topLevelInfo={props.topLevelInfo}
+            inputsEnabled={props.inputsEnabled}
+            actions={[
+              ActionMultipleSpread({
+                actions: [
+                  ActionSingle({
+                    id: "schedule-event-full-days-update",
+                    text: "Save",
+                    value: "update",
+                    highlight: true,
+                    disabled: !props.corePropertyEditable,
+                  }),
+                  ActionSingle({
+                    text: "Change Stream",
+                    value: "change-schedule-stream",
+                    disabled: !props.corePropertyEditable,
+                  }),
+                ],
+              }),
+            ]}
+          />
+        ) : undefined
       }
     >
       <FormControl fullWidth>

--- a/src/core/jupiter/core/schedule/sub/event_full_days/component/editor.tsx
+++ b/src/core/jupiter/core/schedule/sub/event_full_days/component/editor.tsx
@@ -45,7 +45,7 @@ interface ScheduleEventFullDaysEditorProps {
   entityOwnerRefId?: string;
   durationDays?: number;
   onDurationDaysChange?: (value: number) => void;
-  showActions?: boolean;
+  actions?: JSX.Element;
 }
 
 export function ScheduleEventFullDaysEditor(
@@ -71,14 +71,13 @@ export function ScheduleEventFullDaysEditor(
   const selectedScheduleStream = allScheduleStreamsByRefId.get(
     scheduleEventFullDays.schedule_stream_ref_id,
   );
-  const showActions = props.showActions ?? true;
 
   return (
     <SectionCard
       id="schedule-event-full-days-properties"
       title="Properties"
       actions={
-        showActions ? (
+        props.actions ?? (
           <SectionActions
             id="schedule-event-full-days-properties"
             topLevelInfo={props.topLevelInfo}
@@ -102,7 +101,7 @@ export function ScheduleEventFullDaysEditor(
               }),
             ]}
           />
-        ) : undefined
+        )
       }
     >
       <FormControl fullWidth>

--- a/src/core/jupiter/core/schedule/sub/event_in_day/component/editor.tsx
+++ b/src/core/jupiter/core/schedule/sub/event_in_day/component/editor.tsx
@@ -49,6 +49,7 @@ interface ScheduleEventInDayEditorProps {
   onStartDateChange?: (value: string) => void;
   onStartTimeInDayChange?: (value: string) => void;
   onDurationMinsChange?: (value: number) => void;
+  showActions?: boolean;
 }
 
 export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
@@ -72,35 +73,38 @@ export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
   const selectedScheduleStream = allScheduleStreamsByRefId.get(
     scheduleEventInDay.schedule_stream_ref_id,
   );
+  const showActions = props.showActions ?? true;
 
   return (
     <SectionCard
       id="schedule-event-in-day-properties"
       title="Properties"
       actions={
-        <SectionActions
-          id="schedule-event-in-day-properties"
-          topLevelInfo={props.topLevelInfo}
-          inputsEnabled={props.inputsEnabled}
-          actions={[
-            ActionMultipleSpread({
-              actions: [
-                ActionSingle({
-                  id: "schedule-event-in-day-update",
-                  text: "Save",
-                  value: "update",
-                  highlight: true,
-                  disabled: !props.corePropertyEditable,
-                }),
-                ActionSingle({
-                  text: "Change Stream",
-                  value: "change-schedule-stream",
-                  disabled: !props.corePropertyEditable,
-                }),
-              ],
-            }),
-          ]}
-        />
+        showActions ? (
+          <SectionActions
+            id="schedule-event-in-day-properties"
+            topLevelInfo={props.topLevelInfo}
+            inputsEnabled={props.inputsEnabled}
+            actions={[
+              ActionMultipleSpread({
+                actions: [
+                  ActionSingle({
+                    id: "schedule-event-in-day-update",
+                    text: "Save",
+                    value: "update",
+                    highlight: true,
+                    disabled: !props.corePropertyEditable,
+                  }),
+                  ActionSingle({
+                    text: "Change Stream",
+                    value: "change-schedule-stream",
+                    disabled: !props.corePropertyEditable,
+                  }),
+                ],
+              }),
+            ]}
+          />
+        ) : undefined
       }
     >
       <input

--- a/src/core/jupiter/core/schedule/sub/event_in_day/component/editor.tsx
+++ b/src/core/jupiter/core/schedule/sub/event_in_day/component/editor.tsx
@@ -49,7 +49,7 @@ interface ScheduleEventInDayEditorProps {
   onStartDateChange?: (value: string) => void;
   onStartTimeInDayChange?: (value: string) => void;
   onDurationMinsChange?: (value: number) => void;
-  showActions?: boolean;
+  actions?: JSX.Element;
 }
 
 export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
@@ -73,14 +73,13 @@ export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
   const selectedScheduleStream = allScheduleStreamsByRefId.get(
     scheduleEventInDay.schedule_stream_ref_id,
   );
-  const showActions = props.showActions ?? true;
 
   return (
     <SectionCard
       id="schedule-event-in-day-properties"
       title="Properties"
       actions={
-        showActions ? (
+        props.actions ?? (
           <SectionActions
             id="schedule-event-in-day-properties"
             topLevelInfo={props.topLevelInfo}
@@ -104,7 +103,7 @@ export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
               }),
             ]}
           />
-        ) : undefined
+        )
       }
     >
       <input

--- a/src/core/jupiter/core/time_plans/calendar-event.ts
+++ b/src/core/jupiter/core/time_plans/calendar-event.ts
@@ -1,0 +1,102 @@
+import type {
+  CalendarEventsEntries,
+  TimeEventInDayBlock,
+  TimePlanActivity,
+} from "@jupiter/webapi-client";
+
+import { calendarEventLinkKey } from "#/core/calendar/component/calendar-navigation";
+import { entityLinkStd, parseEntityLinkStd } from "#/core/common/entity-link";
+
+// Which of this plan's activities a calendar event belongs to, if any. Events
+// owned by an activity, or by a todo/habit/chore/big plan that is a target of
+// one, open that activity. Everything else is just an event on the same days.
+export function activityRefIdByCalendarEvent(
+  activities: TimePlanActivity[],
+  entries: CalendarEventsEntries | undefined,
+  activityTimeEventBlocks: TimeEventInDayBlock[],
+): Map<string, string> {
+  const byEvent = new Map<string, string>();
+  const activityRefIds = new Set(activities.map((a) => a.ref_id));
+  const activityByTarget = new Map<string, string>();
+  for (const activity of activities) {
+    activityByTarget.set(activity.target, activity.ref_id);
+  }
+
+  function recordInDayBlock(refId: string, activityRefId: string) {
+    byEvent.set(
+      calendarEventLinkKey("time-event-in-day-block", refId),
+      activityRefId,
+    );
+  }
+
+  for (const block of activityTimeEventBlocks) {
+    const { refId } = parseEntityLinkStd(block.owner);
+    if (activityRefIds.has(refId)) {
+      recordInDayBlock(block.ref_id, refId);
+    }
+  }
+
+  if (entries === undefined) {
+    return byEvent;
+  }
+
+  for (const entry of entries.time_plan_activity_entries) {
+    const activityRefId = entry.time_plan_activity.ref_id;
+    if (!activityRefIds.has(activityRefId)) {
+      continue;
+    }
+    for (const timeEvent of entry.time_events) {
+      recordInDayBlock(timeEvent.ref_id, activityRefId);
+    }
+  }
+
+  for (const entry of entries.todo_task_entries) {
+    const activityRefId = activityByTarget.get(
+      entityLinkStd("TodoTask", entry.todo_task.ref_id),
+    );
+    if (activityRefId === undefined) {
+      continue;
+    }
+    for (const timeEvent of entry.time_events) {
+      recordInDayBlock(timeEvent.ref_id, activityRefId);
+    }
+  }
+
+  for (const entry of entries.big_plan_entries) {
+    const activityRefId = activityByTarget.get(
+      entityLinkStd("BigPlan", entry.big_plan.ref_id),
+    );
+    if (activityRefId === undefined) {
+      continue;
+    }
+    for (const timeEvent of entry.time_events) {
+      recordInDayBlock(timeEvent.ref_id, activityRefId);
+    }
+  }
+
+  for (const entry of entries.habit_entries) {
+    const activityRefId = activityByTarget.get(
+      entityLinkStd("Habit", entry.habit.ref_id),
+    );
+    if (activityRefId === undefined) {
+      continue;
+    }
+    for (const timeEvent of entry.time_events) {
+      recordInDayBlock(timeEvent.ref_id, activityRefId);
+    }
+  }
+
+  for (const entry of entries.chore_entries) {
+    const activityRefId = activityByTarget.get(
+      entityLinkStd("Chore", entry.chore.ref_id),
+    );
+    if (activityRefId === undefined) {
+      continue;
+    }
+    for (const timeEvent of entry.time_events) {
+      recordInDayBlock(timeEvent.ref_id, activityRefId);
+    }
+  }
+
+  return byEvent;
+}

--- a/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
@@ -39,6 +39,9 @@ interface TimePlanCalendarActivitiesProps {
   // The very same activities the list view shows, in a column of their own
   // next to the calendar.
   activities: ReactNode;
+  // A leaf for making a new event is open on this plan, so the calendar
+  // shows where it would land.
+  isAdding?: boolean;
 }
 
 // The activities of a time plan side by side with the calendar of the period
@@ -70,14 +73,10 @@ export function TimePlanCalendarActivities(
     );
     return timePlanCalendarNavigation(
       props.timePlan.ref_id,
-      props.periodStartDate,
-      props.timePlan.period,
       activityByEvent,
     );
   }, [
     props.timePlan.ref_id,
-    props.timePlan.period,
-    props.periodStartDate,
     props.timePlanActivities,
     props.entries,
     props.activityTimeEventBlocks,
@@ -95,9 +94,9 @@ export function TimePlanCalendarActivities(
     entries: props.entries,
     // There's no date to navigate around here - the time plan is the period.
     calendarLocation: "",
-    // The panels for adding an event live in the calendar, so by the time one
-    // is open this view is no longer on screen.
-    isAdding: false,
+    // A leaf for making a new event is open on this plan, so the calendar
+    // shows where it would land.
+    isAdding: props.isAdding ?? false,
     // The calendar is the point of this view, so a single day gets the whole
     // column rather than the sliver it takes up in the calendar itself.
     fillWidth: true,

--- a/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
@@ -1,7 +1,9 @@
 import type {
   ADate,
   CalendarEventsEntries,
+  TimeEventInDayBlock,
   TimePlan,
+  TimePlanActivity,
 } from "@jupiter/webapi-client";
 import { RecurringTaskPeriod } from "@jupiter/webapi-client";
 import { Box, Typography } from "@mui/material";
@@ -18,19 +20,22 @@ import { ViewAsCalendarDaily } from "#/core/calendar/component/view-as-calendar-
 import { ViewAsCalendarWeekly } from "#/core/calendar/component/view-as-calendar-weekly";
 import { useBigScreen } from "#/core/infra/component/use-big-screen";
 import { TopLevelInfoContext } from "#/core/infra/top-level-context";
+import { activityRefIdByCalendarEvent } from "#/core/time_plans/calendar-event";
 
 // How often the "right now" line on the calendar catches up with the clock.
 const REFRESH_RIGHT_NOW_MS = 1000 * 60 * 5; // 5 minutes
 
 // How much of the row the activities take up, with the calendar getting the
 // rest of it.
-const ACTIVITIES_COLUMN_WIDTH = "20%";
+const ACTIVITIES_COLUMN_WIDTH = "40%";
 
 interface TimePlanCalendarActivitiesProps {
   timePlan: TimePlan;
   periodStartDate: ADate;
   periodEndDate: ADate;
   entries?: CalendarEventsEntries;
+  timePlanActivities: TimePlanActivity[];
+  activityTimeEventBlocks: TimeEventInDayBlock[];
   // The very same activities the list view shows, in a column of their own
   // next to the calendar.
   activities: ReactNode;
@@ -57,15 +62,26 @@ export function TimePlanCalendarActivities(
     };
   }, [timezone]);
 
-  const navigation = useMemo(
-    () =>
-      timePlanCalendarNavigation(
-        props.timePlan.ref_id,
-        props.periodStartDate,
-        props.timePlan.period,
-      ),
-    [props.timePlan.ref_id, props.timePlan.period, props.periodStartDate],
-  );
+  const navigation = useMemo(() => {
+    const activityByEvent = activityRefIdByCalendarEvent(
+      props.timePlanActivities,
+      props.entries,
+      props.activityTimeEventBlocks,
+    );
+    return timePlanCalendarNavigation(
+      props.timePlan.ref_id,
+      props.periodStartDate,
+      props.timePlan.period,
+      activityByEvent,
+    );
+  }, [
+    props.timePlan.ref_id,
+    props.timePlan.period,
+    props.periodStartDate,
+    props.timePlanActivities,
+    props.entries,
+    props.activityTimeEventBlocks,
+  ]);
 
   const today = rightNow.toISODate() as ADate;
 

--- a/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
@@ -71,10 +71,7 @@ export function TimePlanCalendarActivities(
       props.entries,
       props.activityTimeEventBlocks,
     );
-    return timePlanCalendarNavigation(
-      props.timePlan.ref_id,
-      activityByEvent,
-    );
+    return timePlanCalendarNavigation(props.timePlan.ref_id, activityByEvent);
   }, [
     props.timePlan.ref_id,
     props.timePlanActivities,

--- a/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/calendar-activities.tsx
@@ -1,0 +1,150 @@
+import type {
+  ADate,
+  CalendarEventsEntries,
+  TimePlan,
+} from "@jupiter/webapi-client";
+import { RecurringTaskPeriod } from "@jupiter/webapi-client";
+import { Box, Typography } from "@mui/material";
+import { DateTime } from "luxon";
+import type { ReactNode } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
+
+import {
+  CalendarNavigationProvider,
+  timePlanCalendarNavigation,
+} from "#/core/calendar/component/calendar-navigation";
+import { CalendarEventDragProvider } from "#/core/calendar/component/event-drag";
+import { ViewAsCalendarDaily } from "#/core/calendar/component/view-as-calendar-daily";
+import { ViewAsCalendarWeekly } from "#/core/calendar/component/view-as-calendar-weekly";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
+import { TopLevelInfoContext } from "#/core/infra/top-level-context";
+
+// How often the "right now" line on the calendar catches up with the clock.
+const REFRESH_RIGHT_NOW_MS = 1000 * 60 * 5; // 5 minutes
+
+// How much of the row the activities take up, with the calendar getting the
+// rest of it.
+const ACTIVITIES_COLUMN_WIDTH = "20%";
+
+interface TimePlanCalendarActivitiesProps {
+  timePlan: TimePlan;
+  periodStartDate: ADate;
+  periodEndDate: ADate;
+  entries?: CalendarEventsEntries;
+  // The very same activities the list view shows, in a column of their own
+  // next to the calendar.
+  activities: ReactNode;
+}
+
+// The activities of a time plan side by side with the calendar of the period
+// they're planned for - the events made out of those activities included.
+export function TimePlanCalendarActivities(
+  props: TimePlanCalendarActivitiesProps,
+) {
+  const isBigScreen = useBigScreen();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const timezone = topLevelInfo.user.timezone;
+
+  const [rightNow, setRightNow] = useState(DateTime.local({ zone: timezone }));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRightNow(DateTime.local({ zone: timezone }));
+    }, REFRESH_RIGHT_NOW_MS);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [timezone]);
+
+  const navigation = useMemo(
+    () =>
+      timePlanCalendarNavigation(
+        props.timePlan.ref_id,
+        props.periodStartDate,
+        props.timePlan.period,
+      ),
+    [props.timePlan.ref_id, props.timePlan.period, props.periodStartDate],
+  );
+
+  const today = rightNow.toISODate() as ADate;
+
+  const calendarProps = {
+    rightNow: rightNow,
+    today: today,
+    timezone: timezone,
+    period: props.timePlan.period,
+    periodStartDate: props.periodStartDate,
+    periodEndDate: props.periodEndDate,
+    entries: props.entries,
+    // There's no date to navigate around here - the time plan is the period.
+    calendarLocation: "",
+    // The panels for adding an event live in the calendar, so by the time one
+    // is open this view is no longer on screen.
+    isAdding: false,
+    // The calendar is the point of this view, so a single day gets the whole
+    // column rather than the sliver it takes up in the calendar itself.
+    fillWidth: true,
+  };
+
+  return (
+    <CalendarNavigationProvider value={navigation}>
+      <CalendarEventDragProvider timezone={timezone}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: isBigScreen ? "row" : "column",
+            alignItems: "flex-start",
+            gap: "0.5rem",
+            width: "100%",
+          }}
+        >
+          <Box
+            sx={{
+              flex: isBigScreen ? `0 0 ${ACTIVITIES_COLUMN_WIDTH}` : "0 0 auto",
+              width: isBigScreen ? undefined : "100%",
+              minWidth: 0,
+              // The calendar is a whole day tall, so the activities follow
+              // along rather than scrolling out of sight at the top of it.
+              ...(isBigScreen
+                ? {
+                    position: "sticky",
+                    top: "0.5rem",
+                    maxHeight: "calc(100vh - 8rem)",
+                    overflowY: "auto",
+                  }
+                : {}),
+            }}
+          >
+            {props.activities}
+          </Box>
+
+          <Box
+            sx={{
+              flex: "1 1 0",
+              width: isBigScreen ? undefined : "100%",
+              minWidth: 0,
+              overflowX: "auto",
+            }}
+          >
+            {props.entries === undefined && (
+              <Typography variant="body1">
+                There are no calendar events to show for this time plan.
+              </Typography>
+            )}
+
+            {props.entries !== undefined &&
+              props.timePlan.period === RecurringTaskPeriod.DAILY && (
+                <ViewAsCalendarDaily {...calendarProps} />
+              )}
+
+            {props.entries !== undefined &&
+              props.timePlan.period === RecurringTaskPeriod.WEEKLY && (
+                <ViewAsCalendarWeekly {...calendarProps} />
+              )}
+          </Box>
+        </Box>
+      </CalendarEventDragProvider>
+    </CalendarNavigationProvider>
+  );
+}

--- a/src/core/jupiter/core/time_plans/component/list-by-aspect-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/list-by-aspect-activities.tsx
@@ -32,6 +32,7 @@ interface TimePlanListByAspectActivitiesProps {
   selectedKinds: TimePlanActivityKind[];
   selectedFeasabilities: TimePlanActivityFeasability[];
   selectedDoneness: boolean[];
+  compact?: boolean;
   aspects: AspectSummary[];
   aspectsByRefId: Map<string, AspectSummary>;
   showEmptyGroups?: boolean;
@@ -70,6 +71,8 @@ export function TimePlanListByAspectActivities(
             filterFeasability={props.selectedFeasabilities}
             filterDoneness={props.selectedDoneness}
             timeEventsByRefId={props.timeEventsByRefId}
+            showFeasability={false}
+            compact={props.compact}
           />
         </>
       )}
@@ -109,6 +112,8 @@ export function TimePlanListByAspectActivities(
               filterFeasability={props.selectedFeasabilities}
               filterDoneness={props.selectedDoneness}
               timeEventsByRefId={props.timeEventsByRefId}
+              showFeasability={false}
+              compact={props.compact}
             />
           </Fragment>
         );

--- a/src/core/jupiter/core/time_plans/component/list-by-aspect-and-goals-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/list-by-aspect-and-goals-activities.tsx
@@ -37,6 +37,7 @@ interface TimePlanListByAspectAndGoalsActivitiesProps {
   selectedKinds: TimePlanActivityKind[];
   selectedFeasabilities: TimePlanActivityFeasability[];
   selectedDoneness: boolean[];
+  compact?: boolean;
   aspects: AspectSummary[];
   aspectsByRefId: Map<string, AspectSummary>;
   goals: GoalSummary[];
@@ -110,6 +111,8 @@ export function TimePlanListByAspectAndGoalsActivities(
             filterFeasability={props.selectedFeasabilities}
             filterDoneness={props.selectedDoneness}
             timeEventsByRefId={props.timeEventsByRefId}
+            showFeasability={false}
+            compact={props.compact}
           />
         </>
       )}
@@ -181,6 +184,8 @@ export function TimePlanListByAspectAndGoalsActivities(
                     filterFeasability={props.selectedFeasabilities}
                     filterDoneness={props.selectedDoneness}
                     timeEventsByRefId={props.timeEventsByRefId}
+                    showFeasability={false}
+                    compact={props.compact}
                   />
                 </Fragment>
               );
@@ -205,6 +210,8 @@ export function TimePlanListByAspectAndGoalsActivities(
                   filterFeasability={props.selectedFeasabilities}
                   filterDoneness={props.selectedDoneness}
                   timeEventsByRefId={props.timeEventsByRefId}
+                  showFeasability={false}
+                  compact={props.compact}
                 />
               </>
             )}

--- a/src/core/jupiter/core/time_plans/component/list-merged-activities.tsx
+++ b/src/core/jupiter/core/time_plans/component/list-merged-activities.tsx
@@ -30,6 +30,7 @@ interface TimePlanListMergedActivitiesProps {
   selectedKinds: TimePlanActivityKind[];
   selectedFeasabilities: TimePlanActivityFeasability[];
   selectedDoneness: boolean[];
+  compact?: boolean;
 }
 
 export function TimePlanListMergedActivities(
@@ -58,6 +59,8 @@ export function TimePlanListMergedActivities(
             filterFeasability={props.selectedFeasabilities}
             filterDoneness={props.selectedDoneness}
             timeEventsByRefId={props.timeEventsByRefId}
+            showFeasability={false}
+            compact={props.compact}
           />
         </>
       )}
@@ -81,6 +84,8 @@ export function TimePlanListMergedActivities(
             filterFeasability={props.selectedFeasabilities}
             filterDoneness={props.selectedDoneness}
             timeEventsByRefId={props.timeEventsByRefId}
+            showFeasability={false}
+            compact={props.compact}
           />
         </>
       )}
@@ -104,6 +109,8 @@ export function TimePlanListMergedActivities(
             filterFeasability={props.selectedFeasabilities}
             filterDoneness={props.selectedDoneness}
             timeEventsByRefId={props.timeEventsByRefId}
+            showFeasability={false}
+            compact={props.compact}
           />
         </>
       )}

--- a/src/core/jupiter/core/time_plans/root.ts
+++ b/src/core/jupiter/core/time_plans/root.ts
@@ -20,6 +20,16 @@ export function timePlanAllowsKanbanViews(timePlan: TimePlan): boolean {
   return timePlanAllowsInboxTasks(timePlan);
 }
 
+export function timePlanAllowsCalendarView(timePlan: TimePlan): boolean {
+  // The calendar only builds the events themselves for daily and weekly
+  // periods - anything longer gets stats instead, which is not much of a
+  // calendar to plan against.
+  return (
+    timePlan.period === RecurringTaskPeriod.DAILY ||
+    timePlan.period === RecurringTaskPeriod.WEEKLY
+  );
+}
+
 export function findTimePlansThatAreActive(
   timePlans: Array<TimePlan>,
   rightNow: ADate,

--- a/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
@@ -12,7 +12,8 @@ import {
   TodoTask,
   WorkspaceFeature,
 } from "@jupiter/webapi-client";
-import { Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import type { ReactNode } from "react";
 import { useSearchParams } from "@remix-run/react";
 
 import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
@@ -62,8 +63,8 @@ interface TimePlanActivityCardProps {
   // Off where the cards are already grouped by how feasible they are, since
   // the chip would only say again what the group they sit in says.
   showFeasability?: boolean;
-  // For the narrow column the calendar view puts these in: what can be said
-  // with an emoji is said with an emoji.
+  // For the narrow column the calendar view puts these in: scheduled events
+  // are marked with an emoji rather than a count.
   compact?: boolean;
   allowSelect?: boolean;
   selected?: boolean;
@@ -80,7 +81,6 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
   );
 
   const showFeasability = props.showFeasability ?? true;
-  const statusFormat = props.compact ? "icon" : "name";
 
   const timePlan = props.timePlansByRefId.get(
     props.activity.time_plan_ref_id.toString(),
@@ -127,30 +127,27 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           </CardCornerChipStack>
         )}
         <EntityLink to={activityLocation} block={props.onClick !== undefined}>
-          {inboxTask && <IsKeyTag isKey={inboxTask.is_key} />}
-          <Typography
-            sx={{
-              fontWeight: inboxTask
+          <ActivityCardName
+            isKey={inboxTask?.is_key ?? false}
+            fontWeight={
+              inboxTask
                 ? props.activityDoneness[props.activity.ref_id] ===
                   TimePlanActivityDoneness.DONE
                   ? "bold"
                   : "normal"
-                : "lighter",
-            }}
+                : "lighter"
+            }
           >
             {props.showTimePlanName && timePlan
               ? timePlan.name
               : inboxTask
                 ? inboxTask.name
                 : "Archived Task"}
-          </Typography>
+          </ActivityCardName>
           {props.fullInfo && (
             <>
               {inboxTask && (
-                <InboxTaskStatusTag
-                  status={inboxTask.status}
-                  format={statusFormat}
-                />
+                <InboxTaskStatusTag status={inboxTask.status} />
               )}
               {inboxTask?.due_date && (
                 <ADateTag label="Due At" date={inboxTask.due_date} />
@@ -227,31 +224,28 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
         <EntityLink to={activityLocation} block={props.onClick !== undefined}>
-          {ownedInboxTask && <IsKeyTag isKey={ownedInboxTask.is_key} />}
-          <Typography
-            sx={{
-              fontWeight: todoTask
+          <ActivityCardName
+            isKey={ownedInboxTask?.is_key ?? false}
+            fontWeight={
+              todoTask
                 ? props.activityDoneness[props.activity.ref_id] ===
                   TimePlanActivityDoneness.DONE
                   ? "bold"
                   : "normal"
-                : "lighter",
-            }}
+                : "lighter"
+            }
           >
             {props.showTimePlanName && timePlan
               ? timePlan.name
               : todoTask
                 ? todoTask.name
                 : "Archived Todo"}
-          </Typography>
+          </ActivityCardName>
 
           {props.fullInfo && (
             <>
               {ownedInboxTask && (
-                <InboxTaskStatusTag
-                  status={ownedInboxTask.status}
-                  format={statusFormat}
-                />
+                <InboxTaskStatusTag status={ownedInboxTask.status} />
               )}
               {ownedInboxTask?.due_date && (
                 <ADateTag label="Due At" date={ownedInboxTask.due_date} />
@@ -326,23 +320,23 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
         <EntityLink to={activityLocation} block={props.onClick !== undefined}>
-          {habit && <IsKeyTag isKey={habit.is_key} />}
-          <Typography
-            sx={{
-              fontWeight: habit
+          <ActivityCardName
+            isKey={habit?.is_key ?? false}
+            fontWeight={
+              habit
                 ? props.activityDoneness[props.activity.ref_id] ===
                   TimePlanActivityDoneness.DONE
                   ? "bold"
                   : "normal"
-                : "lighter",
-            }}
+                : "lighter"
+            }
           >
             {props.showTimePlanName && timePlan
               ? timePlan.name
               : habit
                 ? habit.name
                 : "Archived Habit"}
-          </Typography>
+          </ActivityCardName>
 
           {props.fullInfo &&
             timeEvents.length > 0 &&
@@ -414,31 +408,28 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
         <EntityLink to={activityLocation} block={props.onClick !== undefined}>
-          {ownedInboxTask && <IsKeyTag isKey={ownedInboxTask.is_key} />}
-          <Typography
-            sx={{
-              fontWeight: chore
+          <ActivityCardName
+            isKey={ownedInboxTask?.is_key ?? false}
+            fontWeight={
+              chore
                 ? props.activityDoneness[props.activity.ref_id] ===
                   TimePlanActivityDoneness.DONE
                   ? "bold"
                   : "normal"
-                : "lighter",
-            }}
+                : "lighter"
+            }
           >
             {props.showTimePlanName && timePlan
               ? timePlan.name
               : chore
                 ? chore.name
                 : "Archived Chore"}
-          </Typography>
+          </ActivityCardName>
 
           {props.fullInfo && (
             <>
               {ownedInboxTask && (
-                <InboxTaskStatusTag
-                  status={ownedInboxTask.status}
-                  format={statusFormat}
-                />
+                <InboxTaskStatusTag status={ownedInboxTask.status} />
               )}
               {ownedInboxTask?.due_date && (
                 <ADateTag label="Due At" date={ownedInboxTask.due_date} />
@@ -509,32 +500,27 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
         <EntityLink to={activityLocation} block={props.onClick !== undefined}>
-          {bigPlan && <IsKeyTag isKey={bigPlan.is_key} />}
-          <Typography
-            sx={{
-              fontWeight: bigPlan
+          <ActivityCardName
+            isKey={bigPlan?.is_key ?? false}
+            fontWeight={
+              bigPlan
                 ? props.activityDoneness[props.activity.ref_id] ===
                   TimePlanActivityDoneness.DONE
                   ? "bold"
                   : "normal"
-                : "lighter",
-            }}
+                : "lighter"
+            }
           >
             {props.showTimePlanName && timePlan
               ? timePlan.name
               : bigPlan
                 ? bigPlan.name
                 : "Archived Big Plan"}
-          </Typography>
+          </ActivityCardName>
 
           {props.fullInfo && (
             <>
-              {bigPlan && (
-                <BigPlanStatusTag
-                  status={bigPlan.status}
-                  format={statusFormat}
-                />
-              )}
+              {bigPlan && <BigPlanStatusTag status={bigPlan.status} />}
               {bigPlan?.due_date && (
                 <ADateTag label="Due At" date={bigPlan.due_date} />
               )}
@@ -565,4 +551,28 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
   } else {
     return <></>;
   }
+}
+
+// Key chip and name stay on one line so the 🔑 never sits alone after a wrap.
+function ActivityCardName(props: {
+  isKey: boolean;
+  fontWeight: "bold" | "normal" | "lighter";
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexWrap: "nowrap",
+        alignItems: "center",
+        gap: "0.5rem",
+        minWidth: 0,
+      }}
+    >
+      <IsKeyTag isKey={props.isKey} />
+      <Typography sx={{ fontWeight: props.fontWeight, minWidth: 0 }}>
+        {props.children}
+      </Typography>
+    </Box>
+  );
 }

--- a/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
@@ -59,6 +59,12 @@ interface TimePlanActivityCardProps {
   timeEventsByRefId: Map<string, Array<TimeEventInDayBlock>>;
   fullInfo: boolean;
   showTimePlanName?: boolean;
+  // Off where the cards are already grouped by how feasible they are, since
+  // the chip would only say again what the group they sit in says.
+  showFeasability?: boolean;
+  // For the narrow column the calendar view puts these in: what can be said
+  // with an emoji is said with an emoji.
+  compact?: boolean;
   allowSelect?: boolean;
   selected?: boolean;
   indent?: number;
@@ -72,6 +78,9 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
     `/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`,
     timePlanView,
   );
+
+  const showFeasability = props.showFeasability ?? true;
+  const statusFormat = props.compact ? "icon" : "name";
 
   const timePlan = props.timePlansByRefId.get(
     props.activity.time_plan_ref_id.toString(),
@@ -137,24 +146,34 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           </Typography>
           {props.fullInfo && (
             <>
-              {inboxTask && <InboxTaskStatusTag status={inboxTask.status} />}
+              {inboxTask && (
+                <InboxTaskStatusTag
+                  status={inboxTask.status}
+                  format={statusFormat}
+                />
+              )}
               {inboxTask?.due_date && (
                 <ADateTag label="Due At" date={inboxTask.due_date} />
               )}
 
-              {timeEvents.length > 0 && (
-                <>
-                  📅 {timeEvents.length} scheduled event
-                  {timeEvents.length > 1 ? "s" : ""}
-                </>
-              )}
+              {timeEvents.length > 0 &&
+                (props.compact ? (
+                  <>📅</>
+                ) : (
+                  <>
+                    📅 {timeEvents.length} scheduled event
+                    {timeEvents.length > 1 ? "s" : ""}
+                  </>
+                ))}
             </>
           )}
 
           <TimePlanActivityKindTag kind={props.activity.kind} />
-          <TimePlanActivityFeasabilityTag
-            feasability={props.activity.feasability}
-          />
+          {showFeasability && (
+            <TimePlanActivityFeasabilityTag
+              feasability={props.activity.feasability}
+            />
+          )}
 
           {timePlan && <TimePlanTag timePlan={timePlan} />}
         </EntityLink>
@@ -229,25 +248,33 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           {props.fullInfo && (
             <>
               {ownedInboxTask && (
-                <InboxTaskStatusTag status={ownedInboxTask.status} />
+                <InboxTaskStatusTag
+                  status={ownedInboxTask.status}
+                  format={statusFormat}
+                />
               )}
               {ownedInboxTask?.due_date && (
                 <ADateTag label="Due At" date={ownedInboxTask.due_date} />
               )}
 
-              {timeEvents.length > 0 && (
-                <>
-                  📅 {timeEvents.length} scheduled event
-                  {timeEvents.length > 1 ? "s" : ""}
-                </>
-              )}
+              {timeEvents.length > 0 &&
+                (props.compact ? (
+                  <>📅</>
+                ) : (
+                  <>
+                    📅 {timeEvents.length} scheduled event
+                    {timeEvents.length > 1 ? "s" : ""}
+                  </>
+                ))}
             </>
           )}
 
           <TimePlanActivityKindTag kind={props.activity.kind} />
-          <TimePlanActivityFeasabilityTag
-            feasability={props.activity.feasability}
-          />
+          {showFeasability && (
+            <TimePlanActivityFeasabilityTag
+              feasability={props.activity.feasability}
+            />
+          )}
 
           {timePlan && <TimePlanTag timePlan={timePlan} />}
         </EntityLink>
@@ -317,17 +344,23 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
                 : "Archived Habit"}
           </Typography>
 
-          {props.fullInfo && timeEvents.length > 0 && (
-            <>
-              📅 {timeEvents.length} scheduled event
-              {timeEvents.length > 1 ? "s" : ""}
-            </>
-          )}
+          {props.fullInfo &&
+            timeEvents.length > 0 &&
+            (props.compact ? (
+              <>📅</>
+            ) : (
+              <>
+                📅 {timeEvents.length} scheduled event
+                {timeEvents.length > 1 ? "s" : ""}
+              </>
+            ))}
 
           <TimePlanActivityKindTag kind={props.activity.kind} />
-          <TimePlanActivityFeasabilityTag
-            feasability={props.activity.feasability}
-          />
+          {showFeasability && (
+            <TimePlanActivityFeasabilityTag
+              feasability={props.activity.feasability}
+            />
+          )}
 
           {timePlan && <TimePlanTag timePlan={timePlan} />}
         </EntityLink>
@@ -402,25 +435,33 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
           {props.fullInfo && (
             <>
               {ownedInboxTask && (
-                <InboxTaskStatusTag status={ownedInboxTask.status} />
+                <InboxTaskStatusTag
+                  status={ownedInboxTask.status}
+                  format={statusFormat}
+                />
               )}
               {ownedInboxTask?.due_date && (
                 <ADateTag label="Due At" date={ownedInboxTask.due_date} />
               )}
 
-              {timeEvents.length > 0 && (
-                <>
-                  📅 {timeEvents.length} scheduled event
-                  {timeEvents.length > 1 ? "s" : ""}
-                </>
-              )}
+              {timeEvents.length > 0 &&
+                (props.compact ? (
+                  <>📅</>
+                ) : (
+                  <>
+                    📅 {timeEvents.length} scheduled event
+                    {timeEvents.length > 1 ? "s" : ""}
+                  </>
+                ))}
             </>
           )}
 
           <TimePlanActivityKindTag kind={props.activity.kind} />
-          <TimePlanActivityFeasabilityTag
-            feasability={props.activity.feasability}
-          />
+          {showFeasability && (
+            <TimePlanActivityFeasabilityTag
+              feasability={props.activity.feasability}
+            />
+          )}
 
           {timePlan && <TimePlanTag timePlan={timePlan} />}
         </EntityLink>
@@ -488,24 +529,34 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
 
           {props.fullInfo && (
             <>
-              {bigPlan && <BigPlanStatusTag status={bigPlan.status} />}
+              {bigPlan && (
+                <BigPlanStatusTag
+                  status={bigPlan.status}
+                  format={statusFormat}
+                />
+              )}
               {bigPlan?.due_date && (
                 <ADateTag label="Due At" date={bigPlan.due_date} />
               )}
 
-              {timeEvents.length > 0 && (
-                <>
-                  📅 {timeEvents.length} scheduled event
-                  {timeEvents.length > 1 ? "s" : ""}
-                </>
-              )}
+              {timeEvents.length > 0 &&
+                (props.compact ? (
+                  <>📅</>
+                ) : (
+                  <>
+                    📅 {timeEvents.length} scheduled event
+                    {timeEvents.length > 1 ? "s" : ""}
+                  </>
+                ))}
             </>
           )}
 
           <TimePlanActivityKindTag kind={props.activity.kind} />
-          <TimePlanActivityFeasabilityTag
-            feasability={props.activity.feasability}
-          />
+          {showFeasability && (
+            <TimePlanActivityFeasabilityTag
+              feasability={props.activity.feasability}
+            />
+          )}
 
           {timePlan && <TimePlanTag timePlan={timePlan} />}
         </EntityLink>

--- a/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
@@ -13,6 +13,7 @@ import {
   WorkspaceFeature,
 } from "@jupiter/webapi-client";
 import { Typography } from "@mui/material";
+import { useSearchParams } from "@remix-run/react";
 
 import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
 import { BigPlanStatusTag } from "#/core/big_plans/component/status-tag";
@@ -25,6 +26,10 @@ import { TimePlanActivityTargetTypeChip } from "#/core/time_plans/sub/activity/c
 import type { TopLevelInfo } from "#/core/infra/top-level-context";
 import { ADateTag } from "#/core/common/component/adate-tag";
 import { TimePlanTag } from "#/core/time_plans/component/tag";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "#/core/time_plans/view-mode";
 import { IsKeyTag } from "#/core/common/component/is-key-tag";
 import {
   isTimePlanActivityBigPlanTarget,
@@ -61,6 +66,13 @@ interface TimePlanActivityCardProps {
 }
 
 export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
+  const activityLocation = withTimePlanView(
+    `/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`,
+    timePlanView,
+  );
+
   const timePlan = props.timePlansByRefId.get(
     props.activity.time_plan_ref_id.toString(),
   );
@@ -105,10 +117,7 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
             <TimePlanActivityTargetTypeChip target={props.activity.target} />
           </CardCornerChipStack>
         )}
-        <EntityLink
-          to={`/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`}
-          block={props.onClick !== undefined}
-        >
+        <EntityLink to={activityLocation} block={props.onClick !== undefined}>
           {inboxTask && <IsKeyTag isKey={inboxTask.is_key} />}
           <Typography
             sx={{
@@ -198,10 +207,7 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
         <CardCornerChipStack>
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
-        <EntityLink
-          to={`/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`}
-          block={props.onClick !== undefined}
-        >
+        <EntityLink to={activityLocation} block={props.onClick !== undefined}>
           {ownedInboxTask && <IsKeyTag isKey={ownedInboxTask.is_key} />}
           <Typography
             sx={{
@@ -292,10 +298,7 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
         <CardCornerChipStack>
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
-        <EntityLink
-          to={`/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`}
-          block={props.onClick !== undefined}
-        >
+        <EntityLink to={activityLocation} block={props.onClick !== undefined}>
           {habit && <IsKeyTag isKey={habit.is_key} />}
           <Typography
             sx={{
@@ -377,10 +380,7 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
         <CardCornerChipStack>
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
-        <EntityLink
-          to={`/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`}
-          block={props.onClick !== undefined}
-        >
+        <EntityLink to={activityLocation} block={props.onClick !== undefined}>
           {ownedInboxTask && <IsKeyTag isKey={ownedInboxTask.is_key} />}
           <Typography
             sx={{
@@ -467,10 +467,7 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
         <CardCornerChipStack>
           <TimePlanActivityTargetTypeChip target={props.activity.target} />
         </CardCornerChipStack>
-        <EntityLink
-          to={`/app/workspace/time-plans/${props.activity.time_plan_ref_id}/${props.activity.ref_id}`}
-          block={props.onClick !== undefined}
-        >
+        <EntityLink to={activityLocation} block={props.onClick !== undefined}>
           {bigPlan && <IsKeyTag isKey={bigPlan.is_key} />}
           <Typography
             sx={{

--- a/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
@@ -20,6 +20,7 @@ import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
 import { BigPlanStatusTag } from "#/core/big_plans/component/status-tag";
 import { InboxTaskStatusTag } from "#/core/common/sub/inbox_tasks/component/status-tag";
 import { EntityCard, EntityLink } from "#/core/infra/component/entity-card";
+import { useCalendarPlaceActivity } from "#/core/calendar/component/event-drag";
 import { CardCornerChipStack } from "#/core/infra/component/chips";
 import { TimePlanActivityFeasabilityTag } from "#/core/time_plans/sub/activity/component/feasability-tag";
 import { TimePlanActivityKindTag } from "#/core/time_plans/sub/activity/component/kind-tag";
@@ -73,6 +74,29 @@ interface TimePlanActivityCardProps {
 }
 
 export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
+  const place = useCalendarPlaceActivity({
+    activityRefId: props.activity.ref_id,
+    timePlanRefId: props.activity.time_plan_ref_id,
+    archived: props.activity.archived,
+  });
+
+  return (
+    <Box
+      onPointerDownCapture={place.handleProps.onPointerDown}
+      onClickCapture={place.handleProps.onClickCapture}
+      style={place.handleProps.style}
+      sx={{
+        width: "100%",
+        minWidth: 0,
+        "& a": { WebkitUserDrag: "none" },
+      }}
+    >
+      <TimePlanActivityCardBody {...props} />
+    </Box>
+  );
+}
+
+function TimePlanActivityCardBody(props: TimePlanActivityCardProps) {
   const [query] = useSearchParams();
   const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
   const activityLocation = withTimePlanView(

--- a/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/card.tsx
@@ -170,9 +170,7 @@ function TimePlanActivityCardBody(props: TimePlanActivityCardProps) {
           </ActivityCardName>
           {props.fullInfo && (
             <>
-              {inboxTask && (
-                <InboxTaskStatusTag status={inboxTask.status} />
-              )}
+              {inboxTask && <InboxTaskStatusTag status={inboxTask.status} />}
               {inboxTask?.due_date && (
                 <ADateTag label="Due At" date={inboxTask.due_date} />
               )}

--- a/src/core/jupiter/core/time_plans/sub/activity/component/list.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/list.tsx
@@ -39,6 +39,8 @@ interface TimePlanActivityListProps {
   timeEventsByRefId: Map<string, Array<TimeEventInDayBlock>>;
   fullInfo: boolean;
   showTimePlanName?: boolean;
+  showFeasability?: boolean;
+  compact?: boolean;
   filterKind?: TimePlanActivityKind[];
   filterFeasability?: TimePlanActivityFeasability[];
   filterDoneness?: boolean[];
@@ -119,6 +121,8 @@ export function TimePlanActivityList(props: TimePlanActivityListProps) {
             }
             fullInfo={props.fullInfo}
             showTimePlanName={props.showTimePlanName}
+            showFeasability={props.showFeasability}
+            compact={props.compact}
             timePlansByRefId={props.timePlansByRefId}
             inboxTasksByRefId={props.inboxTasksByRefId}
             bigPlansByRefId={props.bigPlansByRefId}

--- a/src/core/jupiter/core/time_plans/sub/activity/component/timeline.tsx
+++ b/src/core/jupiter/core/time_plans/sub/activity/component/timeline.tsx
@@ -16,10 +16,14 @@ import {
   TimePlanActivityDoneness as Doneness,
 } from "@jupiter/webapi-client";
 import { Box, styled, Typography } from "@mui/material";
-import { Link } from "@remix-run/react";
+import { Link, useSearchParams } from "@remix-run/react";
 import { DateTime } from "luxon";
 
 import { aDateToDate } from "#/core/common/adate";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "#/core/time_plans/view-mode";
 import {
   isTimePlanActivityBigPlanTarget,
   isTimePlanActivityChoreTarget,
@@ -55,6 +59,9 @@ interface TimePlanTimelineActivityBarsProps {
 export function TimePlanTimelineActivityBars(
   props: TimePlanTimelineActivityBarsProps,
 ) {
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
+
   const planStart = aDateToDate(props.timePlan.start_date);
   const planEnd = aDateToDate(props.timePlan.end_date);
   const durationDays = Math.max(1, planEnd.diff(planStart, "days").days);
@@ -228,7 +235,10 @@ export function TimePlanTimelineActivityBars(
 
       {rows.map((row, idx) => (
         <TimelineActivityLink
-          to={`/app/workspace/time-plans/${props.timePlan.ref_id}/${row.activity.ref_id}`}
+          to={withTimePlanView(
+            `/app/workspace/time-plans/${props.timePlan.ref_id}/${row.activity.ref_id}`,
+            timePlanView,
+          )}
           key={`timeline-activity-${row.activity.ref_id}`}
           left={row.left}
           width={row.width}

--- a/src/core/jupiter/core/time_plans/view-mode.ts
+++ b/src/core/jupiter/core/time_plans/view-mode.ts
@@ -112,3 +112,14 @@ export function timePlanViewFromQuery(
 ): string | undefined {
   return query.get(TIME_PLAN_VIEW_PARAM) ?? undefined;
 }
+
+// Adding a time event on a time plan opens a leaf on this same plan. The
+// calendar of the period is what you add against, so that leaf is how we
+// know to show it - even if the URL is still carrying another view to
+// restore when the adding is done.
+export function timePlanPathIsAddingTimeEvent(pathname: string): boolean {
+  return (
+    pathname.endsWith("/new-schedule-event-in-day") ||
+    pathname.endsWith("/new-activity-time-event")
+  );
+}

--- a/src/core/jupiter/core/time_plans/view-mode.ts
+++ b/src/core/jupiter/core/time_plans/view-mode.ts
@@ -1,0 +1,114 @@
+import type { TimePlan, Workspace } from "@jupiter/webapi-client";
+import { RecurringTaskPeriod, WorkspaceFeature } from "@jupiter/webapi-client";
+
+import {
+  timePlanAllowsCalendarView,
+  timePlanAllowsKanbanViews,
+} from "#/core/time_plans/root";
+import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
+
+// The ways of looking at the activities of a time plan.
+export enum TimePlanViewMode {
+  KANBAN_BY_EISEN = "kanban-by-eisen",
+  KANBAN = "kanban",
+  LIST = "list",
+  TIMELINE = "timeline",
+  CALENDAR = "calendar",
+}
+
+// The view rides along in the URL, so a reload - or coming back from one of
+// the panels a time plan opens - lands on the same one. It goes by a name of
+// its own rather than plain "view", since some of those panels live in the
+// calendar, which keeps a view of its own in the query.
+export const TIME_PLAN_VIEW_PARAM = "timePlanView";
+
+export function parseTimePlanViewMode(
+  raw: string | null | undefined,
+): TimePlanViewMode | undefined {
+  for (const viewMode of Object.values(TimePlanViewMode)) {
+    if (viewMode === raw) {
+      return viewMode;
+    }
+  }
+
+  return undefined;
+}
+
+export function timePlanViewModeIsAllowed(
+  viewMode: TimePlanViewMode,
+  workspace: Workspace,
+  timePlan: TimePlan,
+): boolean {
+  switch (viewMode) {
+    case TimePlanViewMode.KANBAN:
+    case TimePlanViewMode.KANBAN_BY_EISEN:
+      return timePlanAllowsKanbanViews(timePlan);
+    case TimePlanViewMode.CALENDAR:
+      return (
+        isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.SCHEDULE) &&
+        timePlanAllowsCalendarView(timePlan)
+      );
+    case TimePlanViewMode.LIST:
+    case TimePlanViewMode.TIMELINE:
+      return true;
+  }
+}
+
+// Which view a time plan is being looked at with: whatever the URL asks for,
+// as long as this plan can show it, and the one that suits the plan when it
+// doesn't say - or asks for something that's not on offer here.
+export function resolveTimePlanViewMode(
+  raw: string | null | undefined,
+  workspace: Workspace,
+  timePlan: TimePlan,
+): TimePlanViewMode {
+  const asked = parseTimePlanViewMode(raw);
+  if (
+    asked !== undefined &&
+    timePlanViewModeIsAllowed(asked, workspace, timePlan)
+  ) {
+    return asked;
+  }
+
+  return defaultTimePlanViewMode(workspace, timePlan);
+}
+
+export function defaultTimePlanViewMode(
+  workspace: Workspace,
+  timePlan: TimePlan,
+): TimePlanViewMode {
+  if (!isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.LIFE_PLAN)) {
+    return TimePlanViewMode.LIST;
+  }
+
+  switch (timePlan.period) {
+    case RecurringTaskPeriod.DAILY:
+    case RecurringTaskPeriod.WEEKLY:
+    case RecurringTaskPeriod.MONTHLY:
+      return TimePlanViewMode.LIST;
+    case RecurringTaskPeriod.QUARTERLY:
+    case RecurringTaskPeriod.YEARLY:
+      return TimePlanViewMode.TIMELINE;
+  }
+}
+
+// Tacks the view onto a link, so that wherever it leads comes back to the
+// time plan as it's being looked at right now.
+export function withTimePlanView(
+  path: string,
+  view: string | null | undefined,
+): string {
+  if (view === null || view === undefined || view === "") {
+    return path;
+  }
+
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}${TIME_PLAN_VIEW_PARAM}=${encodeURIComponent(view)}`;
+}
+
+// The view a link came in with, for passing it along further.
+export function timePlanViewFromQuery(
+  query: URLSearchParams,
+): string | undefined {
+  return query.get(TIME_PLAN_VIEW_PARAM) ?? undefined;
+}

--- a/src/webui/app/rendering/standard-should-revalidate.ts
+++ b/src/webui/app/rendering/standard-should-revalidate.ts
@@ -1,4 +1,5 @@
 import type { ShouldRevalidateFunction } from "@remix-run/react";
+import { TIME_PLAN_VIEW_PARAM } from "@jupiter/core/time_plans/view-mode";
 
 export const basicShouldRevalidate: ShouldRevalidateFunction = ({
   currentUrl,
@@ -65,6 +66,54 @@ export const standardShouldRevalidate: ShouldRevalidateFunction = ({
 
   return defaultShouldRevalidate;
 };
+
+// Which way a time plan is being looked at is written down in the URL, but
+// it's nothing the loaders have an opinion about - switching between the
+// views shouldn't cost a round trip to the server.
+export function ignoringTimePlanViewChanges(
+  inner: ShouldRevalidateFunction,
+): ShouldRevalidateFunction {
+  return (args) => {
+    if (
+      args.formMethod === undefined &&
+      args.currentUrl.pathname === args.nextUrl.pathname &&
+      onlyDifferenceIsTheTimePlanView(args.currentUrl, args.nextUrl)
+    ) {
+      return false;
+    }
+
+    return inner(args);
+  };
+}
+
+function onlyDifferenceIsTheTimePlanView(
+  currentUrl: URL,
+  nextUrl: URL,
+): boolean {
+  const keys = new Set([
+    ...currentUrl.searchParams.keys(),
+    ...nextUrl.searchParams.keys(),
+  ]);
+
+  let sawTheViewChange = false;
+  for (const key of keys) {
+    if (
+      currentUrl.searchParams.get(key) === nextUrl.searchParams.get(key) &&
+      currentUrl.searchParams.getAll(key).length ===
+        nextUrl.searchParams.getAll(key).length
+    ) {
+      continue;
+    }
+
+    if (key !== TIME_PLAN_VIEW_PARAM) {
+      return false;
+    }
+
+    sawTheViewChange = true;
+  }
+
+  return sawTheViewChange;
+}
 
 function onlyDifferenceIsInTimeEventParamsSource(
   formMethod: string,

--- a/src/webui/app/routes/app/workspace/big-plans/$id/inbox-tasks/new.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/$id/inbox-tasks/new.tsx
@@ -27,6 +27,10 @@ import {
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { DifficultySelect } from "@jupiter/core/common/component/difficulty-select";
 import { EisenhowerSelect } from "@jupiter/core/common/component/eisenhower-select";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import {
   BetterFieldError,
@@ -151,7 +155,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
     switch (timePlanReason) {
       case "for-time-plan":
         return redirect(
-          `/app/workspace/time-plans/${query.timePlanRefId}/${query.parentTimePlanActivityRefId}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${query.timePlanRefId}/${query.parentTimePlanActivityRefId}`,
+            new URL(request.url).searchParams.get(TIME_PLAN_VIEW_PARAM),
+          ),
         );
 
       case "standard":

--- a/src/webui/app/routes/app/workspace/big-plans/new.tsx
+++ b/src/webui/app/routes/app/workspace/big-plans/new.tsx
@@ -34,6 +34,10 @@ import {
 } from "@jupiter/core/common/suggested-date";
 import { DifficultySelect } from "@jupiter/core/common/component/difficulty-select";
 import { EisenhowerSelect } from "@jupiter/core/common/component/eisenhower-select";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -175,7 +179,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
       case "for-time-plan":
         return redirect(
-          `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+            new URL(request.url).searchParams.get(TIME_PLAN_VIEW_PARAM),
+          ),
         );
     }
   } catch (error) {

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-full-days/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-full-days/$id.tsx
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
 import { isCorePropertyEditable } from "@jupiter/core/schedule/sub/event_full_days/root";
 import { EntityNoteEditor } from "@jupiter/core/infra/component/entity-note-editor";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -153,7 +154,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
             value: form.durationDays,
           },
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "change-schedule-stream": {
@@ -180,14 +181,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         await apiClient.schedule.scheduleEventFullDaysArchive({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "remove": {
         await apiClient.schedule.scheduleEventFullDaysRemove({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "create-publish": {
@@ -261,7 +262,7 @@ export default function ScheduleEventFullDaysViewOne() {
       inputsEnabled={inputsEnabled}
       entityNotEditable={!corePropertyEditable}
       entityArchived={loaderData.scheduleEventFullDays.archived}
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
       publishable
       publishEntity={loaderData.publishEntity ?? undefined}
       accessable

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-full-days/new.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-full-days/new.tsx
@@ -18,6 +18,7 @@ import {
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -112,7 +113,7 @@ export default function ScheduleEventFullDaysNew() {
     <LeafPanel
       key="schedule-event-full-days/new"
       fakeKey="schedule-event-full-days/new"
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
       inputsEnabled={inputsEnabled}
     >
       <GlobalError actionResult={actionData} />

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/$id.tsx
@@ -17,6 +17,7 @@ import {
 } from "@jupiter/core/common/sub/time_events/time-event";
 import { isCorePropertyEditable } from "@jupiter/core/schedule/sub/event_in_day/root";
 import { EntityNoteEditor } from "@jupiter/core/infra/component/entity-note-editor";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -168,7 +169,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
             value: form.durationMins,
           },
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "change-schedule-stream": {
@@ -195,14 +196,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         await apiClient.schedule.scheduleEventInDayArchive({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "remove": {
         await apiClient.schedule.scheduleEventInDayRemove({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "create-publish": {
@@ -312,7 +313,7 @@ export default function ScheduleEventInDayViewOne() {
       inputsEnabled={inputsEnabled}
       entityNotEditable={!corePropertyEditable}
       entityArchived={loaderData.scheduleEventInDay.archived}
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
       publishable
       publishEntity={loaderData.publishEntity ?? undefined}
       accessable

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/new.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/new.tsx
@@ -20,6 +20,7 @@ import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
 import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -143,7 +144,7 @@ export default function ScheduleEventInDayNew() {
     <LeafPanel
       key="schedule-event-in-day/new"
       fakeKey="schedule-event-in-day/new"
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
       inputsEnabled={inputsEnabled}
     >
       <TimeEventParamsSource
@@ -289,7 +290,7 @@ export default function ScheduleEventInDayNew() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (_params, searchParams) => `/app/workspace/calendar?${searchParams}`,
+  (_params, searchParams) => calendarLeafReturnLocation(searchParams),
   ParamsSchema,
   {
     error: () =>

--- a/src/webui/app/routes/app/workspace/calendar/time-event/full-days-block/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/full-days-block/$id.tsx
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { parseParams } from "zodix";
 import { parseEntityLinkStd } from "@jupiter/core/common/entity-link";
 import { occasionTimeEventName } from "@jupiter/core/common/sub/time_events/time-event";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -76,7 +77,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   parseParams(params, ParamsSchema);
   const url = new URL(request.url);
 
-  return redirect(`/app/workspace/calendar?${url.searchParams}`);
+  return redirect(calendarLeafReturnLocation(url.searchParams));
 }
 
 export const shouldRevalidate: ShouldRevalidateFunction = basicShouldRevalidate;
@@ -130,7 +131,7 @@ export default function TimeEventFullDaysBlockViewOne() {
       inputsEnabled={inputsEnabled}
       entityNotEditable={!corePropertyEditable}
       entityArchived={loaderData.fullDaysBlock.archived}
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
     >
       <GlobalError actionResult={actionData} />
       <SectionCard

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
@@ -63,6 +63,7 @@ import {
 } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskStack } from "@jupiter/core/common/sub/inbox_tasks/component/stack";
 import { TodoTaskPropertiesEditor } from "@jupiter/core/todo/components/properties-editor";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -431,21 +432,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
             value: form.durationMins,
           },
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "archive": {
         await apiClient.timeEvents.timeEventInDayBlockArchive({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "remove": {
         await apiClient.timeEvents.timeEventInDayBlockRemove({
           ref_id: id,
         });
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "big-plan-mark-done":
@@ -531,14 +532,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         if (result.record_score_result) {
-          return redirect(`/app/workspace/calendar?${url.searchParams}`, {
+          return redirect(calendarLeafReturnLocation(url.searchParams), {
             headers: {
               "Set-Cookie": await saveScoreAction(result.record_score_result),
             },
           });
         }
 
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "todo-task-mark-done":
@@ -632,7 +633,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "todo-task-delay-1-day":
@@ -686,7 +687,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "inbox-task-mark-done":
@@ -769,14 +770,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         if (result.record_score_result) {
-          return redirect(`/app/workspace/calendar?${url.searchParams}`, {
+          return redirect(calendarLeafReturnLocation(url.searchParams), {
             headers: {
               "Set-Cookie": await saveScoreAction(result.record_score_result),
             },
           });
         }
 
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       case "inbox-task-delay-1-day":
@@ -830,7 +831,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/calendar?${url.searchParams}`);
+        return redirect(calendarLeafReturnLocation(url.searchParams));
       }
 
       default:
@@ -979,7 +980,7 @@ export default function TimeEventInDayBlockViewOne() {
       inputsEnabled={inputsEnabled}
       entityNotEditable={!corePropertyEditable}
       entityArchived={loaderData.inDayBlock.archived}
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
     >
       <TimeEventParamsSource
         startDate={startDate}

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity.tsx
@@ -19,6 +19,7 @@ import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
 import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -140,7 +141,7 @@ export default function TimeEventInDayBlockCreateForTimePlanActivity() {
     <LeafPanel
       key="time-event-in-day-block/new"
       fakeKey="time-event-in-day-block/new"
-      returnLocation={`/app/workspace/calendar?${query}`}
+      returnLocation={calendarLeafReturnLocation(query)}
       inputsEnabled={inputsEnabled}
     >
       <TimeEventParamsSource
@@ -282,7 +283,7 @@ export default function TimeEventInDayBlockCreateForTimePlanActivity() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (_params, searchParams) => `/app/workspace/calendar?${searchParams}`,
+  (_params, searchParams) => calendarLeafReturnLocation(searchParams),
   ParamsSchema,
   {
     error: () =>

--- a/src/webui/app/routes/app/workspace/chores/new.tsx
+++ b/src/webui/app/routes/app/workspace/chores/new.tsx
@@ -25,11 +25,19 @@ import {
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { CheckboxAsString, parseForm, parseQuery } from "zodix";
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -183,7 +191,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
       case "for-time-plan":
         return redirect(
-          `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+            new URL(request.url).searchParams.get(TIME_PLAN_VIEW_PARAM),
+          ),
         );
     }
   } catch (error) {
@@ -196,6 +207,7 @@ export const shouldRevalidate: ShouldRevalidateFunction =
 
 export default function NewChore() {
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
+  const [query] = useSearchParams();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
 
@@ -216,7 +228,10 @@ export default function NewChore() {
       fakeKey={"chores/new"}
       returnLocation={
         loaderData.timePlanReason === "for-time-plan"
-          ? `/app/workspace/time-plans/${(loaderData.associatedTimePlan as TimePlan).ref_id}`
+          ? withTimePlanView(
+              `/app/workspace/time-plans/${(loaderData.associatedTimePlan as TimePlan).ref_id}`,
+              query.get(TIME_PLAN_VIEW_PARAM),
+            )
           : "/app/workspace/chores"
       }
       inputsEnabled={inputsEnabled}

--- a/src/webui/app/routes/app/workspace/habits/new.tsx
+++ b/src/webui/app/routes/app/workspace/habits/new.tsx
@@ -19,12 +19,20 @@ import { FormControl, InputLabel, OutlinedInput, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { CheckboxAsString, parseForm, parseQuery } from "zodix";
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { HabitRepeatStrategySelect } from "@jupiter/core/habits/component/repeat-strategy-select";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -185,7 +193,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
       case "for-time-plan":
         return redirect(
-          `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+            new URL(request.url).searchParams.get(TIME_PLAN_VIEW_PARAM),
+          ),
         );
     }
   } catch (error) {
@@ -198,6 +209,7 @@ export const shouldRevalidate: ShouldRevalidateFunction =
 
 export default function NewHabit() {
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
+  const [query] = useSearchParams();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
 
@@ -225,7 +237,10 @@ export default function NewHabit() {
       fakeKey={"habits/new"}
       returnLocation={
         loaderData.timePlanReason === "for-time-plan"
-          ? `/app/workspace/time-plans/${(loaderData.associatedTimePlan as TimePlan).ref_id}`
+          ? withTimePlanView(
+              `/app/workspace/time-plans/${(loaderData.associatedTimePlan as TimePlan).ref_id}`,
+              query.get(TIME_PLAN_VIEW_PARAM),
+            )
           : "/app/workspace/habits"
       }
       inputsEnabled={inputsEnabled}

--- a/src/webui/app/routes/app/workspace/time-plans.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans.tsx
@@ -46,7 +46,10 @@ import {
 } from "@jupiter/core/infra/top-level-context";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
-import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import {
+  ignoringTimePlanViewChanges,
+  standardShouldRevalidate,
+} from "~/rendering/standard-should-revalidate";
 import { getLoggedInApiClient } from "~/api-clients.server";
 
 export const handle = {
@@ -88,7 +91,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export const shouldRevalidate: ShouldRevalidateFunction =
-  standardShouldRevalidate;
+  ignoringTimePlanViewChanges(standardShouldRevalidate);
 
 export default function TimePlans() {
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -36,6 +36,7 @@ import {
   Outlet,
   useActionData,
   useFetcher,
+  useLocation,
   useNavigation,
   useSearchParams,
 } from "@remix-run/react";
@@ -59,6 +60,8 @@ import {
   resolveTimePlanViewMode,
   TIME_PLAN_VIEW_PARAM,
   TimePlanViewMode,
+  timePlanPathIsAddingTimeEvent,
+  timePlanViewModeIsAllowed,
   withTimePlanView,
 } from "@jupiter/core/time_plans/view-mode";
 import { eisenIcon, eisenName } from "@jupiter/core/common/eisen";
@@ -431,6 +434,7 @@ export default function TimePlanView() {
   const navigation = useNavigation();
   const isBigScreen = useBigScreen();
   const [query, setQuery] = useSearchParams();
+  const location = useLocation();
 
   const shouldShowALeaf = useBranchNeedsToShowLeaf();
 
@@ -577,12 +581,24 @@ export default function TimePlanView() {
   );
   // The view lives in the URL rather than in here, so a reload - or coming
   // back from one of the panels this plan opens - shows the same one again.
+  // Adding a time event is done against the calendar of the period, so that
+  // leaf puts it on screen even when the URL is still carrying another view
+  // to restore when the adding is done.
   const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
-  const selectedView = resolveTimePlanViewMode(
-    timePlanViewParam,
-    topLevelInfo.workspace,
-    loaderData.timePlan,
-  );
+  const isAddingTimeEvent = timePlanPathIsAddingTimeEvent(location.pathname);
+  const selectedView =
+    isAddingTimeEvent &&
+    timePlanViewModeIsAllowed(
+      TimePlanViewMode.CALENDAR,
+      topLevelInfo.workspace,
+      loaderData.timePlan,
+    )
+      ? TimePlanViewMode.CALENDAR
+      : resolveTimePlanViewMode(
+          timePlanViewParam,
+          topLevelInfo.workspace,
+          loaderData.timePlan,
+        );
 
   function setSelectedView(view: TimePlanViewMode) {
     setQuery(newURLParams(query, TIME_PLAN_VIEW_PARAM, view), {
@@ -1155,6 +1171,7 @@ export default function TimePlanView() {
                 timePlanActivities={loaderData.activities}
                 activityTimeEventBlocks={loaderData.activityTimeEventBlocks}
                 activities={activitiesAsList}
+                isAdding={isAddingTimeEvent}
               />
             )}
 

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -651,8 +651,8 @@ export default function TimePlanView() {
   });
 
   // The activities as the list view shows them. The calendar view shows the
-  // very same thing in a column next to the calendar itself - a narrow one,
-  // so everything there says its piece as briefly as it can.
+  // very same thing in a column next to the calendar itself, so everything
+  // there says its piece as briefly as it can.
   const activitiesAreCompact = selectedView === TimePlanViewMode.CALENDAR;
   const activitiesAsList = (() => {
     switch (selectedGrouping) {
@@ -1152,6 +1152,8 @@ export default function TimePlanView() {
                   loaderData.timePlan.end_date
                 }
                 entries={loaderData.calendarEntries ?? undefined}
+                timePlanActivities={loaderData.activities}
+                activityTimeEventBlocks={loaderData.activityTimeEventBlocks}
                 activities={activitiesAsList}
               />
             )}

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -651,7 +651,9 @@ export default function TimePlanView() {
   });
 
   // The activities as the list view shows them. The calendar view shows the
-  // very same thing in a column next to the calendar itself.
+  // very same thing in a column next to the calendar itself - a narrow one,
+  // so everything there says its piece as briefly as it can.
+  const activitiesAreCompact = selectedView === TimePlanViewMode.CALENDAR;
   const activitiesAsList = (() => {
     switch (selectedGrouping) {
       case Grouping.MERGED:
@@ -670,6 +672,7 @@ export default function TimePlanView() {
             selectedKinds={selectedKinds}
             selectedFeasabilities={selectedFeasabilities}
             selectedDoneness={selectedDoneness}
+            compact={activitiesAreCompact}
           />
         );
 
@@ -693,6 +696,7 @@ export default function TimePlanView() {
             showEmptyGroups={
               selectedGroupVisibility === GroupVisibility.SHOW_ALL
             }
+            compact={activitiesAreCompact}
           />
         );
 
@@ -718,6 +722,7 @@ export default function TimePlanView() {
             showEmptyGroups={
               selectedGroupVisibility === GroupVisibility.SHOW_ALL
             }
+            compact={activitiesAreCompact}
           />
         );
     }

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -37,6 +37,7 @@ import {
   useActionData,
   useFetcher,
   useNavigation,
+  useSearchParams,
 } from "@remix-run/react";
 import { AnimatePresence } from "framer-motion";
 import { Fragment, useContext, useEffect, useState } from "react";
@@ -54,6 +55,12 @@ import {
   timePlanAllowsInboxTasks,
   timePlanAllowsKanbanViews,
 } from "@jupiter/core/time_plans/root";
+import {
+  resolveTimePlanViewMode,
+  TIME_PLAN_VIEW_PARAM,
+  TimePlanViewMode,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { eisenIcon, eisenName } from "@jupiter/core/common/eisen";
 import { InboxTaskKanbanBoard } from "@jupiter/core/common/sub/inbox_tasks/component/kanban-board";
 import {
@@ -120,21 +127,17 @@ import {
 } from "@jupiter/core/infra/errors.server";
 
 import { getLoggedInApiClient } from "~/api-clients.server";
-import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { newURLParams } from "~/logic/navigation";
+import {
+  basicShouldRevalidate,
+  ignoringTimePlanViewChanges,
+} from "~/rendering/standard-should-revalidate";
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 
 enum Grouping {
   MERGED = "merged",
   BY_ASPECT = "by-aspect",
   BY_ASPECT_AND_GOALS = "by-aspect-and-goals",
-}
-
-enum ViewMode {
-  KANBAN_BY_EISEN = "kanban-by-eisen",
-  KANBAN = "kanban",
-  LIST = "list",
-  TIMELINE = "timeline",
-  CALENDAR = "calendar",
 }
 
 const EISENS = [
@@ -289,6 +292,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The form posts to this very page, so the way the plan is being looked at
+  // comes along with it and can be handed back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+  const timePlanLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}`,
+    timePlanView,
+  );
 
   try {
     switch (form.intent) {
@@ -325,7 +337,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
                 }
               : { should_change: false },
         });
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "change-time-config-for-generated": {
@@ -359,7 +371,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
                 }
               : { should_change: false },
         });
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "archive": {
@@ -383,7 +395,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           owner: form.publishOwner,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "activate-publish": {
@@ -391,7 +403,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           ref_id: form.publishEntityRefId,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "to-draft-publish": {
@@ -399,7 +411,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           ref_id: form.publishEntityRefId,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       default:
@@ -410,13 +422,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 }
 
-export const shouldRevalidate: ShouldRevalidateFunction = basicShouldRevalidate;
+export const shouldRevalidate: ShouldRevalidateFunction =
+  ignoringTimePlanViewChanges(basicShouldRevalidate);
 
 export default function TimePlanView() {
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isBigScreen = useBigScreen();
+  const [query, setQuery] = useSearchParams();
 
   const shouldShowALeaf = useBranchNeedsToShowLeaf();
 
@@ -561,9 +575,22 @@ export default function TimePlanView() {
   const [selectedGrouping, setSelectedGrouping] = useState(
     inferDefaultSelectedGrouping(topLevelInfo.workspace, loaderData.timePlan),
   );
-  const [selectedView, setSelectedView] = useState<ViewMode>(
-    inferDefaultSelectedView(topLevelInfo.workspace, loaderData.timePlan),
+  // The view lives in the URL rather than in here, so a reload - or coming
+  // back from one of the panels this plan opens - shows the same one again.
+  const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
+  const selectedView = resolveTimePlanViewMode(
+    timePlanViewParam,
+    topLevelInfo.workspace,
+    loaderData.timePlan,
   );
+
+  function setSelectedView(view: TimePlanViewMode) {
+    setQuery(newURLParams(query, TIME_PLAN_VIEW_PARAM, view), {
+      replace: true,
+      preventScrollReset: true,
+    });
+  }
+
   const [selectedGroupVisibility, setSelectedGroupVisibility] =
     useState<GroupVisibility>(GroupVisibility.NON_EMPTY_ONLY);
   const [selectedKinds, setSelectedKinds] = useState<TimePlanActivityKind[]>(
@@ -598,32 +625,11 @@ export default function TimePlanView() {
     setSelectedGrouping(
       inferDefaultSelectedGrouping(topLevelInfo.workspace, loaderData.timePlan),
     );
-    setSelectedView(
-      inferDefaultSelectedView(topLevelInfo.workspace, loaderData.timePlan),
-    );
     setSelectedGroupVisibility(GroupVisibility.NON_EMPTY_ONLY);
     setSelectedKinds([]);
     setSelectedFeasabilities([]);
     setSelectedDoneness([]);
   }, [topLevelInfo.workspace, loaderData.timePlan]);
-
-  // If the selected view is no longer allowed (e.g., kanban for monthly/quarterly/yearly),
-  // switch to a valid default view
-  useEffect(() => {
-    const kanbanNoLongerAllowed =
-      !timePlanAllowsKanbanViews(loaderData.timePlan) &&
-      (selectedView === ViewMode.KANBAN ||
-        selectedView === ViewMode.KANBAN_BY_EISEN);
-    const calendarNoLongerAllowed =
-      !timePlanAllowsCalendarView(loaderData.timePlan) &&
-      selectedView === ViewMode.CALENDAR;
-
-    if (kanbanNoLongerAllowed || calendarNoLongerAllowed) {
-      setSelectedView(
-        inferDefaultSelectedView(topLevelInfo.workspace, loaderData.timePlan),
-      );
-    }
-  }, [loaderData.timePlan, selectedView, topLevelInfo.workspace]);
 
   const sortedAspects = sortAspectsByTreeOrder(loaderData.allAspects || []);
   const allAspectsByRefId = new Map(
@@ -789,64 +795,97 @@ export default function TimePlanView() {
                       ? [
                           NavSingle({
                             text: "New Todo",
-                            link: `/app/workspace/todos/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                            link: withTimePlanView(
+                              `/app/workspace/todos/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.TODO_TASK,
                           }),
                           NavSingle({
                             text: "From Existing Todos",
-                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-todo-tasks`,
+                            link: withTimePlanView(
+                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-todo-tasks`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.TODO_TASK,
                           }),
                           NavSingle({
                             text: "New Habit",
-                            link: `/app/workspace/habits/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                            link: withTimePlanView(
+                              `/app/workspace/habits/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.HABITS,
                           }),
                           NavSingle({
                             text: "From Existing Habits",
-                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-habits`,
+                            link: withTimePlanView(
+                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-habits`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.HABITS,
                           }),
                           NavSingle({
                             text: "New Chore",
-                            link: `/app/workspace/chores/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                            link: withTimePlanView(
+                              `/app/workspace/chores/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.CHORES,
                           }),
                           NavSingle({
                             text: "From Existing Chores",
-                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-chores`,
+                            link: withTimePlanView(
+                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-chores`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.CHORES,
                           }),
                         ]
                       : []),
                     NavSingle({
                       text: "New Big Plan",
-                      link: `/app/workspace/big-plans/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                      link: withTimePlanView(
+                        `/app/workspace/big-plans/new?timePlanReason=for-time-plan&timePlanRefId=${loaderData.timePlan.ref_id}`,
+                        timePlanViewParam,
+                      ),
                       gatedOn: WorkspaceFeature.BIG_PLANS,
                     }),
                     NavSingle({
                       text: "From Existing Big Plans",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`,
+                      link: withTimePlanView(
+                        `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`,
+                        timePlanViewParam,
+                      ),
                       gatedOn: WorkspaceFeature.BIG_PLANS,
                     }),
                     ...(timePlanAllowsInboxTasks(loaderData.timePlan)
                       ? [
                           NavSingle({
                             text: "From Included Big Plan Tasks",
-                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-included-big-plan-tasks`,
+                            link: withTimePlanView(
+                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-included-big-plan-tasks`,
+                              timePlanViewParam,
+                            ),
                             gatedOn: WorkspaceFeature.BIG_PLANS,
                           }),
                         ]
                       : []),
                     NavSingle({
                       text: "From Time Plans",
-                      link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-time-plans/${loaderData.timePlan.ref_id}`,
+                      link: withTimePlanView(
+                        `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-time-plans/${loaderData.timePlan.ref_id}`,
+                        timePlanViewParam,
+                      ),
                     }),
                     ...(timePlanAllowsInboxTasks(loaderData.timePlan)
                       ? [
                           NavSingle({
                             text: "From Generated Inbox Tasks",
-                            link: `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
+                            link: withTimePlanView(
+                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
+                              timePlanViewParam,
+                            ),
                           }),
                         ]
                       : []),
@@ -857,29 +896,29 @@ export default function TimePlanView() {
                   selectedView,
                   [
                     {
-                      value: ViewMode.KANBAN_BY_EISEN,
+                      value: TimePlanViewMode.KANBAN_BY_EISEN,
                       text: "Kanban by Eisen",
                       icon: <ViewKanbanIcon />,
                       disabled: !timePlanAllowsKanbanViews(loaderData.timePlan),
                     },
                     {
-                      value: ViewMode.KANBAN,
+                      value: TimePlanViewMode.KANBAN,
                       text: "Kanban",
                       icon: <ViewKanbanIcon />,
                       disabled: !timePlanAllowsKanbanViews(loaderData.timePlan),
                     },
                     {
-                      value: ViewMode.LIST,
+                      value: TimePlanViewMode.LIST,
                       text: "List",
                       icon: <ViewListIcon />,
                     },
                     {
-                      value: ViewMode.TIMELINE,
+                      value: TimePlanViewMode.TIMELINE,
                       text: "Timeline",
                       icon: <ViewTimelineIcon />,
                     },
                     {
-                      value: ViewMode.CALENDAR,
+                      value: TimePlanViewMode.CALENDAR,
                       text: "Calendar",
                       icon: <CalendarMonthIcon />,
                       gatedOn: WorkspaceFeature.SCHEDULE,
@@ -981,14 +1020,20 @@ export default function TimePlanView() {
               message="There are no activities to show. You can create a new activity."
               newEntityLocations={
                 timePlanAllowsInboxTasks(loaderData.timePlan)
-                  ? `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`
-                  : `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`
+                  ? withTimePlanView(
+                      `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-generated-inbox-tasks?showFromPeriod=${loaderData.timePlan.period}`,
+                      timePlanViewParam,
+                    )
+                  : withTimePlanView(
+                      `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/add-from-current-big-plans`,
+                      timePlanViewParam,
+                    )
               }
               helpSubject={DocsHelpSubject.TIME_PLANS}
             />
           )}
 
-          {selectedView === ViewMode.KANBAN_BY_EISEN &&
+          {selectedView === TimePlanViewMode.KANBAN_BY_EISEN &&
             timePlanAllowsKanbanViews(loaderData.timePlan) && (
               <>
                 {isBigScreen && (
@@ -1013,7 +1058,10 @@ export default function TimePlanView() {
                             allowEisen={e}
                             draggedInboxTaskId={draggedInboxTaskId}
                             cardLinkResolver={(it) =>
-                              `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
+                              withTimePlanView(
+                                `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`,
+                                timePlanViewParam,
+                              )
                             }
                           />
                         </Fragment>
@@ -1030,14 +1078,17 @@ export default function TimePlanView() {
                     actionableTime={ActionableTime.NOW}
                     emptyParent="inbox task"
                     cardLinkResolver={(it) =>
-                      `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
+                      withTimePlanView(
+                        `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`,
+                        timePlanViewParam,
+                      )
                     }
                   />
                 )}
               </>
             )}
 
-          {selectedView === ViewMode.KANBAN &&
+          {selectedView === TimePlanViewMode.KANBAN &&
             timePlanAllowsKanbanViews(loaderData.timePlan) && (
               <>
                 {isBigScreen && (
@@ -1054,7 +1105,10 @@ export default function TimePlanView() {
                       actionableTime={ActionableTime.NOW}
                       draggedInboxTaskId={draggedInboxTaskId}
                       cardLinkResolver={(it) =>
-                        `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
+                        withTimePlanView(
+                          `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`,
+                          timePlanViewParam,
+                        )
                       }
                     />
                   </DragDropContext>
@@ -1068,16 +1122,19 @@ export default function TimePlanView() {
                     actionableTime={ActionableTime.NOW}
                     emptyParent="inbox task"
                     cardLinkResolver={(it) =>
-                      `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`
+                      withTimePlanView(
+                        `/app/workspace/time-plans/${loaderData.timePlan.ref_id}/${activityByInboxTaskRefId.get(it.ref_id)?.ref_id ?? it.ref_id}`,
+                        timePlanViewParam,
+                      )
                     }
                   />
                 )}
               </>
             )}
 
-          {selectedView === ViewMode.LIST && activitiesAsList}
+          {selectedView === TimePlanViewMode.LIST && activitiesAsList}
 
-          {selectedView === ViewMode.CALENDAR &&
+          {selectedView === TimePlanViewMode.CALENDAR &&
             timePlanAllowsCalendarView(loaderData.timePlan) && (
               <TimePlanCalendarActivities
                 timePlan={loaderData.timePlan}
@@ -1094,7 +1151,7 @@ export default function TimePlanView() {
               />
             )}
 
-          {selectedView === ViewMode.TIMELINE &&
+          {selectedView === TimePlanViewMode.TIMELINE &&
             selectedGrouping === Grouping.MERGED && (
               <TimePlanTimelineMergedActivities
                 timePlan={loaderData.timePlan}
@@ -1114,7 +1171,7 @@ export default function TimePlanView() {
               />
             )}
 
-          {selectedView === ViewMode.TIMELINE &&
+          {selectedView === TimePlanViewMode.TIMELINE &&
             selectedGrouping === Grouping.BY_ASPECT && (
               <TimePlanTimelineByAspectActivities
                 timePlan={loaderData.timePlan}
@@ -1138,7 +1195,7 @@ export default function TimePlanView() {
               />
             )}
 
-          {selectedView === ViewMode.TIMELINE &&
+          {selectedView === TimePlanViewMode.TIMELINE &&
             selectedGrouping === Grouping.BY_ASPECT_AND_GOALS && (
               <TimePlanTimelineByAspectAndGoalActivities
                 timePlan={loaderData.timePlan}
@@ -1290,21 +1347,5 @@ function inferDefaultSelectedGrouping(
     case RecurringTaskPeriod.QUARTERLY:
     case RecurringTaskPeriod.YEARLY:
       return Grouping.BY_ASPECT_AND_GOALS;
-  }
-}
-
-function inferDefaultSelectedView(workspace: Workspace, timePlan: TimePlan) {
-  if (!isWorkspaceFeatureAvailable(workspace, WorkspaceFeature.LIFE_PLAN)) {
-    return ViewMode.LIST;
-  }
-
-  switch (timePlan.period) {
-    case RecurringTaskPeriod.DAILY:
-    case RecurringTaskPeriod.WEEKLY:
-    case RecurringTaskPeriod.MONTHLY:
-      return ViewMode.LIST;
-    case RecurringTaskPeriod.QUARTERLY:
-    case RecurringTaskPeriod.YEARLY:
-      return ViewMode.TIMELINE;
   }
 }

--- a/src/webui/app/routes/app/workspace/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id.tsx
@@ -23,6 +23,7 @@ import {
 } from "@jupiter/webapi-client";
 import type { DragStart, DropResult } from "@hello-pangea/dnd";
 import { DragDropContext } from "@hello-pangea/dnd";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import FlareIcon from "@mui/icons-material/Flare";
 import FlagIcon from "@mui/icons-material/Flag";
 import ViewKanbanIcon from "@mui/icons-material/ViewKanban";
@@ -49,6 +50,7 @@ import { filterActivityByFeasabilityWithParents } from "@jupiter/core/time_plans
 import { isTimePlanActivityInboxTaskTarget } from "@jupiter/core/time_plans/sub/activity/target-wire";
 import {
   sortTimePlansNaturally,
+  timePlanAllowsCalendarView,
   timePlanAllowsInboxTasks,
   timePlanAllowsKanbanViews,
 } from "@jupiter/core/time_plans/root";
@@ -106,6 +108,7 @@ import { TimePlanListByAspectAndGoalsActivities } from "@jupiter/core/time_plans
 import { TimePlanTimelineMergedActivities } from "@jupiter/core/time_plans/component/timeline-merged-activities";
 import { TimePlanTimelineByAspectActivities } from "@jupiter/core/time_plans/component/timeline-by-aspect-activities";
 import { TimePlanTimelineByAspectAndGoalActivities } from "@jupiter/core/time_plans/component/timeline-by-aspect-and-goal-activities";
+import { TimePlanCalendarActivities } from "@jupiter/core/time_plans/component/calendar-activities";
 import { TimePlanStack } from "@jupiter/core/time_plans/component/stack";
 import {
   fixSelectOutputEntityId,
@@ -131,6 +134,7 @@ enum ViewMode {
   KANBAN = "kanban",
   LIST = "list",
   TIMELINE = "timeline",
+  CALENDAR = "calendar",
 }
 
 const EISENS = [
@@ -268,8 +272,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       previousTimePlan: result.previous_time_plan as TimePlan,
       journal: journalResult?.journal,
       subPeriodJournals: journalResult?.sub_period_journals || [],
-      timeEventForInboxTasks: timeEventResult?.entries?.todo_task_entries || [],
-      timeEventForBigPlans: timeEventResult?.entries?.big_plan_entries || [],
+      calendarEntries: timeEventResult?.entries ?? null,
+      calendarPeriodStartDate: timeEventResult?.period_start_date ?? null,
+      calendarPeriodEndDate: timeEventResult?.period_end_date ?? null,
       activityTimeEventBlocks: result.activity_time_event_blocks || [],
       publishEntity: result.publish_entity ?? null,
       owner: result.owner,
@@ -535,10 +540,10 @@ export default function TimePlanView() {
       : [],
   );
   const timeEventsByRefId = new Map();
-  for (const e of loaderData.timeEventForInboxTasks) {
+  for (const e of loaderData.calendarEntries?.todo_task_entries ?? []) {
     timeEventsByRefId.set(`it:${e.inbox_task.ref_id}`, e.time_events);
   }
-  for (const e of loaderData.timeEventForBigPlans) {
+  for (const e of loaderData.calendarEntries?.big_plan_entries ?? []) {
     timeEventsByRefId.set(`bp:${e.big_plan.ref_id}`, e.time_events);
   }
   for (const block of loaderData.activityTimeEventBlocks) {
@@ -605,11 +610,15 @@ export default function TimePlanView() {
   // If the selected view is no longer allowed (e.g., kanban for monthly/quarterly/yearly),
   // switch to a valid default view
   useEffect(() => {
-    if (
+    const kanbanNoLongerAllowed =
       !timePlanAllowsKanbanViews(loaderData.timePlan) &&
       (selectedView === ViewMode.KANBAN ||
-        selectedView === ViewMode.KANBAN_BY_EISEN)
-    ) {
+        selectedView === ViewMode.KANBAN_BY_EISEN);
+    const calendarNoLongerAllowed =
+      !timePlanAllowsCalendarView(loaderData.timePlan) &&
+      selectedView === ViewMode.CALENDAR;
+
+    if (kanbanNoLongerAllowed || calendarNoLongerAllowed) {
       setSelectedView(
         inferDefaultSelectedView(topLevelInfo.workspace, loaderData.timePlan),
       );
@@ -634,6 +643,79 @@ export default function TimePlanView() {
     activityDoneness: loaderData.activityDoneness,
     completedNontargetInboxTasks: loaderData.completedNontargetInboxTasks ?? [],
   });
+
+  // The activities as the list view shows them. The calendar view shows the
+  // very same thing in a column next to the calendar itself.
+  const activitiesAsList = (() => {
+    switch (selectedGrouping) {
+      case Grouping.MERGED:
+        return (
+          <TimePlanListMergedActivities
+            mustDoActivities={mustDoActivities}
+            niceToHaveActivities={niceToHaveActivities}
+            stretchActivities={stretchActivities}
+            targetInboxTasksByRefId={targetInboxTasksByRefId}
+            targetBigPlansByRefId={targetBigPlansByRefId}
+            targetTodoTasksByRefId={targetTodoTasksByRefId}
+            targetHabitsByRefId={targetHabitsByRefId}
+            targetChoresByRefId={targetChoresByRefId}
+            activityDoneness={loaderData.activityDoneness}
+            timeEventsByRefId={timeEventsByRefId}
+            selectedKinds={selectedKinds}
+            selectedFeasabilities={selectedFeasabilities}
+            selectedDoneness={selectedDoneness}
+          />
+        );
+
+      case Grouping.BY_ASPECT:
+        return (
+          <TimePlanListByAspectActivities
+            mustDoActivities={mustDoActivities}
+            otherActivities={otherActivities}
+            targetInboxTasksByRefId={targetInboxTasksByRefId}
+            targetBigPlansByRefId={targetBigPlansByRefId}
+            targetTodoTasksByRefId={targetTodoTasksByRefId}
+            targetHabitsByRefId={targetHabitsByRefId}
+            targetChoresByRefId={targetChoresByRefId}
+            activityDoneness={loaderData.activityDoneness}
+            timeEventsByRefId={timeEventsByRefId}
+            selectedKinds={selectedKinds}
+            selectedFeasabilities={selectedFeasabilities}
+            selectedDoneness={selectedDoneness}
+            aspects={sortedAspects}
+            aspectsByRefId={allAspectsByRefId}
+            showEmptyGroups={
+              selectedGroupVisibility === GroupVisibility.SHOW_ALL
+            }
+          />
+        );
+
+      case Grouping.BY_ASPECT_AND_GOALS:
+        return (
+          <TimePlanListByAspectAndGoalsActivities
+            mustDoActivities={mustDoActivities}
+            otherActivities={otherActivities}
+            targetInboxTasksByRefId={targetInboxTasksByRefId}
+            targetBigPlansByRefId={targetBigPlansByRefId}
+            targetTodoTasksByRefId={targetTodoTasksByRefId}
+            targetHabitsByRefId={targetHabitsByRefId}
+            targetChoresByRefId={targetChoresByRefId}
+            activityDoneness={loaderData.activityDoneness}
+            timeEventsByRefId={timeEventsByRefId}
+            selectedKinds={selectedKinds}
+            selectedFeasabilities={selectedFeasabilities}
+            selectedDoneness={selectedDoneness}
+            aspects={sortedAspects}
+            aspectsByRefId={allAspectsByRefId}
+            goals={sortedGoals}
+            goalsByRefId={allGoalsByRefId}
+            showEmptyGroups={
+              selectedGroupVisibility === GroupVisibility.SHOW_ALL
+            }
+          />
+        );
+    }
+  })();
 
   return (
     <BranchPanel
@@ -795,6 +877,15 @@ export default function TimePlanView() {
                       value: ViewMode.TIMELINE,
                       text: "Timeline",
                       icon: <ViewTimelineIcon />,
+                    },
+                    {
+                      value: ViewMode.CALENDAR,
+                      text: "Calendar",
+                      icon: <CalendarMonthIcon />,
+                      gatedOn: WorkspaceFeature.SCHEDULE,
+                      disabled: !timePlanAllowsCalendarView(
+                        loaderData.timePlan,
+                      ),
                     },
                   ],
                   (selected) => setSelectedView(selected),
@@ -984,70 +1075,22 @@ export default function TimePlanView() {
               </>
             )}
 
-          {selectedView === ViewMode.LIST &&
-            selectedGrouping === Grouping.MERGED && (
-              <TimePlanListMergedActivities
-                mustDoActivities={mustDoActivities}
-                niceToHaveActivities={niceToHaveActivities}
-                stretchActivities={stretchActivities}
-                targetInboxTasksByRefId={targetInboxTasksByRefId}
-                targetBigPlansByRefId={targetBigPlansByRefId}
-                targetTodoTasksByRefId={targetTodoTasksByRefId}
-                targetHabitsByRefId={targetHabitsByRefId}
-                targetChoresByRefId={targetChoresByRefId}
-                activityDoneness={loaderData.activityDoneness}
-                timeEventsByRefId={timeEventsByRefId}
-                selectedKinds={selectedKinds}
-                selectedFeasabilities={selectedFeasabilities}
-                selectedDoneness={selectedDoneness}
-              />
-            )}
+          {selectedView === ViewMode.LIST && activitiesAsList}
 
-          {selectedView === ViewMode.LIST &&
-            selectedGrouping === Grouping.BY_ASPECT && (
-              <TimePlanListByAspectActivities
-                mustDoActivities={mustDoActivities}
-                otherActivities={otherActivities}
-                targetInboxTasksByRefId={targetInboxTasksByRefId}
-                targetBigPlansByRefId={targetBigPlansByRefId}
-                targetTodoTasksByRefId={targetTodoTasksByRefId}
-                targetHabitsByRefId={targetHabitsByRefId}
-                targetChoresByRefId={targetChoresByRefId}
-                activityDoneness={loaderData.activityDoneness}
-                timeEventsByRefId={timeEventsByRefId}
-                selectedKinds={selectedKinds}
-                selectedFeasabilities={selectedFeasabilities}
-                selectedDoneness={selectedDoneness}
-                aspects={sortedAspects}
-                aspectsByRefId={allAspectsByRefId}
-                showEmptyGroups={
-                  selectedGroupVisibility === GroupVisibility.SHOW_ALL
+          {selectedView === ViewMode.CALENDAR &&
+            timePlanAllowsCalendarView(loaderData.timePlan) && (
+              <TimePlanCalendarActivities
+                timePlan={loaderData.timePlan}
+                periodStartDate={
+                  loaderData.calendarPeriodStartDate ??
+                  loaderData.timePlan.start_date
                 }
-              />
-            )}
-
-          {selectedView === ViewMode.LIST &&
-            selectedGrouping === Grouping.BY_ASPECT_AND_GOALS && (
-              <TimePlanListByAspectAndGoalsActivities
-                mustDoActivities={mustDoActivities}
-                otherActivities={otherActivities}
-                targetInboxTasksByRefId={targetInboxTasksByRefId}
-                targetBigPlansByRefId={targetBigPlansByRefId}
-                targetTodoTasksByRefId={targetTodoTasksByRefId}
-                targetHabitsByRefId={targetHabitsByRefId}
-                targetChoresByRefId={targetChoresByRefId}
-                activityDoneness={loaderData.activityDoneness}
-                timeEventsByRefId={timeEventsByRefId}
-                selectedKinds={selectedKinds}
-                selectedFeasabilities={selectedFeasabilities}
-                selectedDoneness={selectedDoneness}
-                aspects={sortedAspects}
-                aspectsByRefId={allAspectsByRefId}
-                goals={sortedGoals}
-                goalsByRefId={allGoalsByRefId}
-                showEmptyGroups={
-                  selectedGroupVisibility === GroupVisibility.SHOW_ALL
+                periodEndDate={
+                  loaderData.calendarPeriodEndDate ??
+                  loaderData.timePlan.end_date
                 }
+                entries={loaderData.calendarEntries ?? undefined}
+                activities={activitiesAsList}
               />
             )}
 

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -39,6 +39,7 @@ import {
   sortInboxTaskTimeEventsNaturally,
   timeEventInDayBlockToTimezone,
 } from "@jupiter/core/common/sub/time_events/time-event";
+import { TIME_PLAN_ACTIVITY_TIME_EVENT_PARAM } from "@jupiter/core/calendar/component/calendar-navigation";
 import {
   isInboxTaskCoreFieldEditable,
   sortInboxTasksNaturally,
@@ -57,6 +58,7 @@ import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-bound
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
 import {
+  ActionMultipleSpread,
   ActionSingle,
   NavMultipleSpread,
   NavSingle,
@@ -182,6 +184,10 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
   }),
   z.object({
     intent: z.literal("remove"),
+  }),
+  z.object({
+    intent: z.literal("remove-time-event"),
+    timeEventRefId: z.string(),
   }),
   z.object({
     intent: z.literal("target-inbox-task-mark-done"),
@@ -439,6 +445,19 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(timePlanLocation);
+      }
+
+      case "remove-time-event": {
+        await apiClient.timeEvents.timeEventInDayBlockArchive({
+          ref_id: form.timeEventRefId,
+        });
+
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-inbox-task-mark-done":
@@ -1303,6 +1322,10 @@ export default function TimePlanActivity() {
   const sortedActivityTimeEventEntries = sortInboxTaskTimeEventsNaturally(
     activityTimeEventEntries,
   );
+  const calendarTimeEventRefId = query.get(TIME_PLAN_ACTIVITY_TIME_EVENT_PARAM);
+  const calendarTimeEvent = (loaderData.activityTimeEventBlocks || []).find(
+    (block) => block.ref_id === calendarTimeEventRefId,
+  );
 
   let newActivityTimeEventLocation: string | undefined = undefined;
   if (
@@ -1344,15 +1367,36 @@ export default function TimePlanActivity() {
             topLevelInfo={topLevelInfo}
             inputsEnabled={inputsEnabled}
             actions={[
-              ActionSingle({
-                text: "Save",
-                value: "update",
-                highlight: true,
-              }),
+              calendarTimeEvent
+                ? ActionMultipleSpread({
+                    actions: [
+                      ActionSingle({
+                        text: "Save",
+                        value: "update",
+                        highlight: true,
+                      }),
+                      ActionSingle({
+                        text: "Remove Event",
+                        value: "remove-time-event",
+                      }),
+                    ],
+                  })
+                : ActionSingle({
+                    text: "Save",
+                    value: "update",
+                    highlight: true,
+                  }),
             ]}
           />
         }
       >
+        {calendarTimeEvent && (
+          <input
+            type="hidden"
+            name="timeEventRefId"
+            value={calendarTimeEvent.ref_id}
+          />
+        )}
         <Stack
           spacing={2}
           useFlexGap

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -28,6 +28,7 @@ import {
   useNavigation,
   useParams,
   useRouteLoaderData,
+  useSearchParams,
 } from "@remix-run/react";
 import { useContext } from "react";
 import { z } from "zod";
@@ -48,6 +49,10 @@ import { ChorePropertiesEditor } from "@jupiter/core/chores/component/properties
 import { InboxTaskPropertiesEditor } from "@jupiter/core/common/sub/inbox_tasks/component/properties-editor";
 import { InboxTaskStack } from "@jupiter/core/common/sub/inbox_tasks/component/stack";
 import { EntityNoteEditor } from "@jupiter/core/infra/component/entity-note-editor";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -392,6 +397,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id, activityId } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+  const timePlanLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}`,
+    timePlanView,
+  );
 
   try {
     switch (form.intent) {
@@ -408,7 +422,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "archive": {
@@ -416,7 +430,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           ref_id: activityId,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "remove": {
@@ -424,7 +438,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           ref_id: activityId,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "target-inbox-task-mark-done":
@@ -512,7 +526,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "target-inbox-task-delay-1-day":
@@ -566,7 +580,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "target-big-plan-mark-done":
@@ -662,7 +676,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "target-big-plan-create-note": {
@@ -681,7 +695,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-todo-task-mark-done":
@@ -807,7 +826,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-todo-task-create-note": {
@@ -826,7 +850,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-habit-update": {
@@ -934,7 +963,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-habit-create-note": {
@@ -953,7 +987,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-habit-gen": {
@@ -968,7 +1007,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-chore-update": {
@@ -1082,7 +1126,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           },
         });
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-chore-create-note": {
@@ -1101,7 +1150,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       case "target-chore-gen": {
@@ -1116,7 +1170,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
           });
         }
 
-        return redirect(`/app/workspace/time-plans/${id}/${activityId}`);
+        return redirect(
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${activityId}`,
+            timePlanView,
+          ),
+        );
       }
 
       default:
@@ -1129,6 +1188,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function TimePlanActivity() {
   const { id, activityId } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const parentLoaderData = useRouteLoaderData<{
     timePlan: TimePlan;
@@ -1255,6 +1316,9 @@ export default function TimePlanActivity() {
       timePlanActivityRefId: activityId as string,
       timePlanRefId: id as string,
     });
+    if (timePlanView !== null) {
+      params.set(TIME_PLAN_VIEW_PARAM, timePlanView);
+    }
     newActivityTimeEventLocation = `/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity?${params.toString()}`;
   }
 
@@ -1267,7 +1331,10 @@ export default function TimePlanActivity() {
       showArchiveAndRemoveButton
       inputsEnabled={inputsEnabled}
       entityArchived={loaderData.timePlanActivity.archived}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
       initialExpansionState={LeafPanelExpansionState.MEDIUM}
     >
       <GlobalError actionResult={actionData} />
@@ -1404,12 +1471,18 @@ export default function TimePlanActivity() {
                           ? [
                               NavSingle({
                                 text: "New Inbox Task",
-                                link: `/app/workspace/big-plans/${loaderData.targetBigPlan.ref_id}/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${id}&parentTimePlanActivityRefId=${activityId}`,
+                                link: withTimePlanView(
+                                  `/app/workspace/big-plans/${loaderData.targetBigPlan.ref_id}/inbox-tasks/new?timePlanReason=for-time-plan&timePlanRefId=${id}&parentTimePlanActivityRefId=${activityId}`,
+                                  timePlanView,
+                                ),
                                 highlight: true,
                               }),
                               NavSingle({
                                 text: "From Big Plan Inbox Tasks",
-                                link: `/app/workspace/time-plans/${id}/add-from-big-plan-inbox-tasks?bigPlanRefId=${loaderData.targetBigPlan.ref_id}&timePlanActivityRefId=${activityId}`,
+                                link: withTimePlanView(
+                                  `/app/workspace/time-plans/${id}/add-from-big-plan-inbox-tasks?bigPlanRefId=${loaderData.targetBigPlan.ref_id}&timePlanActivityRefId=${activityId}`,
+                                  timePlanView,
+                                ),
                               }),
                             ]
                           : []),
@@ -1579,7 +1652,10 @@ export default function TimePlanActivity() {
                             navs: [
                               NavSingle({
                                 text: "From Habit Inbox Tasks",
-                                link: `/app/workspace/time-plans/${id}/add-from-habit-inbox-tasks?habitRefId=${loaderData.targetHabit.ref_id}&timePlanActivityRefId=${activityId}`,
+                                link: withTimePlanView(
+                                  `/app/workspace/time-plans/${id}/add-from-habit-inbox-tasks?habitRefId=${loaderData.targetHabit.ref_id}&timePlanActivityRefId=${activityId}`,
+                                  timePlanView,
+                                ),
                               }),
                             ],
                           }),
@@ -1683,7 +1759,10 @@ export default function TimePlanActivity() {
                             navs: [
                               NavSingle({
                                 text: "From Chore Inbox Tasks",
-                                link: `/app/workspace/time-plans/${id}/add-from-chore-inbox-tasks?choreRefId=${loaderData.targetChore.ref_id}&timePlanActivityRefId=${activityId}`,
+                                link: withTimePlanView(
+                                  `/app/workspace/time-plans/${id}/add-from-chore-inbox-tasks?choreRefId=${loaderData.targetChore.ref_id}&timePlanActivityRefId=${activityId}`,
+                                  timePlanView,
+                                ),
                               }),
                             ],
                           }),

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -1310,16 +1310,13 @@ export default function TimePlanActivity() {
     timePlan.period === RecurringTaskPeriod.WEEKLY
   ) {
     const params = new URLSearchParams({
-      date: timePlan.start_date,
-      period: timePlan.period,
-      view: "calendar",
       timePlanActivityRefId: activityId as string,
-      timePlanRefId: id as string,
+      date: timePlan.start_date,
     });
-    if (timePlanView !== null) {
-      params.set(TIME_PLAN_VIEW_PARAM, timePlanView);
-    }
-    newActivityTimeEventLocation = `/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity?${params.toString()}`;
+    newActivityTimeEventLocation = withTimePlanView(
+      `/app/workspace/time-plans/${id}/new-activity-time-event?${params.toString()}`,
+      timePlanView,
+    );
   }
 
   return (

--- a/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/$activityId.tsx
@@ -1335,7 +1335,7 @@ export default function TimePlanActivity() {
         `/app/workspace/time-plans/${id}`,
         timePlanView,
       )}
-      initialExpansionState={LeafPanelExpansionState.MEDIUM}
+      initialExpansionState={LeafPanelExpansionState.SMALL}
     >
       <GlobalError actionResult={actionData} />
       <SectionCard

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-big-plan-inbox-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-big-plan-inbox-tasks.tsx
@@ -28,6 +28,10 @@ import {
 } from "#/core/common/sub/inbox_tasks/root";
 import type { InboxTaskParent } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskCard } from "@jupiter/core/common/sub/inbox_tasks/component/card";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -140,6 +144,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const { id } = parseParams(params, ParamsSchema);
   const query = parseQuery(request, QuerySchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     switch (form.intent) {
@@ -170,7 +179,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
 
     return redirect(
-      `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+      withTimePlanView(
+        `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+        timePlanView,
+      ),
     );
   } catch (error) {
     return handleActionApiError(error);
@@ -186,6 +198,7 @@ export default function TimePlanAddFromBigPlanInboxTasks() {
   const isBigScreen = useBigScreen();
   const [searchParams] = useSearchParams();
   const query = parseQuery(searchParams, QuerySchema);
+  const timePlanViewParam = searchParams.get(TIME_PLAN_VIEW_PARAM);
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
@@ -227,7 +240,10 @@ export default function TimePlanAddFromBigPlanInboxTasks() {
     },
   ).filter((it) => !alreadyIncludedInboxTaskRefIds.has(it.ref_id));
 
-  const returnLocation = `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`;
+  const returnLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+    timePlanViewParam,
+  );
 
   return (
     <LeafPanel
@@ -345,7 +361,11 @@ export default function TimePlanAddFromBigPlanInboxTasks() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-chore-inbox-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-chore-inbox-tasks.tsx
@@ -36,6 +36,10 @@ import {
 } from "#/core/common/sub/inbox_tasks/root";
 import type { InboxTaskParent } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskCard } from "@jupiter/core/common/sub/inbox_tasks/component/card";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -150,6 +154,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const { id } = parseParams(params, ParamsSchema);
   const query = parseQuery(request, QuerySchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     switch (form.intent) {
@@ -163,12 +172,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(
-          `/app/workspace/time-plans/${id}/add-from-chore-inbox-tasks?${new URLSearchParams(
-            {
-              choreRefId: query.choreRefId,
-              timePlanActivityRefId: query.timePlanActivityRefId,
-            },
-          ).toString()}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/add-from-chore-inbox-tasks?${new URLSearchParams(
+              {
+                choreRefId: query.choreRefId,
+                timePlanActivityRefId: query.timePlanActivityRefId,
+              },
+            ).toString()}`,
+            timePlanView,
+          ),
         );
       }
 
@@ -182,7 +194,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(
-          `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+            timePlanView,
+          ),
         );
       }
 
@@ -203,6 +218,7 @@ export default function TimePlanAddFromChoreInboxTasks() {
   const isBigScreen = useBigScreen();
   const [searchParams] = useSearchParams();
   const query = parseQuery(searchParams, QuerySchema);
+  const timePlanViewParam = searchParams.get(TIME_PLAN_VIEW_PARAM);
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
@@ -244,7 +260,10 @@ export default function TimePlanAddFromChoreInboxTasks() {
     },
   ).filter((it) => !alreadyIncludedInboxTaskRefIds.has(it.ref_id));
 
-  const returnLocation = `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`;
+  const returnLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+    timePlanViewParam,
+  );
 
   return (
     <LeafPanel
@@ -397,7 +416,11 @@ export default function TimePlanAddFromChoreInboxTasks() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-big-plans.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-big-plans.tsx
@@ -19,7 +19,12 @@ import { FormControl, FormLabel, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import type { DateTime } from "luxon";
 import { Fragment, useContext, useEffect, useState } from "react";
 import { z } from "zod";
@@ -38,6 +43,10 @@ import type { BigPlanParent } from "@jupiter/core/big_plans/root";
 import { BigPlanStack } from "@jupiter/core/big_plans/component/stack";
 import { BigPlanTimelineBigScreen } from "@jupiter/core/big_plans/component/timeline-big-screen";
 import { BigPlanTimelineSmallScreen } from "@jupiter/core/big_plans/component/timeline-small-screen";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -147,6 +156,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+  const timePlanLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}`,
+    timePlanView,
+  );
 
   try {
     switch (form.intent) {
@@ -159,7 +177,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           feasability: form.feasability,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "add-and-override": {
@@ -171,7 +189,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           feasability: form.feasability,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       default:
@@ -184,6 +202,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function TimePlanAddFromCurrentBigPlans() {
   const { id } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -237,7 +257,10 @@ export default function TimePlanAddFromCurrentBigPlans() {
     <LeafPanel
       key={`time-plan-${id}/add-from-current-big-plans`}
       fakeKey={`time-plan-${id}/add-from-current-big-plans`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
       returnLocationDiscriminator="add-from-current-big-plans"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}
@@ -451,7 +474,11 @@ export default function TimePlanAddFromCurrentBigPlans() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-chores.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-chores.tsx
@@ -11,7 +11,12 @@ import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
@@ -21,6 +26,10 @@ import {
   EntityLink,
 } from "@jupiter/core/infra/component/entity-card";
 import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -116,6 +125,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     await apiClient.timePlans.timePlanAssociateWithChores({
@@ -125,7 +139,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
       feasability: form.feasability,
     });
 
-    return redirect(`/app/workspace/time-plans/${id}`);
+    return redirect(
+      withTimePlanView(`/app/workspace/time-plans/${id}`, timePlanView),
+    );
   } catch (error) {
     return handleActionApiError(error);
   }
@@ -137,6 +153,7 @@ function isSelectableChoreEntry(entry: ChoreFindResultEntry): boolean {
 
 export default function TimePlanAddFromCurrentChores() {
   const { id } = useParams();
+  const [query] = useSearchParams();
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -144,6 +161,7 @@ export default function TimePlanAddFromCurrentChores() {
     navigation.state === "idle" && !loaderData.timePlan.archived;
   const topLevelInfo = useContext(TopLevelInfoContext);
   const isBigScreen = useBigScreen();
+  const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
 
   const alreadyIncludedChoreRefIds = new Set(
     loaderData.activities
@@ -198,7 +216,10 @@ export default function TimePlanAddFromCurrentChores() {
     <LeafPanel
       key={`time-plan-${id}/add-from-current-chores`}
       fakeKey={`time-plan-${id}/add-from-current-chores`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanViewParam,
+      )}
       returnLocationDiscriminator="add-from-current-chores"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-habits.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-habits.tsx
@@ -11,7 +11,12 @@ import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
@@ -21,6 +26,10 @@ import {
   EntityLink,
 } from "@jupiter/core/infra/component/entity-card";
 import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -116,6 +125,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     await apiClient.timePlans.timePlanAssociateWithHabits({
@@ -125,7 +139,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
       feasability: form.feasability,
     });
 
-    return redirect(`/app/workspace/time-plans/${id}`);
+    return redirect(
+      withTimePlanView(`/app/workspace/time-plans/${id}`, timePlanView),
+    );
   } catch (error) {
     return handleActionApiError(error);
   }
@@ -137,6 +153,7 @@ function isSelectableHabitEntry(entry: HabitFindResultEntry): boolean {
 
 export default function TimePlanAddFromCurrentHabits() {
   const { id } = useParams();
+  const [query] = useSearchParams();
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -144,6 +161,7 @@ export default function TimePlanAddFromCurrentHabits() {
     navigation.state === "idle" && !loaderData.timePlan.archived;
   const topLevelInfo = useContext(TopLevelInfoContext);
   const isBigScreen = useBigScreen();
+  const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
 
   const alreadyIncludedHabitRefIds = new Set(
     loaderData.activities
@@ -198,7 +216,10 @@ export default function TimePlanAddFromCurrentHabits() {
     <LeafPanel
       key={`time-plan-${id}/add-from-current-habits`}
       fakeKey={`time-plan-${id}/add-from-current-habits`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanViewParam,
+      )}
       returnLocationDiscriminator="add-from-current-habits"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-time-plans/$otherTimePlanId.tsx
@@ -22,7 +22,12 @@ import { FormControl, FormLabel, Stack } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
@@ -32,6 +37,10 @@ import {
   sortTimePlanActivitiesNaturally,
 } from "@jupiter/core/time_plans/sub/activity/root";
 import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -173,6 +182,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id, otherTimePlanId } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+  const timePlanLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}`,
+    timePlanView,
+  );
 
   try {
     switch (form.intent) {
@@ -186,7 +204,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           override_existing_dates: false,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       case "add-and-override": {
@@ -199,7 +217,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           override_existing_dates: true,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       default:
@@ -212,6 +230,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function TimePlanAddFromCurrentTimePlans() {
   const { id, otherTimePlanId } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -308,7 +328,10 @@ export default function TimePlanAddFromCurrentTimePlans() {
     <LeafPanel
       key={`time-plan-${id}/add-from-current-time-plans-${otherTimePlanId}`}
       fakeKey={`time-plan-${id}/add-from-current-time-plans-${otherTimePlanId}`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
       returnLocationDiscriminator="add-from-current-time-plans"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-todo-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-current-todo-tasks.tsx
@@ -10,7 +10,12 @@ import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import { useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
@@ -25,6 +30,10 @@ import {
   EntityLink,
 } from "@jupiter/core/infra/component/entity-card";
 import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -120,6 +129,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     switch (form.intent) {
@@ -132,7 +146,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
           feasability: form.feasability,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(
+          withTimePlanView(`/app/workspace/time-plans/${id}`, timePlanView),
+        );
       }
 
       case "add-and-override": {
@@ -144,7 +160,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
           feasability: form.feasability,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(
+          withTimePlanView(`/app/workspace/time-plans/${id}`, timePlanView),
+        );
       }
 
       default:
@@ -165,6 +183,7 @@ function isWorkableTodoEntry(entry: TodoTaskFindResultEntry): boolean {
 
 export default function TimePlanAddFromCurrentTodoTasks() {
   const { id } = useParams();
+  const [query] = useSearchParams();
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -172,6 +191,7 @@ export default function TimePlanAddFromCurrentTodoTasks() {
     navigation.state === "idle" && !loaderData.timePlan.archived;
   const topLevelInfo = useContext(TopLevelInfoContext);
   const isBigScreen = useBigScreen();
+  const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
 
   const alreadyIncludedTodoTaskRefIds = new Set(
     loaderData.activities
@@ -237,7 +257,10 @@ export default function TimePlanAddFromCurrentTodoTasks() {
     <LeafPanel
       key={`time-plan-${id}/add-from-current-todo-tasks`}
       fakeKey={`time-plan-${id}/add-from-current-todo-tasks`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanViewParam,
+      )}
       returnLocationDiscriminator="add-from-current-todo-tasks"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-generated-inbox-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-generated-inbox-tasks.tsx
@@ -40,6 +40,10 @@ import {
 } from "#/core/common/sub/inbox_tasks/root";
 import type { InboxTaskParent } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskCard } from "@jupiter/core/common/sub/inbox_tasks/component/card";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -143,6 +147,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
   const query = await parseQuery(request, QuerySchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+  const timePlanLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}`,
+    timePlanView,
+  );
 
   try {
     switch (form.intent) {
@@ -153,7 +166,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(
-          `/app/workspace/time-plans/${id}/add-from-generated-inbox-tasks?${new URLSearchParams(query).toString()}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/add-from-generated-inbox-tasks?${new URLSearchParams(query).toString()}`,
+            timePlanView,
+          ),
         );
       }
 
@@ -166,7 +182,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           feasability: form.feasability,
         });
 
-        return redirect(`/app/workspace/time-plans/${id}`);
+        return redirect(timePlanLocation);
       }
 
       default:
@@ -186,6 +202,7 @@ export default function TimePlanAddFromCurrentInboxTasks() {
   const isBigScreen = useBigScreen();
   const [searchParams] = useSearchParams();
   const query = parseQuery(searchParams, QuerySchema);
+  const timePlanView = searchParams.get(TIME_PLAN_VIEW_PARAM);
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
@@ -244,7 +261,10 @@ export default function TimePlanAddFromCurrentInboxTasks() {
     <LeafPanel
       key={`time-plan-${id}/add-from-generated-inbox-tasks`}
       fakeKey={`time-plan-${id}/add-from-generated-inbox-tasks`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
       returnLocationDiscriminator="add-from-generated-inbox-tasks"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}
@@ -410,7 +430,11 @@ export default function TimePlanAddFromCurrentInboxTasks() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-habit-inbox-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-habit-inbox-tasks.tsx
@@ -36,6 +36,10 @@ import {
 } from "#/core/common/sub/inbox_tasks/root";
 import type { InboxTaskParent } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskCard } from "@jupiter/core/common/sub/inbox_tasks/component/card";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -150,6 +154,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const { id } = parseParams(params, ParamsSchema);
   const query = parseQuery(request, QuerySchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     switch (form.intent) {
@@ -163,12 +172,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(
-          `/app/workspace/time-plans/${id}/add-from-habit-inbox-tasks?${new URLSearchParams(
-            {
-              habitRefId: query.habitRefId,
-              timePlanActivityRefId: query.timePlanActivityRefId,
-            },
-          ).toString()}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/add-from-habit-inbox-tasks?${new URLSearchParams(
+              {
+                habitRefId: query.habitRefId,
+                timePlanActivityRefId: query.timePlanActivityRefId,
+              },
+            ).toString()}`,
+            timePlanView,
+          ),
         );
       }
 
@@ -182,7 +194,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
         });
 
         return redirect(
-          `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+            timePlanView,
+          ),
         );
       }
 
@@ -203,6 +218,7 @@ export default function TimePlanAddFromHabitInboxTasks() {
   const isBigScreen = useBigScreen();
   const [searchParams] = useSearchParams();
   const query = parseQuery(searchParams, QuerySchema);
+  const timePlanViewParam = searchParams.get(TIME_PLAN_VIEW_PARAM);
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
@@ -244,7 +260,10 @@ export default function TimePlanAddFromHabitInboxTasks() {
     },
   ).filter((it) => !alreadyIncludedInboxTaskRefIds.has(it.ref_id));
 
-  const returnLocation = `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`;
+  const returnLocation = withTimePlanView(
+    `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+    timePlanViewParam,
+  );
 
   return (
     <LeafPanel
@@ -397,7 +416,11 @@ export default function TimePlanAddFromHabitInboxTasks() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/add-from-included-big-plan-tasks.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/add-from-included-big-plan-tasks.tsx
@@ -13,7 +13,12 @@ import { FormControl, FormLabel, Stack, Typography } from "@mui/material";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { useActionData, useNavigation, useParams } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
 import { Fragment, useContext, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
@@ -27,6 +32,10 @@ import {
 import type { InboxTaskParent } from "#/core/common/sub/inbox_tasks/root";
 import { InboxTaskCard } from "@jupiter/core/common/sub/inbox_tasks/component/card";
 import { EntityStack } from "@jupiter/core/infra/component/entity-stack";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -138,6 +147,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
   const { id } = parseParams(params, ParamsSchema);
   const form = await parseForm(request, UpdateFormSchema);
+  // The panel was opened from a time plan being looked at one way or another
+  // - whatever it does, it hands that back on the way out.
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
 
   try {
     switch (form.intent) {
@@ -167,7 +181,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
         throw new Response("Bad Intent", { status: 500 });
     }
 
-    return redirect(`/app/workspace/time-plans/${id}`);
+    return redirect(
+      withTimePlanView(`/app/workspace/time-plans/${id}`, timePlanView),
+    );
   } catch (error) {
     return handleActionApiError(error);
   }
@@ -175,11 +191,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function TimePlanAddFromIncludedBigPlanTasks() {
   const { id } = useParams();
+  const [query] = useSearchParams();
   const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const topLevelInfo = useContext(TopLevelInfoContext);
   const isBigScreen = useBigScreen();
+  const timePlanViewParam = query.get(TIME_PLAN_VIEW_PARAM);
 
   const inputsEnabled =
     navigation.state === "idle" && !loaderData.timePlan.archived;
@@ -244,7 +262,10 @@ export default function TimePlanAddFromIncludedBigPlanTasks() {
     <LeafPanel
       key={`time-plan-${id}/add-from-included-big-plan-tasks`}
       fakeKey={`time-plan-${id}/add-from-included-big-plan-tasks`}
-      returnLocation={`/app/workspace/time-plans/${id}`}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanViewParam,
+      )}
       returnLocationDiscriminator="add-from-included-big-plan-tasks"
       inputsEnabled={inputsEnabled}
       initialExpansionState={LeafPanelExpansionState.LARGE}
@@ -383,7 +404,11 @@ export default function TimePlanAddFromIncludedBigPlanTasks() {
 }
 
 export const ErrorBoundary = makeLeafErrorBoundary(
-  (params) => `/app/workspace/time-plans/${params.id}`,
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
   ParamsSchema,
   {
     notFound: (params) => `Could not find time plan #${params.id}!`,

--- a/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
@@ -1,0 +1,574 @@
+import type {
+  Contact,
+  Person,
+  ScheduleEventFullDays,
+  ScheduleEventInDay,
+  ScheduleStreamSummary,
+  Tag,
+  TimeEventFullDaysBlock,
+  TimeEventInDayBlock,
+  Timezone,
+  UserLight,
+} from "@jupiter/webapi-client";
+import { NamedEntityTag } from "@jupiter/webapi-client";
+import LaunchIcon from "@mui/icons-material/Launch";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+} from "@mui/material";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+import { Link, useParams, useSearchParams } from "@remix-run/react";
+import { useContext } from "react";
+import { z } from "zod";
+import { parseParams } from "zodix";
+
+import { parseEntityLinkStd } from "@jupiter/core/common/entity-link";
+import { TimeEventSourceLink } from "@jupiter/core/common/sub/time_events/component/source-link";
+import {
+  occasionTimeEventName,
+  timeEventInDayBlockParamsToTimezone,
+} from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  calendarEventWorkspacePath,
+} from "@jupiter/core/calendar/component/calendar-navigation";
+import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
+import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
+import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
+import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
+import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import { handleLoaderApiError } from "@jupiter/core/infra/errors.server";
+import { ScheduleEventInDayEditor } from "@jupiter/core/schedule/sub/event_in_day/component/editor";
+import { ScheduleEventFullDaysEditor } from "@jupiter/core/schedule/sub/event_full_days/component/editor";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
+
+import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+const ParamsSchema = z.object({
+  id: z.string(),
+  kind: z.enum([
+    "schedule-event-in-day",
+    "schedule-event-full-days",
+    "time-event-in-day-block",
+    "time-event-full-days-block",
+  ]),
+  refId: z.string(),
+});
+
+export const handle = {
+  displayType: DisplayType.LEAF,
+};
+
+type ScheduleExtras = {
+  allScheduleStreams: Array<ScheduleStreamSummary>;
+  tags: Array<Tag>;
+  contacts: Array<Contact>;
+  allTags: Array<Tag>;
+  allContacts: Array<Contact>;
+  owner?: UserLight;
+};
+
+type CalendarEventDetails =
+  | {
+      kind: "schedule-event-in-day";
+      refId: string;
+      archived: boolean;
+      originalPath: string;
+      scheduleEventInDay: ScheduleEventInDay;
+      timeEventInDayBlock: TimeEventInDayBlock;
+      extras: ScheduleExtras;
+    }
+  | {
+      kind: "schedule-event-full-days";
+      refId: string;
+      archived: boolean;
+      originalPath: string;
+      scheduleEventFullDays: ScheduleEventFullDays;
+      timeEventFullDaysBlock: TimeEventFullDaysBlock;
+      extras: ScheduleExtras;
+    }
+  | {
+      kind: "time-event-in-day-block";
+      refId: string;
+      archived: boolean;
+      originalPath: string;
+      name: string;
+      inDayBlock: TimeEventInDayBlock;
+    }
+  | {
+      kind: "time-event-full-days-block";
+      refId: string;
+      archived: boolean;
+      originalPath: string;
+      name: string;
+      fullDaysBlock: TimeEventFullDaysBlock;
+      person?: Person;
+    };
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const { kind, refId } = parseParams(params, ParamsSchema);
+  const originalPath = calendarEventWorkspacePath(kind, refId);
+
+  try {
+    switch (kind) {
+      case "schedule-event-in-day": {
+        const [summaryResponse, response, allTags, allContacts] =
+          await Promise.all([
+            apiClient.application.getSummaries({
+              include_schedule_streams: true,
+            }),
+            apiClient.schedule.scheduleEventInDayLoad({
+              ref_id: refId,
+              allow_archived: true,
+            }),
+            apiClient.tags.tagFind({ allow_archived: false }),
+            apiClient.contacts.contactFind({ allow_archived: false }),
+          ]);
+        const summaryStreams =
+          (summaryResponse.schedule_streams as Array<ScheduleStreamSummary>) ??
+          [];
+        const allScheduleStreams = summaryStreams.some(
+          (stream) => stream.ref_id === response.schedule_stream.ref_id,
+        )
+          ? summaryStreams
+          : [...summaryStreams, response.schedule_stream];
+        return json({
+          kind,
+          refId,
+          archived: response.schedule_event_in_day.archived,
+          originalPath,
+          scheduleEventInDay: response.schedule_event_in_day,
+          timeEventInDayBlock: response.time_event_in_day_block,
+          extras: {
+            allScheduleStreams,
+            tags: response.tags as Array<Tag>,
+            contacts: response.contacts ?? [],
+            allTags: allTags.tags as Array<Tag>,
+            allContacts: allContacts.contacts as Array<Contact>,
+            owner: response.owner,
+          },
+        } satisfies CalendarEventDetails);
+      }
+
+      case "schedule-event-full-days": {
+        const [summaryResponse, response, allTags, allContacts] =
+          await Promise.all([
+            apiClient.application.getSummaries({
+              include_schedule_streams: true,
+            }),
+            apiClient.schedule.scheduleEventFullDaysLoad({
+              ref_id: refId,
+              allow_archived: true,
+            }),
+            apiClient.tags.tagFind({ allow_archived: false }),
+            apiClient.contacts.contactFind({ allow_archived: false }),
+          ]);
+        const summaryStreams =
+          (summaryResponse.schedule_streams as Array<ScheduleStreamSummary>) ??
+          [];
+        const allScheduleStreams = summaryStreams.some(
+          (stream) => stream.ref_id === response.schedule_stream.ref_id,
+        )
+          ? summaryStreams
+          : [...summaryStreams, response.schedule_stream];
+        return json({
+          kind,
+          refId,
+          archived: response.schedule_event_full_days.archived,
+          originalPath,
+          scheduleEventFullDays: response.schedule_event_full_days,
+          timeEventFullDaysBlock: response.time_event_full_days_block,
+          extras: {
+            allScheduleStreams,
+            tags: response.tags as Array<Tag>,
+            contacts: response.contacts ?? [],
+            allTags: allTags.tags as Array<Tag>,
+            allContacts: allContacts.contacts as Array<Contact>,
+            owner: response.owner,
+          },
+        } satisfies CalendarEventDetails);
+      }
+
+      case "time-event-in-day-block": {
+        const response = await apiClient.timeEvents.timeEventInDayBlockLoad({
+          ref_id: refId,
+          allow_archived: true,
+        });
+        const name =
+          response.schedule_event?.name ??
+          response.big_plan?.name ??
+          response.todo_task?.name ??
+          response.habit?.name ??
+          response.chore?.name ??
+          response.time_plan_activity?.name ??
+          response.in_day_block.name;
+        return json({
+          kind,
+          refId,
+          archived: response.in_day_block.archived,
+          originalPath,
+          name,
+          inDayBlock: response.in_day_block,
+        } satisfies CalendarEventDetails);
+      }
+
+      case "time-event-full-days-block": {
+        const response = await apiClient.timeEvents.timeEventFullDaysBlockLoad({
+          ref_id: refId,
+          allow_archived: true,
+        });
+        const ownerType = parseEntityLinkStd(response.full_days_block.owner)
+          .theType as NamedEntityTag;
+        let name = response.full_days_block.name;
+        if (
+          ownerType === NamedEntityTag.OCCASION &&
+          response.contact &&
+          response.occasion
+        ) {
+          name = occasionTimeEventName(
+            response.full_days_block,
+            response.contact,
+            response.occasion,
+          );
+        } else if (ownerType === NamedEntityTag.VACATION && response.vacation) {
+          name = response.vacation.name;
+        } else if (
+          ownerType === NamedEntityTag.SCHEDULE_EVENT_FULL_DAYS &&
+          response.schedule_event
+        ) {
+          name = response.schedule_event.name;
+        }
+        return json({
+          kind,
+          refId,
+          archived: response.full_days_block.archived,
+          originalPath,
+          name,
+          fullDaysBlock: response.full_days_block,
+          person: response.person ?? undefined,
+        } satisfies CalendarEventDetails);
+      }
+    }
+  } catch (error) {
+    handleLoaderApiError(error);
+  }
+}
+
+export const shouldRevalidate: ShouldRevalidateFunction = basicShouldRevalidate;
+
+export default function TimePlanCalendarEventDetails() {
+  const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const { id } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
+
+  return (
+    <LeafPanel
+      key={`time-plan-calendar-event-${loaderData.kind}-${loaderData.refId}`}
+      fakeKey={`time-plan-calendar-event-${loaderData.kind}-${loaderData.refId}`}
+      inputsEnabled={true}
+      entityArchived={loaderData.archived}
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
+      initialExpansionState={LeafPanelExpansionState.SMALL}
+    >
+      {loaderData.kind === "schedule-event-in-day" && (
+        <ScheduleEventInDayProperties
+          loaderData={loaderData}
+          timezone={topLevelInfo.user.timezone}
+        />
+      )}
+      {loaderData.kind === "schedule-event-full-days" && (
+        <ScheduleEventFullDaysProperties loaderData={loaderData} />
+      )}
+      {loaderData.kind === "time-event-in-day-block" && (
+        <TimeEventInDayProperties
+          name={loaderData.name}
+          inDayBlock={loaderData.inDayBlock}
+          timezone={topLevelInfo.user.timezone}
+        />
+      )}
+      {loaderData.kind === "time-event-full-days-block" && (
+        <TimeEventFullDaysProperties
+          name={loaderData.name}
+          fullDaysBlock={loaderData.fullDaysBlock}
+          person={loaderData.person}
+        />
+      )}
+
+      <Box>
+        <Button
+          type="button"
+          startIcon={<LaunchIcon />}
+          variant="outlined"
+          size="small"
+          component={Link}
+          to={loaderData.originalPath}
+        >
+          Open original
+        </Button>
+      </Box>
+    </LeafPanel>
+  );
+}
+
+function ScheduleEventInDayProperties({
+  loaderData,
+  timezone,
+}: {
+  loaderData: Extract<CalendarEventDetails, { kind: "schedule-event-in-day" }>;
+  timezone: Timezone;
+}) {
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const local = timeEventInDayBlockParamsToTimezone(
+    {
+      startDate: loaderData.timeEventInDayBlock.start_date,
+      startTimeInDay: loaderData.timeEventInDayBlock.start_time_in_day,
+    },
+    timezone,
+  );
+
+  return (
+    <ScheduleEventInDayEditor
+      scheduleEventInDay={loaderData.scheduleEventInDay}
+      timeEventInDayBlock={loaderData.timeEventInDayBlock}
+      allScheduleStreams={loaderData.extras.allScheduleStreams}
+      tags={loaderData.extras.tags}
+      contacts={loaderData.extras.contacts}
+      allTags={loaderData.extras.allTags}
+      allContacts={loaderData.extras.allContacts}
+      inputsEnabled={false}
+      corePropertyEditable={false}
+      topLevelInfo={topLevelInfo}
+      entityOwnerRefId={loaderData.extras.owner?.ref_id}
+      startDate={local.startDate!}
+      startTimeInDay={local.startTimeInDay!}
+      durationMins={loaderData.timeEventInDayBlock.duration_mins}
+      showActions={false}
+    />
+  );
+}
+
+function ScheduleEventFullDaysProperties({
+  loaderData,
+}: {
+  loaderData: Extract<
+    CalendarEventDetails,
+    { kind: "schedule-event-full-days" }
+  >;
+}) {
+  const topLevelInfo = useContext(TopLevelInfoContext);
+
+  return (
+    <ScheduleEventFullDaysEditor
+      scheduleEventFullDays={loaderData.scheduleEventFullDays}
+      timeEventFullDaysBlock={loaderData.timeEventFullDaysBlock}
+      allScheduleStreams={loaderData.extras.allScheduleStreams}
+      tags={loaderData.extras.tags}
+      contacts={loaderData.extras.contacts}
+      allTags={loaderData.extras.allTags}
+      allContacts={loaderData.extras.allContacts}
+      inputsEnabled={false}
+      corePropertyEditable={false}
+      topLevelInfo={topLevelInfo}
+      entityOwnerRefId={loaderData.extras.owner?.ref_id}
+      showActions={false}
+    />
+  );
+}
+
+function TimeEventInDayProperties({
+  name,
+  inDayBlock,
+  timezone,
+}: {
+  name: string;
+  inDayBlock: TimeEventInDayBlock;
+  timezone: Timezone;
+}) {
+  const local = timeEventInDayBlockParamsToTimezone(
+    {
+      startDate: inDayBlock.start_date,
+      startTimeInDay: inDayBlock.start_time_in_day,
+    },
+    timezone,
+  );
+  const durationMins = inDayBlock.duration_mins;
+
+  return (
+    <SectionCard id="time-plan-calendar-event-details" title="Properties">
+      <Box sx={{ display: "flex", flexDirection: "row", gap: "0.25rem" }}>
+        <FormControl fullWidth>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput
+            label="name"
+            name="name"
+            readOnly={true}
+            defaultValue={name}
+          />
+        </FormControl>
+        <TimeEventSourceLink timeEvent={inDayBlock} />
+      </Box>
+
+      <FormControl fullWidth>
+        <InputLabel id="startDate" shrink margin="dense">
+          Start Date
+        </InputLabel>
+        <OutlinedInput
+          type="date"
+          notched
+          label="startDate"
+          name="startDate"
+          readOnly={true}
+          disabled={true}
+          defaultValue={local.startDate}
+        />
+      </FormControl>
+
+      <FormControl fullWidth>
+        <InputLabel id="startTimeInDay" shrink margin="dense">
+          Start Time
+        </InputLabel>
+        <OutlinedInput
+          type="time"
+          label="startTimeInDay"
+          name="startTimeInDay"
+          readOnly={true}
+          defaultValue={local.startTimeInDay}
+        />
+      </FormControl>
+
+      <Stack spacing={2} direction="row">
+        <ButtonGroup variant="outlined" disabled>
+          <Button variant={durationMins === 15 ? "contained" : "outlined"}>
+            15m
+          </Button>
+          <Button variant={durationMins === 30 ? "contained" : "outlined"}>
+            30m
+          </Button>
+          <Button variant={durationMins === 60 ? "contained" : "outlined"}>
+            60m
+          </Button>
+        </ButtonGroup>
+
+        <FormControl fullWidth>
+          <InputLabel id="durationMins" shrink margin="dense">
+            Duration (Mins)
+          </InputLabel>
+          <OutlinedInput
+            type="number"
+            label="Duration (Mins)"
+            name="durationMins"
+            readOnly={true}
+            defaultValue={durationMins}
+          />
+        </FormControl>
+      </Stack>
+    </SectionCard>
+  );
+}
+
+function TimeEventFullDaysProperties({
+  name,
+  fullDaysBlock,
+  person,
+}: {
+  name: string;
+  fullDaysBlock: TimeEventFullDaysBlock;
+  person?: Person;
+}) {
+  const durationDays = fullDaysBlock.duration_days;
+
+  return (
+    <SectionCard id="time-plan-calendar-event-details" title="Properties">
+      <Box sx={{ display: "flex", flexDirection: "row", gap: "0.25rem" }}>
+        <FormControl fullWidth>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput
+            label="name"
+            name="name"
+            readOnly={true}
+            defaultValue={name}
+          />
+        </FormControl>
+        <TimeEventSourceLink
+          timeEvent={fullDaysBlock}
+          extraInfo={{ person }}
+        />
+      </Box>
+
+      <FormControl fullWidth>
+        <InputLabel id="startDate" shrink margin="dense">
+          Start Date
+        </InputLabel>
+        <OutlinedInput
+          type="date"
+          notched
+          label="startDate"
+          name="startDate"
+          readOnly={true}
+          disabled={true}
+          defaultValue={fullDaysBlock.start_date}
+        />
+      </FormControl>
+
+      <Stack spacing={2} direction="row">
+        <ButtonGroup variant="outlined" disabled>
+          <Button variant={durationDays === 1 ? "contained" : "outlined"}>
+            1D
+          </Button>
+          <Button variant={durationDays === 3 ? "contained" : "outlined"}>
+            3d
+          </Button>
+          <Button variant={durationDays === 7 ? "contained" : "outlined"}>
+            7d
+          </Button>
+        </ButtonGroup>
+
+        <FormControl fullWidth>
+          <InputLabel id="durationDays" shrink margin="dense">
+            Duration (Days)
+          </InputLabel>
+          <OutlinedInput
+            type="number"
+            label="Duration (Days)"
+            name="durationDays"
+            readOnly={true}
+            defaultValue={durationDays}
+          />
+        </FormControl>
+      </Stack>
+    </SectionCard>
+  );
+}
+
+export const ErrorBoundary = makeLeafErrorBoundary(
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
+  ParamsSchema,
+  {
+    notFound: (params) =>
+      `Could not find calendar event ${params.refId} in time plan ${params.id}!`,
+    error: (params) =>
+      `There was an error loading calendar event ${params.refId} in time plan ${params.id}! Please try again!`,
+  },
+);

--- a/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
@@ -28,7 +28,6 @@ import { useParams, useSearchParams } from "@remix-run/react";
 import { useContext } from "react";
 import { z } from "zod";
 import { parseParams } from "zodix";
-
 import { parseEntityLinkStd } from "@jupiter/core/common/entity-link";
 import { TimeEventSourceLink } from "@jupiter/core/common/sub/time_events/component/source-link";
 import {
@@ -39,7 +38,10 @@ import { calendarEventWorkspacePathFromTimePlan } from "@jupiter/core/calendar/c
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
-import { NavSingle, SectionActions } from "@jupiter/core/infra/component/section-actions";
+import {
+  NavSingle,
+  SectionActions,
+} from "@jupiter/core/infra/component/section-actions";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -547,10 +549,7 @@ function TimeEventFullDaysProperties({
             defaultValue={name}
           />
         </FormControl>
-        <TimeEventSourceLink
-          timeEvent={fullDaysBlock}
-          extraInfo={{ person }}
-        />
+        <TimeEventSourceLink timeEvent={fullDaysBlock} extraInfo={{ person }} />
       </Box>
 
       <FormControl fullWidth>

--- a/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/calendar-event/$kind/$refId.tsx
@@ -24,7 +24,7 @@ import {
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { Link, useParams, useSearchParams } from "@remix-run/react";
+import { useParams, useSearchParams } from "@remix-run/react";
 import { useContext } from "react";
 import { z } from "zod";
 import { parseParams } from "zodix";
@@ -35,15 +35,15 @@ import {
   occasionTimeEventName,
   timeEventInDayBlockParamsToTimezone,
 } from "@jupiter/core/common/sub/time_events/time-event";
-import {
-  calendarEventWorkspacePath,
-} from "@jupiter/core/calendar/component/calendar-navigation";
+import { calendarEventWorkspacePathFromTimePlan } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { NavSingle, SectionActions } from "@jupiter/core/infra/component/section-actions";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import type { TopLevelInfo } from "@jupiter/core/infra/top-level-context";
 import { handleLoaderApiError } from "@jupiter/core/infra/errors.server";
 import { ScheduleEventInDayEditor } from "@jupiter/core/schedule/sub/event_in_day/component/editor";
 import { ScheduleEventFullDaysEditor } from "@jupiter/core/schedule/sub/event_full_days/component/editor";
@@ -119,8 +119,8 @@ type CalendarEventDetails =
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const apiClient = await getLoggedInApiClient(request);
-  const { kind, refId } = parseParams(params, ParamsSchema);
-  const originalPath = calendarEventWorkspacePath(kind, refId);
+  const { id, kind, refId } = parseParams(params, ParamsSchema);
+  const originalPath = calendarEventWorkspacePathFromTimePlan(kind, refId, id);
 
   try {
     switch (kind) {
@@ -302,6 +302,7 @@ export default function TimePlanCalendarEventDetails() {
           name={loaderData.name}
           inDayBlock={loaderData.inDayBlock}
           timezone={topLevelInfo.user.timezone}
+          originalPath={loaderData.originalPath}
         />
       )}
       {loaderData.kind === "time-event-full-days-block" && (
@@ -309,22 +310,31 @@ export default function TimePlanCalendarEventDetails() {
           name={loaderData.name}
           fullDaysBlock={loaderData.fullDaysBlock}
           person={loaderData.person}
+          originalPath={loaderData.originalPath}
         />
       )}
-
-      <Box>
-        <Button
-          type="button"
-          startIcon={<LaunchIcon />}
-          variant="outlined"
-          size="small"
-          component={Link}
-          to={loaderData.originalPath}
-        >
-          Open original
-        </Button>
-      </Box>
     </LeafPanel>
+  );
+}
+
+function openOriginalActions(
+  id: string,
+  topLevelInfo: TopLevelInfo,
+  originalPath: string,
+) {
+  return (
+    <SectionActions
+      id={id}
+      topLevelInfo={topLevelInfo}
+      inputsEnabled={true}
+      actions={[
+        NavSingle({
+          text: "Open original",
+          icon: <LaunchIcon />,
+          link: originalPath,
+        }),
+      ]}
+    />
   );
 }
 
@@ -360,7 +370,11 @@ function ScheduleEventInDayProperties({
       startDate={local.startDate!}
       startTimeInDay={local.startTimeInDay!}
       durationMins={loaderData.timeEventInDayBlock.duration_mins}
-      showActions={false}
+      actions={openOriginalActions(
+        "schedule-event-in-day-properties",
+        topLevelInfo,
+        loaderData.originalPath,
+      )}
     />
   );
 }
@@ -388,7 +402,11 @@ function ScheduleEventFullDaysProperties({
       corePropertyEditable={false}
       topLevelInfo={topLevelInfo}
       entityOwnerRefId={loaderData.extras.owner?.ref_id}
-      showActions={false}
+      actions={openOriginalActions(
+        "schedule-event-full-days-properties",
+        topLevelInfo,
+        loaderData.originalPath,
+      )}
     />
   );
 }
@@ -397,11 +415,14 @@ function TimeEventInDayProperties({
   name,
   inDayBlock,
   timezone,
+  originalPath,
 }: {
   name: string;
   inDayBlock: TimeEventInDayBlock;
   timezone: Timezone;
+  originalPath: string;
 }) {
+  const topLevelInfo = useContext(TopLevelInfoContext);
   const local = timeEventInDayBlockParamsToTimezone(
     {
       startDate: inDayBlock.start_date,
@@ -412,7 +433,15 @@ function TimeEventInDayProperties({
   const durationMins = inDayBlock.duration_mins;
 
   return (
-    <SectionCard id="time-plan-calendar-event-details" title="Properties">
+    <SectionCard
+      id="time-plan-calendar-event-details"
+      title="Properties"
+      actions={openOriginalActions(
+        "time-plan-calendar-event-details",
+        topLevelInfo,
+        originalPath,
+      )}
+    >
       <Box sx={{ display: "flex", flexDirection: "row", gap: "0.25rem" }}>
         <FormControl fullWidth>
           <InputLabel id="name">Name</InputLabel>
@@ -488,15 +517,26 @@ function TimeEventFullDaysProperties({
   name,
   fullDaysBlock,
   person,
+  originalPath,
 }: {
   name: string;
   fullDaysBlock: TimeEventFullDaysBlock;
   person?: Person;
+  originalPath: string;
 }) {
+  const topLevelInfo = useContext(TopLevelInfoContext);
   const durationDays = fullDaysBlock.duration_days;
 
   return (
-    <SectionCard id="time-plan-calendar-event-details" title="Properties">
+    <SectionCard
+      id="time-plan-calendar-event-details"
+      title="Properties"
+      actions={openOriginalActions(
+        "time-plan-calendar-event-details",
+        topLevelInfo,
+        originalPath,
+      )}
+    >
       <Box sx={{ display: "flex", flexDirection: "row", gap: "0.25rem" }}>
         <FormControl fullWidth>
           <InputLabel id="name">Name</InputLabel>

--- a/src/webui/app/routes/app/workspace/time-plans/$id/new-activity-time-event.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/new-activity-time-event.tsx
@@ -1,0 +1,317 @@
+import {
+  Button,
+  ButtonGroup,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+} from "@mui/material";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
+import { DateTime } from "luxon";
+import { useContext, useEffect, useState } from "react";
+import { z } from "zod";
+import { parseForm, parseParams, parseQuery } from "zodix";
+import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
+import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
+import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
+import {
+  ActionSingle,
+  SectionActions,
+} from "@jupiter/core/infra/component/section-actions";
+import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
+import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
+import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
+import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import { timePlanActivityTargetNameForEvent } from "@jupiter/core/time_plans/sub/activity/root";
+import { handleActionApiError } from "@jupiter/core/infra/errors.server";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
+
+import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+const ParamsSchema = z.object({
+  id: z.string(),
+});
+
+const QuerySchema = z.object({
+  timePlanActivityRefId: z.string(),
+  date: z
+    .string()
+    .regex(/[0-9][0-9][0-9][0-9][-][0-9][0-9][-][0-9][0-9]/)
+    .optional(),
+});
+
+const CreateFormSchema = z.object({
+  userTimezone: z.string(),
+  startDate: z.string(),
+  startTimeInDay: z.string().optional(),
+  durationMins: z.string().transform((v) => parseInt(v, 10)),
+});
+
+export const handle = {
+  displayType: DisplayType.LEAF,
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const query = parseQuery(request, QuerySchema);
+
+  const activityResponse = await apiClient.timePlans.timePlanActivityLoad({
+    ref_id: query.timePlanActivityRefId,
+    allow_archived: true,
+  });
+
+  return json({
+    date: query.date,
+    timePlanActivity: activityResponse.time_plan_activity,
+    targetInboxTask: activityResponse.target_inbox_task,
+    targetBigPlan: activityResponse.target_big_plan,
+    targetTodoTask: activityResponse.target_todo_task,
+    targetHabit: activityResponse.target_habit,
+    targetChore: activityResponse.target_chore,
+  });
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const { id } = parseParams(params, ParamsSchema);
+  const query = parseQuery(request, QuerySchema);
+  const form = await parseForm(request, CreateFormSchema);
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+
+  try {
+    const { startDate, startTimeInDay } = timeEventInDayBlockParamsToUtc(
+      form,
+      form.userTimezone,
+    );
+
+    await apiClient.timeEvents.timeEventInDayBlockCreateForTimePlanActivity({
+      time_plan_activity_ref_id: query.timePlanActivityRefId,
+      start_date: startDate,
+      start_time_in_day: startTimeInDay ?? "",
+      duration_mins: form.durationMins,
+    });
+
+    return redirect(
+      withTimePlanView(
+        `/app/workspace/time-plans/${id}/${query.timePlanActivityRefId}`,
+        timePlanView,
+      ),
+    );
+  } catch (error) {
+    return handleActionApiError(error);
+  }
+}
+
+export const shouldRevalidate: ShouldRevalidateFunction =
+  standardShouldRevalidate;
+
+export default function TimePlanActivityTimeEventNew() {
+  const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const navigation = useNavigation();
+  const { id } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
+
+  const inputsEnabled =
+    navigation.state === "idle" && !loaderData.timePlanActivity.archived;
+
+  const rightNow = DateTime.local({ zone: topLevelInfo.user.timezone });
+
+  const [startDate, setStartDate] = useState(
+    loaderData.date ?? rightNow.toFormat("yyyy-MM-dd"),
+  );
+  const [startTimeInDay, setStartTimeInDay] = useState(
+    rightNow.toFormat("HH:mm"),
+  );
+  const [durationMins, setDurationMins] = useState(60);
+
+  useEffect(() => {
+    if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
+      setStartDate(query.get("sourceStartDate")!);
+      setStartTimeInDay(query.get("sourceStartTimeInDay")!);
+    }
+    if (query.get("sourceDurationMins")) {
+      setDurationMins(parseInt(query.get("sourceDurationMins")!, 10));
+    }
+  }, [query]);
+
+  return (
+    <LeafPanel
+      key="time-plan-activity-time-event/new"
+      fakeKey="time-plan-activity-time-event/new"
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
+      inputsEnabled={inputsEnabled}
+      initialExpansionState={LeafPanelExpansionState.SMALL}
+    >
+      <TimeEventParamsSource
+        startDate={startDate}
+        startTimeInDay={startTimeInDay}
+        durationMins={durationMins}
+      />
+      <GlobalError actionResult={actionData} />
+      <SectionCard
+        id="time-event-in-day-block-properties"
+        title="Properties"
+        actions={
+          <SectionActions
+            id="time-event-in-day-block-properties"
+            topLevelInfo={topLevelInfo}
+            inputsEnabled={inputsEnabled}
+            actions={[
+              ActionSingle({
+                text: "Create",
+                value: "create",
+                highlight: true,
+              }),
+            ]}
+          />
+        }
+      >
+        <input
+          type="hidden"
+          name="userTimezone"
+          value={topLevelInfo.user.timezone}
+        />
+
+        <FormControl fullWidth>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput
+            label="name"
+            name="name"
+            defaultValue={timePlanActivityTargetNameForEvent(
+              loaderData.targetInboxTask,
+              loaderData.targetBigPlan,
+              loaderData.timePlanActivity.ref_id,
+              loaderData.targetTodoTask,
+              loaderData.targetHabit,
+              loaderData.targetChore,
+            )}
+            readOnly={true}
+          />
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel id="startDate" shrink margin="dense">
+            Start Date
+          </InputLabel>
+          <OutlinedInput
+            type="date"
+            notched
+            label="startDate"
+            name="startDate"
+            readOnly={!inputsEnabled}
+            disabled={!inputsEnabled}
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+
+          <FieldError actionResult={actionData} fieldName="/start_date" />
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel id="startTimeInDay" shrink margin="dense">
+            Start Time
+          </InputLabel>
+          <OutlinedInput
+            type="time"
+            label="startTimeInDay"
+            name="startTimeInDay"
+            readOnly={!inputsEnabled}
+            value={startTimeInDay}
+            onChange={(e) => setStartTimeInDay(e.target.value)}
+          />
+
+          <FieldError
+            actionResult={actionData}
+            fieldName="/start_time_in_day"
+          />
+        </FormControl>
+
+        <Stack spacing={2} direction="row">
+          <ButtonGroup variant="outlined" disabled={!inputsEnabled}>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 15 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(15)}
+            >
+              15m
+            </Button>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 30 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(30)}
+            >
+              30m
+            </Button>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 60 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(60)}
+            >
+              60m
+            </Button>
+          </ButtonGroup>
+
+          <FormControl fullWidth>
+            <InputLabel id="durationMins" shrink margin="dense">
+              Duration (Mins)
+            </InputLabel>
+            <OutlinedInput
+              type="number"
+              label="Duration (Mins)"
+              name="durationMins"
+              readOnly={!inputsEnabled}
+              value={durationMins}
+              onChange={(e) => {
+                if (Number.isNaN(parseInt(e.target.value, 10))) {
+                  setDurationMins(0);
+                  e.preventDefault();
+                  return;
+                }
+
+                return setDurationMins(parseInt(e.target.value, 10));
+              }}
+            />
+
+            <FieldError actionResult={actionData} fieldName="/duration_mins" />
+          </FormControl>
+        </Stack>
+      </SectionCard>
+    </LeafPanel>
+  );
+}
+
+export const ErrorBoundary = makeLeafErrorBoundary(
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
+  ParamsSchema,
+  {
+    error: () =>
+      `There was an error creating the event in day! Please try again!`,
+  },
+);

--- a/src/webui/app/routes/app/workspace/time-plans/$id/new-schedule-event-in-day.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/$id/new-schedule-event-in-day.tsx
@@ -1,0 +1,319 @@
+import type { ScheduleStreamSummary } from "@jupiter/webapi-client";
+import {
+  Button,
+  ButtonGroup,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+} from "@mui/material";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+import {
+  useActionData,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "@remix-run/react";
+import { DateTime } from "luxon";
+import { useContext, useEffect, useState } from "react";
+import { z } from "zod";
+import { parseForm, parseParams, parseQuery } from "zodix";
+import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
+import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
+import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
+import {
+  ActionSingle,
+  SectionActions,
+} from "@jupiter/core/infra/component/section-actions";
+import {
+  ActionsPosition,
+  SectionCard,
+} from "@jupiter/core/infra/component/section-card";
+import { ScheduleStreamSelect } from "@jupiter/core/schedule/component/select";
+import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
+import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
+import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
+import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
+import { handleActionApiError } from "@jupiter/core/infra/errors.server";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
+
+import { standardShouldRevalidate } from "~/rendering/standard-should-revalidate";
+import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+const ParamsSchema = z.object({
+  id: z.string(),
+});
+
+const QuerySchema = z.object({
+  date: z
+    .string()
+    .regex(/[0-9][0-9][0-9][0-9][-][0-9][0-9][-][0-9][0-9]/)
+    .optional(),
+});
+
+const CreateFormSchema = z.object({
+  scheduleStreamRefId: z.string(),
+  userTimezone: z.string(),
+  name: z.string(),
+  startDate: z.string(),
+  startTimeInDay: z.string().optional(),
+  durationMins: z.string().transform((v) => parseInt(v, 10)),
+});
+
+export const handle = {
+  displayType: DisplayType.LEAF,
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const query = parseQuery(request, QuerySchema);
+
+  const summaryResponse = await apiClient.application.getSummaries({
+    include_schedule_streams: true,
+  });
+
+  return json({
+    date: query.date,
+    allScheduleStreams:
+      summaryResponse.schedule_streams as Array<ScheduleStreamSummary>,
+  });
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const { id } = parseParams(params, ParamsSchema);
+  const form = await parseForm(request, CreateFormSchema);
+  const timePlanView = new URL(request.url).searchParams.get(
+    TIME_PLAN_VIEW_PARAM,
+  );
+
+  try {
+    const { startDate, startTimeInDay } = timeEventInDayBlockParamsToUtc(
+      form,
+      form.userTimezone,
+    );
+    const response = await apiClient.schedule.scheduleEventInDayCreate({
+      schedule_stream_ref_id: form.scheduleStreamRefId,
+      name: form.name,
+      start_date: startDate,
+      start_time_in_day: startTimeInDay ?? "",
+      duration_mins: form.durationMins,
+    });
+
+    return redirect(
+      withTimePlanView(
+        `/app/workspace/time-plans/${id}/calendar-event/schedule-event-in-day/${response.new_schedule_event_in_day.ref_id}`,
+        timePlanView,
+      ),
+    );
+  } catch (error) {
+    return handleActionApiError(error);
+  }
+}
+
+export const shouldRevalidate: ShouldRevalidateFunction =
+  standardShouldRevalidate;
+
+export default function TimePlanScheduleEventInDayNew() {
+  const loaderData = useLoaderDataSafeForAnimation<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const topLevelInfo = useContext(TopLevelInfoContext);
+  const navigation = useNavigation();
+  const { id } = useParams();
+  const [query] = useSearchParams();
+  const timePlanView = query.get(TIME_PLAN_VIEW_PARAM);
+
+  const inputsEnabled = navigation.state === "idle";
+
+  const rightNow = DateTime.local({ zone: topLevelInfo.user.timezone });
+
+  const [startDate, setStartDate] = useState(
+    loaderData.date ?? rightNow.toFormat("yyyy-MM-dd"),
+  );
+  const [startTimeInDay, setStartTimeInDay] = useState(
+    rightNow.toFormat("HH:mm"),
+  );
+  const [durationMins, setDurationMins] = useState(30);
+
+  useEffect(() => {
+    if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
+      setStartDate(query.get("sourceStartDate")!);
+      setStartTimeInDay(query.get("sourceStartTimeInDay")!);
+    }
+    if (query.get("sourceDurationMins")) {
+      setDurationMins(parseInt(query.get("sourceDurationMins")!, 10));
+    }
+  }, [query]);
+
+  return (
+    <LeafPanel
+      key="time-plan-schedule-event-in-day/new"
+      fakeKey="time-plan-schedule-event-in-day/new"
+      returnLocation={withTimePlanView(
+        `/app/workspace/time-plans/${id}`,
+        timePlanView,
+      )}
+      inputsEnabled={inputsEnabled}
+      initialExpansionState={LeafPanelExpansionState.SMALL}
+    >
+      <TimeEventParamsSource
+        startDate={startDate}
+        startTimeInDay={startTimeInDay}
+        durationMins={durationMins}
+      />
+      <GlobalError actionResult={actionData} />
+      <SectionCard
+        id="schedule-event-in-day-properties"
+        title="Properties"
+        actionsPosition={ActionsPosition.BELOW}
+        actions={
+          <SectionActions
+            id="schedule-event-in-day-properties"
+            topLevelInfo={topLevelInfo}
+            inputsEnabled={inputsEnabled}
+            actions={[
+              ActionSingle({
+                text: "Create",
+                value: "create",
+                highlight: true,
+              }),
+            ]}
+          />
+        }
+      >
+        <input
+          type="hidden"
+          name="userTimezone"
+          value={topLevelInfo.user.timezone}
+        />
+        <FormControl fullWidth>
+          <InputLabel id="scheduleStreamRefId">Schedule Stream</InputLabel>
+          <ScheduleStreamSelect
+            labelId="scheduleStreamRefId"
+            label="Schedule Stream"
+            name="scheduleStreamRefId"
+            readOnly={!inputsEnabled}
+            allScheduleStreams={loaderData.allScheduleStreams}
+            defaultValue={loaderData.allScheduleStreams[0]}
+          />
+          <FieldError
+            actionResult={actionData}
+            fieldName="/schedule_stream_ref_id"
+          />
+        </FormControl>
+        <FormControl fullWidth>
+          <InputLabel id="name">Name</InputLabel>
+          <OutlinedInput label="name" name="name" readOnly={!inputsEnabled} />
+          <FieldError actionResult={actionData} fieldName="/name" />
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel id="startDate" shrink margin="dense">
+            Start Date
+          </InputLabel>
+          <OutlinedInput
+            type="date"
+            notched
+            label="startDate"
+            name="startDate"
+            readOnly={!inputsEnabled}
+            disabled={!inputsEnabled}
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+
+          <FieldError actionResult={actionData} fieldName="/start_date" />
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel id="startTimeInDay" shrink margin="dense">
+            Start Time
+          </InputLabel>
+          <OutlinedInput
+            type="time"
+            label="startTimeInDay"
+            name="startTimeInDay"
+            readOnly={!inputsEnabled}
+            value={startTimeInDay}
+            onChange={(e) => setStartTimeInDay(e.target.value)}
+          />
+
+          <FieldError
+            actionResult={actionData}
+            fieldName="/start_time_in_day"
+          />
+        </FormControl>
+
+        <Stack spacing={2} direction="row">
+          <ButtonGroup variant="outlined" disabled={!inputsEnabled}>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 15 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(15)}
+            >
+              15m
+            </Button>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 30 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(30)}
+            >
+              30m
+            </Button>
+            <Button
+              disabled={!inputsEnabled}
+              variant={durationMins === 60 ? "contained" : "outlined"}
+              onClick={() => setDurationMins(60)}
+            >
+              60m
+            </Button>
+          </ButtonGroup>
+
+          <FormControl fullWidth>
+            <InputLabel id="durationMins" shrink margin="dense">
+              Duration (Mins)
+            </InputLabel>
+            <OutlinedInput
+              type="number"
+              label="Duration (Mins)"
+              name="durationMins"
+              readOnly={!inputsEnabled}
+              value={durationMins}
+              onChange={(e) => {
+                if (Number.isNaN(parseInt(e.target.value, 10))) {
+                  setDurationMins(0);
+                  e.preventDefault();
+                  return;
+                }
+
+                return setDurationMins(parseInt(e.target.value, 10));
+              }}
+            />
+
+            <FieldError actionResult={actionData} fieldName="/duration_mins" />
+          </FormControl>
+        </Stack>
+      </SectionCard>
+    </LeafPanel>
+  );
+}
+
+export const ErrorBoundary = makeLeafErrorBoundary(
+  (params, searchParams) =>
+    withTimePlanView(
+      `/app/workspace/time-plans/${params.id}`,
+      searchParams.get(TIME_PLAN_VIEW_PARAM),
+    ),
+  ParamsSchema,
+  {
+    error: () =>
+      `There was an error creating the event in day! Please try again!`,
+  },
+);

--- a/src/webui/app/routes/app/workspace/time-plans/place-activity-time-event.tsx
+++ b/src/webui/app/routes/app/workspace/time-plans/place-activity-time-event.tsx
@@ -1,0 +1,42 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { z } from "zod";
+import { parseForm } from "zodix";
+import { noErrorNoData } from "@jupiter/core/infra/action-result";
+import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import { handleActionApiError } from "@jupiter/core/infra/errors.server";
+
+import { getLoggedInApiClient } from "~/api-clients.server";
+
+// Creates a time event for a time plan activity at the moment it was dropped
+// on the calendar.
+const PlaceFormSchema = z.object({
+  timePlanActivityRefId: z.string(),
+  startDate: z.string(),
+  startTimeInDay: z.string(),
+  durationMins: z.string().transform((v) => parseInt(v, 10)),
+  userTimezone: z.string(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const apiClient = await getLoggedInApiClient(request);
+  const form = await parseForm(request, PlaceFormSchema);
+
+  const { startDate, startTimeInDay } = timeEventInDayBlockParamsToUtc(
+    { startDate: form.startDate, startTimeInDay: form.startTimeInDay },
+    form.userTimezone,
+  );
+
+  try {
+    await apiClient.timeEvents.timeEventInDayBlockCreateForTimePlanActivity({
+      time_plan_activity_ref_id: form.timePlanActivityRefId,
+      start_date: startDate,
+      start_time_in_day: startTimeInDay ?? "",
+      duration_mins: form.durationMins,
+    });
+
+    return json(noErrorNoData());
+  } catch (error) {
+    return handleActionApiError(error);
+  }
+}

--- a/src/webui/app/routes/app/workspace/todos/new.tsx
+++ b/src/webui/app/routes/app/workspace/todos/new.tsx
@@ -31,6 +31,10 @@ import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import { DifficultySelect } from "@jupiter/core/common/component/difficulty-select";
 import { EisenhowerSelect } from "@jupiter/core/common/component/eisenhower-select";
 import { IsKeySelect } from "@jupiter/core/common/component/is-key-select";
+import {
+  TIME_PLAN_VIEW_PARAM,
+  withTimePlanView,
+} from "@jupiter/core/time_plans/view-mode";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -175,7 +179,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
       case "for-time-plan":
         return redirect(
-          `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+          withTimePlanView(
+            `/app/workspace/time-plans/${result.new_time_plan_activity?.time_plan_ref_id}/${result.new_time_plan_activity?.ref_id}`,
+            new URL(request.url).searchParams.get(TIME_PLAN_VIEW_PARAM),
+          ),
         );
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR adds a new calendar view to time plans, allowing users to visualize their planned activities alongside a calendar interface for daily and weekly time periods. The calendar view displays activities in a sidebar next to the calendar, enabling better visual planning and scheduling.

## Key Changes

- **New Calendar View Mode**: Added `CALENDAR` to the `ViewMode` enum in the time plan view, with a calendar icon button in the view selector
- **Calendar View Component**: Created `TimePlanCalendarActivities` component that displays activities alongside a calendar interface, with responsive layout (side-by-side on large screens, stacked on mobile)
- **Period Restrictions**: Implemented `timePlanAllowsCalendarView()` function to restrict calendar view to daily and weekly time periods only (monthly/quarterly/yearly periods show stats instead)
- **Refactored List Activities**: Extracted list view rendering logic into a reusable `activitiesAsList` variable to avoid duplication when displaying activities in both list and calendar views
- **Calendar Navigation**: Enhanced `CalendarNavigationValue` interface with `newInDayEventPath()` method and added `timePlanCalendarNavigation()` function to handle navigation within time plan calendar context
- **Return Location Handling**: Created `calendarLeafReturnLocation()` utility to properly route event panel closures back to either the time plan or calendar based on context
- **Data Structure Updates**: Refactored loader data to use `calendarEntries`, `calendarPeriodStartDate`, and `calendarPeriodEndDate` instead of separate `timeEventForInboxTasks` and `timeEventForBigPlans`
- **Calendar Event Panels**: Updated all calendar event panel routes (event-in-day, event-full-days, time-event blocks) to use `calendarLeafReturnLocation()` for proper navigation back to the originating view
- **Responsive Layout**: Calendar view uses sticky positioning for activities sidebar on large screens and respects the `fillWidth` prop for proper day column sizing

## Notable Implementation Details

- The calendar view reuses the same activity filtering and grouping logic as the list view, ensuring consistency
- Calendar entries are only loaded when needed (daily/weekly periods)
- The "right now" indicator on the calendar updates every 5 minutes to keep the current time visible
- Event panels opened from the time plan calendar view include a `timePlanRefId` query parameter to return to the correct location when closed
- The calendar view is gated behind the `SCHEDULE` workspace feature flag

https://claude.ai/code/session_01PpfjSmjncVjfN2Jh91QM8b