### PR TITLE
Improve mobile layout for section cards with tight padding

### DIFF
--- a/src/core/jupiter/core/apps/time_plans/sub/activity/component/card.tsx
+++ b/src/core/jupiter/core/apps/time_plans/sub/activity/component/card.tsx
@@ -151,12 +151,13 @@ export function TimePlanActivityCard(props: TimePlanActivityCardProps) {
               }
             : !isBigScreen
               ? {
-                  // A tenth of the 16px the link normally uses on each side,
-                  // so the name gets the width back on a phone. The vertical
-                  // padding stays put and keeps the name clear of the corner
-                  // chip.
-                  paddingLeft: "1.6px",
-                  paddingRight: "1.6px",
+                  // A fifth of the 16px the link normally uses on each side:
+                  // enough that the name is not flush against the card edge,
+                  // with the width it gives up taken from the section around
+                  // the card instead. The vertical padding stays put and keeps
+                  // the name clear of the corner chip.
+                  paddingLeft: "3.2px",
+                  paddingRight: "3.2px",
                 }
               : {}),
         },

--- a/src/core/jupiter/core/infra/component/section-card.tsx
+++ b/src/core/jupiter/core/infra/component/section-card.tsx
@@ -10,6 +10,12 @@ import { Form } from "@remix-run/react";
 import type { PropsWithChildren } from "react";
 
 import { CARD_INNER_CORNER_RADIUS } from "#/core/infra/component/theme";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
+
+// What the section keeps between its own border and the cards inside it on a
+// phone - just enough to read as a gap, with the rest of the width going to
+// the cards.
+const SMALL_SCREEN_TIGHT_PADDING = "4px";
 
 export enum ActionsPosition {
   ABOVE,
@@ -22,10 +28,16 @@ interface SectionCardProps {
   actions?: JSX.Element;
   actionsPosition?: ActionsPosition;
   method?: "get" | "post";
+  // For sections that are a list of cards: on a phone the section's own
+  // padding is width those cards could be using, so it drops to almost
+  // nothing there.
+  tightContentOnSmallScreen?: boolean;
 }
 
 export function SectionCard(props: PropsWithChildren<SectionCardProps>) {
+  const isBigScreen = useBigScreen();
   const actionsPosition = props.actionsPosition ?? ActionsPosition.ABOVE;
+  const tightContent = props.tightContentOnSmallScreen === true && !isBigScreen;
 
   return (
     <StyledCard id={props.id}>
@@ -36,7 +48,18 @@ export function SectionCard(props: PropsWithChildren<SectionCardProps>) {
           </SectionHeaderContent>
           {actionsPosition === ActionsPosition.ABOVE && props.actions}
         </SectionHeader>
-        <CardContent>
+        <CardContent
+          sx={
+            tightContent
+              ? {
+                  padding: SMALL_SCREEN_TIGHT_PADDING,
+                  "&:last-child": {
+                    paddingBottom: SMALL_SCREEN_TIGHT_PADDING,
+                  },
+                }
+              : undefined
+          }
+        >
           <Stack spacing={2}>{props.children}</Stack>
         </CardContent>
         {actionsPosition === ActionsPosition.BELOW && (

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id.tsx
@@ -887,6 +887,7 @@ export default function TimePlanView() {
         <SectionCard
           id="time-plan-activities"
           title="Activities"
+          tightContentOnSmallScreen
           actions={
             <SectionActions
               id="activities"


### PR DESCRIPTION
## Summary
This PR improves the mobile layout for section cards that contain lists of cards by reducing unnecessary padding on small screens, allowing more width for the card content itself.

## Key Changes
- Added `useBigScreen` hook to `SectionCard` component to detect screen size
- Introduced new `tightContentOnSmallScreen` prop to `SectionCard` that reduces padding on mobile devices from normal spacing to 4px
- Applied conditional styling to `CardContent` that uses `SMALL_SCREEN_TIGHT_PADDING` when the prop is enabled and screen is small
- Updated `TimePlanActivityCard` padding values from 1.6px to 3.2px (a fifth instead of a tenth of normal 16px padding) to better balance spacing while giving up width to the section's reduced padding
- Enabled `tightContentOnSmallScreen` on the Activities section in the time plan view

## Implementation Details
- The tight padding is only applied on small screens (phones), preserving normal spacing on larger screens
- The padding reduction uses a constant `SMALL_SCREEN_TIGHT_PADDING = "4px"` to maintain consistency
- The change is opt-in via the `tightContentOnSmallScreen` prop, allowing selective application to sections that benefit from it
- Padding adjustments in the activity card were increased slightly to prevent content from appearing flush against edges while still reclaiming width for the cards

https://claude.ai/code/session_018WSaXqGrEwc2hTg5Zn9EGB