### PR TITLE
Document standard questions for journals and time plans

### DIFF
--- a/src/docs/material/concepts/journals.md
+++ b/src/docs/material/concepts/journals.md
@@ -47,3 +47,46 @@ Journals are mainly a written artifact, so they're essentially one big
 document.But they do have a recording ot the work activitythat happened during
 that period (scores achieved, tasks done, etc),much like in the [report
 functionality](reporting.md).
+
+## Standard Questions
+
+Journaling goes easier when you don't have to invent the prompts every time. You
+can set up a list of _standard questions_ - "What went well this week?", "What
+did I learn?", and so on - and Thrive will use them to lay out the document of
+each new journal.
+
+Questions live in the "questions" view of the journals app. Each one has:
+
+* A _name_, which is the question itself, as it'll show up in the journal.
+* A _period_, which decides which journals it applies to. A weekly question
+  appears in weekly journals only.
+
+Questions are grouped by period, and within a period they have an order you
+control with the up and down arrows next to each one. That's the order they
+appear in the journal.
+
+The name of a question can be changed at any time. The period can't - make a
+question for the other period instead.
+
+### How Questions Reach A Journal
+
+When a journal is created, the questions for its period are used to build the
+journal's [note](core-entities/notes.md). Each question becomes a heading, with
+an empty paragraph under it for you to write in.
+
+When you create a journal yourself, the new journal form lists the questions for
+the period you picked, with all of them selected. Unselect the ones you don't
+need this time around, or unselect all of them to start from an empty document.
+Switching the period swaps the list for that period's questions.
+
+Journals created by the [task gen mechanism](tasks-generation.md) get all the
+questions of their period.
+
+The questions are copied into the journal's document at the moment the journal
+is created. Editing, reordering, archiving, or removing a question afterwards
+leaves the journals you already have alone - it only affects the ones created
+from that point on.
+
+Archiving a question keeps it around, but drops it from the ordering and from
+new journals. Removing it gets rid of it for good. The general rules are in
+[archival and removal](archival-and-removal.md).

--- a/src/docs/material/concepts/time-plans.md
+++ b/src/docs/material/concepts/time-plans.md
@@ -84,3 +84,47 @@ looking at the whole thing.
 * Big plans of a _make progress kind_ are considered done if all the inbox tasks
   associated with it in the time plan are considered done, or if there are no
   such tasks if there is some modification done during the time plan's period.
+
+## Standard Questions
+
+Planning goes easier when you don't have to invent the prompts every time. You
+can set up a list of _standard questions_ - "What must get done this week?",
+"What could get in the way?", and so on - and Thrive will use them to lay out
+the document of each new time plan.
+
+Questions live in the "questions" view of the time plans app. Each one has:
+
+* A _name_, which is the question itself, as it'll show up in the plan.
+* A _period_, which decides which plans it applies to. A weekly question appears
+  in weekly plans only.
+
+Questions are grouped by period, and within a period they have an order you
+control with the up and down arrows next to each one. That's the order they
+appear in the plan.
+
+The name of a question can be changed at any time. The period can't - make a
+question for the other period instead.
+
+### How Questions Reach A Time Plan
+
+When a time plan is created, the questions for its period are used to build the
+plan's [note](core-entities/notes.md) - the written document attached to it, not
+its activities. Each question becomes a heading, with an empty paragraph under
+it for you to write in.
+
+When you create a time plan yourself, the new time plan form lists the questions
+for the period you picked, with all of them selected. Unselect the ones you
+don't need this time around, or unselect all of them to start from an empty
+document. Switching the period swaps the list for that period's questions.
+
+Time plans created by the [task gen mechanism](tasks-generation.md) get all the
+questions of their period.
+
+The questions are copied into the plan's document at the moment the plan is
+created. Editing, reordering, archiving, or removing a question afterwards
+leaves the plans you already have alone - it only affects the ones created from
+that point on.
+
+Archiving a question keeps it around, but drops it from the ordering and from
+new plans. Removing it gets rid of it for good. The general rules are in
+[archival and removal](archival-and-removal.md).


### PR DESCRIPTION
Add a "Standard Questions" section to the journals and time plans concept
docs, covering what a question is (name plus period), where they're managed
and reordered, how they're used to lay out the document of a new journal or
plan, the per-creation selection on the new forms, what task gen does, and
that questions are copied in at creation so later edits don't touch existing
entries.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B6yj8cZUeYrjcva1ePSdnq