### PR TITLE
Add a clear-query button to the search widget

### DIFF
--- a/src/core/jupiter/core/common/search/components/search-widget.tsx
+++ b/src/core/jupiter/core/common/search/components/search-widget.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@jupiter/webapi-client";
 import { AppShell } from "@jupiter/webapi-client";
 import {
+  Backspace as BackspaceIcon,
   Close as CloseIcon,
   Search as SearchIcon,
   Tune as TuneIcon,
@@ -166,6 +167,12 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
     setSearchOffset(0);
   };
 
+  const handleClearQuery = () => {
+    setSearchOffset(0);
+    setSearchQuery("");
+    searchInputRef.current?.focus();
+  };
+
   const inputsEnabled = searchFetcher.state === "idle";
 
   const instantAction = searchFetcher.data as
@@ -267,6 +274,14 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
                   ),
                 }}
               />
+              <IconButton
+                id="instant-search-clear-query"
+                aria-label="Clear search query"
+                disabled={searchQuery === ""}
+                onClick={handleClearQuery}
+              >
+                <BackspaceIcon />
+              </IconButton>
               <IconButton
                 id="instant-search-close"
                 aria-label="Close search"
@@ -390,6 +405,14 @@ export function SearchWidget({ allTags, allContacts }: SearchWidgetProps) {
                 onClick={() => setFiltersOpen((s) => !s)}
               >
                 <TuneIcon />
+              </IconButton>
+              <IconButton
+                id="instant-search-clear-query"
+                aria-label="Clear search query"
+                disabled={searchQuery === ""}
+                onClick={handleClearQuery}
+              >
+                <BackspaceIcon />
               </IconButton>
               <IconButton
                 id="instant-search-close"


### PR DESCRIPTION
The instant search dialog only had a button to dismiss the whole search page. This adds a small icon button next to it that clears just the current query.

## Changes

All in `src/core/jupiter/core/common/search/components/search-widget.tsx`:

- A `handleClearQuery` handler that resets the query, resets the result offset to 0, and refocuses the query input.
- An `IconButton` (Backspace icon, `aria-label="Clear search query"`) placed immediately before the existing close button in **both** toolbar variants — the mobile row and the desktop row. It is disabled while the query is empty.

Two design choices worth flagging:

- The Backspace glyph is used rather than an X, so the new button does not read as a second close button sitting right next to the real one.
- It clears only the query — tag, contact, and date filters are left alone.

Clearing the query flows through the existing debounced fetch, so the results list empties on its own with no extra wiring.

## Testing

- Prettier (repo's pinned 3.5.3 and config) passes on the changed file.
- TypeScript over `src/core`'s tsconfig reports no errors in the changed file beyond pre-existing unresolved-workspace-package errors caused by an incomplete dependency install in the dev environment.

Note: the full `mise run lint` (tsc + eslint per package) could not be run here. `pnpm install` fails partway because `@electron/node-gyp` resolves to a `codeload.github.com` tarball that this environment's egress policy blocks, so the typecheck above ran against a partially populated `node_modules` using a newer global tsc (6.0.2 vs. the pinned 5.8.2). ESLint in particular is unverified — CI is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDfxg2T1uoppUDDuJ4LbqU)_