### PR TITLE
Add ADR 0012 on undo/redo sessions and groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Current topics include (non-exhaustive; browse the directory):
 | 0009 | Search index method version |
 | 0010 | Entity publish mechanism (public sharing) |
 | 0011 | Access control and authenticated sharing |
+| 0012 | Undo/redo sessions and groups (proposed) |
 
 ## Generating code
 

--- a/docs/adrs/0012.undo-redo-sessions-and-groups.md
+++ b/docs/adrs/0012.undo-redo-sessions-and-groups.md
@@ -1,0 +1,481 @@
+# ADR 0012: Undo and redo — sessions, groups, and mutation reversal
+
+## Status
+
+Proposed (2026-08-28)
+
+**Nothing in this ADR is implemented yet.** It records the design reached while
+exploring undo/redo so the reasoning survives until the work is built. Sections
+marked *(exists)* describe code that is already in the tree and that the design
+leans on; everything else is proposed.
+
+## Context
+
+[ADR 0005](0005.recording-events.md) introduced `mutation_entity_event` and
+`mutation_invocation_record`, and named undo/redo as one of the things they
+should eventually power. The tables carry enough metadata to reconstruct *what*
+happened, but nothing above `trace_id` — so there is no way to express "the
+thing the user thinks of as one action."
+
+### Recording levels today *(exists)*
+
+```
+trace      ← one top-level action, per request      (config.py, TraceId.new())
+ └─ mutation  ← one use case invocation
+     └─ event    ← one change to one entity
+```
+
+`event_source` records which app produced the mutation; `context_str` records
+the acting user (`user:{id}+workspace:{id}`).
+
+### The problem this has to solve
+
+Undo/redo is blocked less by storage than by **granularity**, and note editing
+makes that concrete.
+
+`EntityNoteEditor` has no debounce: every EditorJS `onChange` submits the
+**entire document** (`infra/component/entity-note-editor.tsx:41-69`), and while
+a request is in flight exactly one more is queued. Each such request writes the
+whole document three times over —
+
+| Write | Where |
+| ----- | ----- |
+| `note.content` JSONB | `storage/postgres/repository.py:181` |
+| `mutation_entity_event.data` | `entity.py:446-465` captures the update's frame args; `storage/postgres/events.py:67-99` persists them |
+| `mutation_invocation_record.args` | `use_case.py:287` encodes the whole `NoteUpdateArgs` |
+
+— plus a `search_mutation_log_record` row (`config.py:570-591`) that later
+drives a full re-index. `NoteUpdateArgs.content` is
+`UpdateAction[list[OneOfNoteContentBlock]]`, so "the args" *are* the document.
+
+The consequences that matter for undo:
+
+- **One event per keystroke means one undo step per keystroke.** Unusable, and
+  not fixable at read time — folding thousands of full-document blobs per undo
+  is not a query anyone wants to run.
+- **The history read path is unbounded.**
+  `find_all_entity_events_by_timestamp_desc` takes no limit, and
+  `GetEntityMutationHistoryUseCase` fans out to every linked support entity,
+  sorts in Python, and `json.dumps(..., indent=2)` every row.
+- **Writes are last-write-wins.** `save()` issues
+  `UPDATE ... WHERE ref_id = ?` with no version check
+  (`storage/postgres/repository.py:181-207`). Combined with whole-document
+  payloads, a stale tab that types one character reverts everything anyone else
+  did in the meantime. This is a present data-loss bug in shared docs,
+  independent of undo.
+
+## Decision
+
+### 1. Two new levels above trace
+
+```
+session   ← one client instance                    (new)
+ └─ group    ← one undo step                       (new)
+     └─ trace       ← one request                  (exists)
+         └─ mutation   ← one use case invocation   (exists)
+             └─ event     ← one entity change      (exists)
+```
+
+Both are **client-generated ids that the server records**. No session entity, no
+server-side lifecycle, no cleanup job.
+
+They are carried as request headers and placed on `DomainContext` alongside
+`trace_id` (`framework/context.py`), so every recorded mutation picks them up
+without touching a single use-case args class. The pattern already exists for
+trace id (`webapi/config.py:485-490`):
+
+```python
+def _extract_trace_id(request: Request) -> TraceId:
+    trace_id_header = request.headers.get(TRACE_ID_HEADER)
+    if trace_id_header is None:
+        return TraceId.new()
+    return _TRACE_ID_DECODER.decode(trace_id_header)
+```
+
+`_extract_session_id` / `_extract_group_id` follow it directly. The API gateway
+already forwards `X-Jupiter-Trace-Id` downstream (`api/config.py:151`), so
+multi-hop propagation needs no new mechanism.
+
+**Storage**: columns on `mutation_invocation_record`, indexed on
+`(context_str, session_id, timestamp desc)`. Deliberately *not* on
+`mutation_entity_event` — that is the high-volume table, and it joins on
+`mutation_id`.
+
+**Session boundary**: `sessionStorage`, not application startup. A web app has
+no crisp "startup" (soft nav, hard reload, bfcache restore, a PWA killed by the
+OS), and reload is frequently involuntary — losing the undo stack because of a
+deploy is a bad surprise. `sessionStorage` is per-tab, survives reload, dies
+with the tab, and is already the established pattern here
+(`infra/component/use-idempotency.ts`).
+
+### 2. Group, precisely
+
+> A **group** is the maximal contiguous run of mutations, within one session,
+> that share a single edit intent and must be undone or redone as one unit.
+
+Identity is `(session_id, group_id)`. The id is minted **at input time**, not at
+save time: the group is a property of the edit; a save carries whichever group
+is open.
+
+**Admission.** A mutation joins the open group iff all of:
+
+1. same session;
+2. same **focus key**;
+3. the operation is *continuous*, not self-sealing;
+4. time since the last **input** in the group < `T_idle`;
+5. the group has not hit its cap.
+
+Otherwise the open group is sealed and a new one opened.
+
+**Focus key** is `(entity_type, entity_ref_id, locus)`, where locus is the block
+`correlation_id` for note/doc bodies, the field name for form-driven entities,
+and ⊥ (whole entity) otherwise. This rule does most of the work: editing
+paragraph 3 and then paragraph 7 is two groups regardless of timing.
+
+**Self-sealing operations** open and close immediately and never coalesce:
+block add/remove/move, paste, block-type conversion, table row/column
+add/remove, checklist toggle, archive, complete. Membership test: *its inverse
+is structural rather than "restore the prior text."*
+
+**Sealing conditions**, first to fire:
+
+- the focus key changes;
+- idle > `T_idle`, **measured from the last input event, not the last save** —
+  saves are debounced, so request gaps are the wrong clock;
+- a self-sealing operation arrives;
+- explicit departure: blur, navigation, tab hidden, editor unmount;
+- a **foreign write** to the same focus key (see §6);
+- cap exceeded: > `N` mutations or > `T_max` wall clock;
+- the user invokes undo — seal before acting.
+
+**Invariants.**
+
+- **G1** — A group never spans sessions.
+- **G2** — Every mutation belongs to exactly one group. Where no client supplies
+  one, `group_id := trace_id`. No nulls; the degenerate case is a group of one.
+- **G3** — **Sealing implies flushing; flushing does not imply sealing.** The
+  sealing conditions must be a subset of the flush conditions, or a single
+  request straddles a boundary and carries two groups' worth of change, which
+  cannot be split afterwards. The debounce flush and the max-wait checkpoint are
+  flushes that deliberately do *not* seal.
+- **G4** — A group is atomic under undo. No state interior to a group is ever
+  presented to the user.
+- **G5** — Group id is stable under retry.
+
+**Two tests** for whether a boundary is in the right place:
+
+- *Atomicity* — if you can describe a halfway state the user would be content to
+  land in, it is two groups.
+- *Recognizability* — after undoing, is the resulting state one the user
+  actually saw on screen? Debounce checkpoints fail this test, which is why they
+  cannot be boundaries, and why the group concept has to exist at all.
+
+The group is also the row unit of the history view. If the history reads as
+"edited paragraph 3", the grouping is right; if one sentence produces forty
+rows, it is not.
+
+**Starting parameters**: `T_idle` ≈ 1.5–2s, `T_max` ≈ 60s, `N` ≈ 50, against a
+~600ms debounce. Do not over-tune; for documents the focus-key rule dominates
+and the timer is a backstop. The caps exist for held keys and scripted input,
+where a group could otherwise grow until undoing it discards an hour of work.
+
+### 3. Content representation: block operations with inverses
+
+Full-document updates cannot support undo at a usable granularity. Note updates
+move to an operation list, keyed on the `correlation_id` each block already
+carries (`common/sub/notes/content_block.py:54`), which round-trips through
+EditorJS as the block id (`infra/component/block-editor.tsx:224,327`).
+
+```
+SetBlock(correlation_id, block, before)
+InsertBlock(correlation_id, block, after_correlation_id)
+RemoveBlock(correlation_id, before)
+MoveBlock(correlation_id, from, to)
+```
+
+- Introduced as a **new** mutation (`NoteApplyEdits`), leaving `NoteUpdate`
+  intact for API/MCP/CLI callers.
+- `before` is stored so undo is "apply the inverse", with no replay from
+  genesis and no snapshot storage.
+- **Positions are expressed as `after_correlation_id`, never as indices.** Index
+  positions make almost nothing commute, since every insert shifts every
+  subsequent index; anchor positions commute freely. This matters for §6.
+- Event data becomes O(edit) rather than O(document).
+- No OT, no CRDT. Editing is single-writer per note in practice.
+
+`update_entity_action` currently hard-codes "event data = frame args"
+(`entity.py:452-462`). It gains a way for an entity method to supply a compact
+inverse payload, defaulting to frame args. Every other entity in the system is
+small enough that frame args are fine; only `Note` is pathological, and this
+keeps the fix local rather than forking the event machinery.
+
+### 4. Undoability is a separate, ternary axis
+
+Group size and reversibility are independent. `mutation_use_case` already takes
+keyword flags and stamps class attributes (`use_case.py:1116`), so this follows
+the existing pattern:
+
+| Value | Meaning | Seals an open group |
+| ----- | ------- | ------------------- |
+| `undoable` | invertible; appears on the stack | yes |
+| `not_undoable` | a real act, recorded and visible, but not reversible | yes |
+| `transparent` | background bookkeeping; never on the stack | **no** |
+
+`transparent` is load-bearing. Without it, `not_undoable` and
+`seals-your-group` get conflated, and in an app with hourly gen, GC and stats
+runs, every cron tick would punctuate the user's editing. Search reindex
+follow-ups and stat recomputes are `transparent`.
+
+Default is `not_undoable`; reversibility is opted into explicitly.
+
+**Shapes across the system:**
+
+| Shape | Example | Group | Undoable |
+| ----- | ------- | ----- | -------- |
+| Coalescing edit | note / doc body | many mutations → 1 | yes, via inverse ops |
+| Form save | inbox task update | 1 → 1, multi-entity cascade | yes |
+| Discrete flip | complete, archive | 1 → 1 | yes |
+| Creation | doc create (Doc + Note) | 1 → 1, multi-entity | yes |
+| Batch run | gen, gc, stats | 1 → 1, non-atomic | no |
+| External effect | schedule external sync | 1 → 1 | no |
+
+Two notes on that table:
+
+**Inbox task update is singular but wide.** `InboxTaskUpdateUseCase` cascades
+into big plan stats (`mark_inbox_task_done/undone`, lines 241/248), habit streak
+marks (263), a `TimePlanActivity` via `generic_creator` (211), and a
+gamification score record (168). The cascade *is* the intent — undoing the
+status flip without retracting the score record leaves the user's points wrong.
+The unit of undo is therefore the mutation's full event set, which
+`find_all_entity_events_for_mutation` already retrieves *(exists)*.
+
+**Gen is one group but not undoable.** `GenDoUseCase` is a single mutation use
+case, so `group_id := trace_id` trivially. But it extends the non-transactional
+base and `GenService` opens **48 separate units of work**, so it is not atomic
+at the database level and G4 cannot hold for it. Semantically it is worse: by
+the time anyone reaches for undo, some generated tasks have been completed, and
+removing them destroys real work.
+
+### 5. Reversing creations
+
+Undo of a creation is **archive**, not remove. `generic_crown_remover` /
+`remove()` describe themselves as irreversible, which disqualifies them.
+
+- `generic_crown_archiver` *(exists)* already marks an entity archived and walks
+  its links doing the same, guarded by `is_safe_to_archive`.
+- `JupiterArchivalReason` gains `UNDO` alongside `USER | GC | SYNC`. It then
+  flows through every repository's `allow_archived` handling for free — the note
+  repository's `_archived_clause` already accepts
+  `bool | EnumValue | list[JupiterArchivalReason]`.
+
+**The cascade boundary is read from the model, not hand-written.**
+`OwnsLink` / `ContainsLink` mean constituent part; `RefsMany` means reference.
+`generic_crown_archiver` already walks exactly the former and stops at the
+latter. Three cases sort themselves:
+
+1. **Constituent parts** — the `Note` of a `Doc`. Cascaded automatically.
+   `Note.can_be_removed_independently` already expresses the same instinct for
+   removal (`common/sub/notes/root.py:104-113`).
+2. **Derived ledger records** — `ScoreLogEntry`, big plan stats, streak marks.
+   These want their inverse operation, not archiving. Several already have a
+   symmetric pair (`mark_inbox_task_done` / `mark_inbox_task_undone`).
+3. **Independent entities in another tree** — the `TimePlanActivity` created
+   when a task is assigned to a time plan. Not owned by the inbox task, so no
+   cascade reaches it, and the user may have edited it since.
+
+For case 3 the guard is cheap and uses existing data: if the created entity has
+any event after its creation belonging to a *different* mutation, it has been
+independently touched. Undo then refuses, or degrades to partial and names what
+it left alone — never silently discards the edit.
+
+**Redo of an undone creation is unarchive, not re-create.** Re-creating collides
+with unique indexes, trips `idx_doc_idempotency_key`, and — decisively — mints a
+new `ref_id`, dangling every reference to the old one. The inverse must record
+the *prior* archived state rather than assuming `false`, so an entity already
+archived before the mutation is not resurrected.
+
+**Prerequisite audit**: unique indexes are inconsistent about archived state.
+`vision` gets it right (`WHERE archived=false AND status='active'`), but
+`ix_note_owner ON note (owner)` and
+`ix_working_mem_working_mem_collection_ref_id` have no archived guard, so an
+archived row still occupies the slot. Archive-as-undo therefore frees the slot
+for some entity types and not others. This needs a pass before undo ships.
+
+### 6. Concurrency
+
+Multi-user undo is **selective undo**. Given `A1 B1 A2 B2`, A undoing A2 means
+applying `inverse(A2)` to a state containing B2, which is valid only if the two
+**commute**. Transforming the inverse instead is OT, which we are not building.
+
+Block operations make commutativity decidable:
+
+| Pair | Commutes |
+| ---- | -------- |
+| `SetBlock(X)` / `SetBlock(Y)`, X≠Y | yes |
+| `SetBlock(X)` / `SetBlock(X)` | no |
+| `RemoveBlock(X)` / anything on X | no |
+| `InsertBlock` / `MoveBlock` | no |
+| `SetBlock(X)` / `InsertBlock` elsewhere | yes, given anchor-based positions |
+
+**Rule**: undo a group iff every operation in it commutes with everything that
+landed since. Otherwise refuse, naming what happened. Refuse the **whole**
+group, never part of it — partial undo produces exactly the state-never-seen
+that G4 exists to prevent.
+
+**Redo has a shorter reach than undo.** A undoes an edit to block X; B, seeing
+the reverted state, edits X; A redoes. Design in the asymmetry: a redo entry is
+invalidated by any foreign write to its focus key. Undo refuses with an
+explanation; redo silently drops off the stack, since the user has not asked for
+it yet.
+
+**"Foreign" means different session, not different user.** Undoing on a laptop
+something changed on a phone is exactly as unsafe as a colleague's edit; the
+commutativity argument does not care about identity. Only the copy differs.
+
+**Detection has existing parts** *(exists)*: an authenticated websocket
+(`WebsocketProgressReporterFactory`, sockets registered by auth token), a source
+of entity-change events (the progress reporter's
+`mark_created`/`mark_updated`/`mark_removed`), and an audience computation
+(`ReaderUserRefIdsForEntityService`, used by the search indexer). The gap is
+only that `new_reporter(dedup_key)` keys the channel to
+`user:{id}+workspace:{id}`, so a mutation reaches the acting user's tabs and
+nobody else's. Fanning out to an entity's readers is wiring, not a new
+subsystem, and yields the multi-device case for free.
+
+**Rollout**: start pessimistic — undo reaches back only as far as the last
+foreign write on that entity — and upgrade to commutativity checking once block
+operations exist. Same plumbing, two levels of permissiveness. Given how rarely
+two people edit the same Thrive document at once, level one may be where this
+rests permanently.
+
+### 7. Non-interactive surfaces
+
+**Session derivation**, by fallback chain — explicit header, else surface-derived,
+else `session_id := trace_id`:
+
+| Surface | Session |
+| ------- | ------- |
+| CLI | the process invocation |
+| MCP | the protocol session, or the agent turn |
+| API | caller-supplied; else per-request |
+| cron | the run |
+
+**The stack is per-user, not per-session.** If an agent edits over MCP and the
+human undoes it from the web UI, the undoing session is not the acting session.
+Session is attribution, grouping, and the default filter — not a partition. This
+is what makes server-side stack reconstruction necessary rather than optional.
+
+**Granularity varies by surface.** An agent turn may be fifty mutations across
+twenty focus keys — twenty groups — but the user thinks "undo what the assistant
+did", which is the *session*. The web UI pops groups; MCP and CLI pop sessions.
+The hierarchy supports both.
+
+**Write authority is per-session** even though visibility is per-user. A human
+may undo anything of theirs from any surface; an MCP agent may undo **only its
+own session's groups**. Otherwise an agent can quietly revert a morning's work
+because it judged that helpful.
+
+**Undo is an ordinary mutation** and goes through the normal path so it
+re-checks ACL. A user who edits a shared doc, loses the grant, then hits undo
+must fail the check — only the ordinary path gets that right.
+
+MCP is where undo has the most value in the whole system: the human did not make
+the change, a model did, and they were not watching.
+
+CLI is the simplest surface. `NoteUpdateUseCase` is declared
+`@mutation_use_case(exclude_component=[AppCore.CLI])`, so document editing is
+not reachable there; every CLI mutation is discrete, and group = mutation =
+trace always.
+
+### 8. Prerequisites
+
+Ordered, and each independently valuable:
+
+1. **Client debounce and no-op suppression.** ~600ms idle plus a ~5s max-wait
+   checkpoint; flush on blur, unmount and `visibilitychange` (`sendBeacon` or a
+   keepalive fetch for tab close). Skip submits whose serialized content is
+   unchanged. No schema change; removes most of the write volume.
+2. **Bound the history read path.** Add limit/offset to
+   `find_all_entity_events_by_timestamp_desc` and paginate
+   `GetEntityMutationHistoryUseCase`. This breaks first on any document with a
+   real history.
+3. **Optimistic concurrency.** `save()` becomes
+   `WHERE ref_id = ? AND version = ?`, raising on `rowcount == 0`. Turns silent
+   clobbering into a detectable conflict, and is what makes foreign writes
+   detectable at write time.
+4. **Rename `mutation_entity_event.session_index` to `event_index`.** It means
+   the index of an event within one mutation for one entity
+   (`storage/postgres/events.py:87`) and has nothing to do with a user session.
+   Once sessions exist the name is actively misleading. It participates in a
+   unique index, so this is a migration in both flavors — cheap now, expensive
+   later.
+5. **Stop double-recording heavy args.** `mutation_invocation_record.args`
+   duplicates `mutation_entity_event.data` for note edits. A per-arg
+   "do not record" annotation halves the write. Note `framework/secure.py` is
+   currently a no-op marker with no field-level mechanism to reuse.
+6. **Audit unique indexes for archived state** (see §5).
+7. **Retention/compaction.** Fold events older than a threshold into a snapshot
+   and drop the fine-grained ones. Deep undo only matters for recent edits.
+
+## Consequences
+
+- **Recording decisions foreclose options; UI decisions do not.** Recording
+  session, group and affected entity on every mutation keeps both a global stack
+  and a focus-scoped stack available. Global-vs-focused undo scope is
+  deliberately left undecided.
+- **The concurrency fix arrives with the performance fix.** Block operations are
+  not only a write-amplification improvement; they are what stops two people
+  editing different paragraphs from clobbering each other, which is a present
+  bug.
+- **Undo becomes explainable.** Refusals name a cause ("someone else edited that
+  paragraph"), rather than undo silently doing something surprising.
+- **The event log grows on undo.** Undo is itself a mutation and records events.
+  `undo_of: mutation_id` on the invocation record lets the stack walk skip
+  paired mutations, so undo/redo/undo does not degenerate into a toggle.
+- **Batch domains keep their own audit story.** `GenLog`/`GenLogEntry`, `GCLog`,
+  `StatsLog`, `ScoreLog` and `ScheduleExternalSyncLog` are each a
+  `TrunkEntity` + `LeafSupportEntity` pair recording what a run created,
+  updated and removed — `GenLogEntry` even carries an `opened: bool`. These stay
+  **separate** from groups: they are domain-visible history with
+  domain-specific fields, where group is infrastructure. Their existence is
+  further evidence that batch mutations do not belong on the undo stack.
+- **Cost**: a migration on `mutation_invocation_record` (plus the
+  `session_index` rename), header plumbing in the webapi, client-side group
+  tracking in the editor, and client codegen for the new note mutation.
+
+## Open questions
+
+- **Redo cursor placement.** Client-only (a reload loses redo, as desktop apps
+  do) or server-side (a real session entity with state)? This is the only place
+  expected to need a server-side session entity.
+- **Undo scope in the UI.** Global per session, or filtered to the focused
+  surface? Deferred by design; the recording supports both.
+- **Habit streak inversion.** Retracting score points looks straightforward;
+  un-breaking a streak is subtler. `HabitStreakRecorderService` needs review
+  before inbox task updates are marked `undoable`.
+- **`NoteUpdateUseCase` requires only `AccessLevel.COMMENTER`**
+  (`common/sub/notes/use_case/update.py:53`) while crown entity updates default
+  to `WRITER` (`crown_entity_support.py:247`). On a shared doc a commenter can
+  therefore rewrite the body but not the name. Intentional if notes are the
+  commenting substrate — but a doc's body *is* a note, so it warrants a second
+  look independently of undo.
+- **EditorJS change events.** EditorJS 2.31's `onChange` is understood to pass
+  `(api, event)` with block mutation events carrying
+  `block-added`/`block-changed`/`block-removed`/`block-moved` and
+  `detail.target`; the current code discards both parameters
+  (`infra/component/block-editor.tsx:107`). If that holds, focus keys and
+  self-sealing classification come nearly free. **Confirm against the installed
+  version first** — much of §2 and §3 is cheaper if true.
+- **"Revert to this version"** — an owner undoing someone else's changes — is a
+  *different feature* built on the same event data
+  (`GetEntityMutationHistoryUseCase` already returns the users). Keeping it out
+  of the undo design is deliberate; conflating them is what makes multi-user
+  undo look intractable.
+
+## Related
+
+- ADR 0005 — recording events (defines trace / mutation / event; names undo/redo
+  as a goal)
+- ADR 0011 — access control and authenticated sharing (multi-writer entities)
+- ADR 0007 — search entity indexing map and hourly backfill (the reindex
+  follow-up each mutation enqueues)


### PR DESCRIPTION
Records the design reached while exploring undo/redo, so the reasoning
survives until the work is built. Nothing here is implemented yet; the
ADR is marked Proposed and flags which pieces already exist in the tree.

Covers: two new recording levels (session, group) above trace; a precise
definition of a group with its admission, sealing and invariant rules;
block-level note operations with stored inverses; undoability as a
ternary axis separate from grouping; reversing creations via archive and
the declared link taxonomy; commutativity-based handling of concurrent
writers; and session derivation for the CLI, API and MCP surfaces.

Also lists the prerequisites that are independently valuable — client
debounce, history pagination, optimistic concurrency, and the
session_index rename.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D94PLCXKVCtrdcqJ2GDFdv