### PR TITLE
Add big plan dependencies

### DIFF
--- a/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
@@ -102,6 +102,7 @@ from .big_plan_update_args import BigPlanUpdateArgs
 from .big_plan_update_args_actionable_date import BigPlanUpdateArgsActionableDate
 from .big_plan_update_args_aspect_ref_id import BigPlanUpdateArgsAspectRefId
 from .big_plan_update_args_chapter_ref_id import BigPlanUpdateArgsChapterRefId
+from .big_plan_update_args_dependency_ref_ids import BigPlanUpdateArgsDependencyRefIds
 from .big_plan_update_args_difficulty import BigPlanUpdateArgsDifficulty
 from .big_plan_update_args_due_date import BigPlanUpdateArgsDueDate
 from .big_plan_update_args_eisen import BigPlanUpdateArgsEisen
@@ -1253,6 +1254,7 @@ __all__ = (
     "BigPlanUpdateArgsActionableDate",
     "BigPlanUpdateArgsAspectRefId",
     "BigPlanUpdateArgsChapterRefId",
+    "BigPlanUpdateArgsDependencyRefIds",
     "BigPlanUpdateArgsDifficulty",
     "BigPlanUpdateArgsDueDate",
     "BigPlanUpdateArgsEisen",

--- a/gen/py/webapi-client/jupiter_webapi_client/models/big_plan.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/big_plan.py
@@ -31,6 +31,7 @@ class BigPlan:
         is_key (bool):
         eisen (Eisen): The Eisenhower status of a particular task.
         difficulty (Difficulty): The difficulty of a particular task.
+        dependency_ref_ids (list[str]):
         archival_reason (None | str | Unset):
         archived_time (None | str | Unset):
         chapter_ref_id (None | str | Unset):
@@ -53,6 +54,7 @@ class BigPlan:
     is_key: bool
     eisen: Eisen
     difficulty: Difficulty
+    dependency_ref_ids: list[str]
     archival_reason: None | str | Unset = UNSET
     archived_time: None | str | Unset = UNSET
     chapter_ref_id: None | str | Unset = UNSET
@@ -87,6 +89,8 @@ class BigPlan:
         eisen = self.eisen.value
 
         difficulty = self.difficulty.value
+
+        dependency_ref_ids = self.dependency_ref_ids
 
         archival_reason: None | str | Unset
         if isinstance(self.archival_reason, Unset):
@@ -152,6 +156,7 @@ class BigPlan:
                 "is_key": is_key,
                 "eisen": eisen,
                 "difficulty": difficulty,
+                "dependency_ref_ids": dependency_ref_ids,
             }
         )
         if archival_reason is not UNSET:
@@ -199,6 +204,8 @@ class BigPlan:
         eisen = Eisen(d.pop("eisen"))
 
         difficulty = Difficulty(d.pop("difficulty"))
+
+        dependency_ref_ids = cast(list[str], d.pop("dependency_ref_ids"))
 
         def _parse_archival_reason(data: object) -> None | str | Unset:
             if data is None:
@@ -285,6 +292,7 @@ class BigPlan:
             is_key=is_key,
             eisen=eisen,
             difficulty=difficulty,
+            dependency_ref_ids=dependency_ref_ids,
             archival_reason=archival_reason,
             archived_time=archived_time,
             chapter_ref_id=chapter_ref_id,

--- a/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_create_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_create_args.py
@@ -32,6 +32,7 @@ class BigPlanCreateArgs:
         goal_ref_id (None | str | Unset):
         actionable_date (None | str | Unset):
         due_date (None | str | Unset):
+        dependency_ref_ids (list[str] | None | Unset):
     """
 
     name: str
@@ -46,6 +47,7 @@ class BigPlanCreateArgs:
     goal_ref_id: None | str | Unset = UNSET
     actionable_date: None | str | Unset = UNSET
     due_date: None | str | Unset = UNSET
+    dependency_ref_ids: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -109,6 +111,15 @@ class BigPlanCreateArgs:
         else:
             due_date = self.due_date
 
+        dependency_ref_ids: list[str] | None | Unset
+        if isinstance(self.dependency_ref_ids, Unset):
+            dependency_ref_ids = UNSET
+        elif isinstance(self.dependency_ref_ids, list):
+            dependency_ref_ids = self.dependency_ref_ids
+
+        else:
+            dependency_ref_ids = self.dependency_ref_ids
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -135,6 +146,8 @@ class BigPlanCreateArgs:
             field_dict["actionable_date"] = actionable_date
         if due_date is not UNSET:
             field_dict["due_date"] = due_date
+        if dependency_ref_ids is not UNSET:
+            field_dict["dependency_ref_ids"] = dependency_ref_ids
 
         return field_dict
 
@@ -239,6 +252,23 @@ class BigPlanCreateArgs:
 
         due_date = _parse_due_date(d.pop("due_date", UNSET))
 
+        def _parse_dependency_ref_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                dependency_ref_ids_type_0 = cast(list[str], data)
+
+                return dependency_ref_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        dependency_ref_ids = _parse_dependency_ref_ids(d.pop("dependency_ref_ids", UNSET))
+
         big_plan_create_args = cls(
             name=name,
             is_key=is_key,
@@ -252,6 +282,7 @@ class BigPlanCreateArgs:
             goal_ref_id=goal_ref_id,
             actionable_date=actionable_date,
             due_date=due_date,
+            dependency_ref_ids=dependency_ref_ids,
         )
 
         big_plan_create_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_update_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_update_args.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from ..models.big_plan_update_args_actionable_date import BigPlanUpdateArgsActionableDate
     from ..models.big_plan_update_args_aspect_ref_id import BigPlanUpdateArgsAspectRefId
     from ..models.big_plan_update_args_chapter_ref_id import BigPlanUpdateArgsChapterRefId
+    from ..models.big_plan_update_args_dependency_ref_ids import BigPlanUpdateArgsDependencyRefIds
     from ..models.big_plan_update_args_difficulty import BigPlanUpdateArgsDifficulty
     from ..models.big_plan_update_args_due_date import BigPlanUpdateArgsDueDate
     from ..models.big_plan_update_args_eisen import BigPlanUpdateArgsEisen
@@ -38,6 +39,7 @@ class BigPlanUpdateArgs:
         difficulty (BigPlanUpdateArgsDifficulty):
         actionable_date (BigPlanUpdateArgsActionableDate):
         due_date (BigPlanUpdateArgsDueDate):
+        dependency_ref_ids (BigPlanUpdateArgsDependencyRefIds):
     """
 
     ref_id: str
@@ -51,6 +53,7 @@ class BigPlanUpdateArgs:
     difficulty: BigPlanUpdateArgsDifficulty
     actionable_date: BigPlanUpdateArgsActionableDate
     due_date: BigPlanUpdateArgsDueDate
+    dependency_ref_ids: BigPlanUpdateArgsDependencyRefIds
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -76,6 +79,8 @@ class BigPlanUpdateArgs:
 
         due_date = self.due_date.to_dict()
 
+        dependency_ref_ids = self.dependency_ref_ids.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -91,6 +96,7 @@ class BigPlanUpdateArgs:
                 "difficulty": difficulty,
                 "actionable_date": actionable_date,
                 "due_date": due_date,
+                "dependency_ref_ids": dependency_ref_ids,
             }
         )
 
@@ -101,6 +107,7 @@ class BigPlanUpdateArgs:
         from ..models.big_plan_update_args_actionable_date import BigPlanUpdateArgsActionableDate
         from ..models.big_plan_update_args_aspect_ref_id import BigPlanUpdateArgsAspectRefId
         from ..models.big_plan_update_args_chapter_ref_id import BigPlanUpdateArgsChapterRefId
+        from ..models.big_plan_update_args_dependency_ref_ids import BigPlanUpdateArgsDependencyRefIds
         from ..models.big_plan_update_args_difficulty import BigPlanUpdateArgsDifficulty
         from ..models.big_plan_update_args_due_date import BigPlanUpdateArgsDueDate
         from ..models.big_plan_update_args_eisen import BigPlanUpdateArgsEisen
@@ -132,6 +139,8 @@ class BigPlanUpdateArgs:
 
         due_date = BigPlanUpdateArgsDueDate.from_dict(d.pop("due_date"))
 
+        dependency_ref_ids = BigPlanUpdateArgsDependencyRefIds.from_dict(d.pop("dependency_ref_ids"))
+
         big_plan_update_args = cls(
             ref_id=ref_id,
             name=name,
@@ -144,6 +153,7 @@ class BigPlanUpdateArgs:
             difficulty=difficulty,
             actionable_date=actionable_date,
             due_date=due_date,
+            dependency_ref_ids=dependency_ref_ids,
         )
 
         big_plan_update_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_update_args_dependency_ref_ids.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/big_plan_update_args_dependency_ref_ids.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BigPlanUpdateArgsDependencyRefIds")
+
+
+@_attrs_define
+class BigPlanUpdateArgsDependencyRefIds:
+    """
+    Attributes:
+        should_change (bool):
+        value (list[str] | Unset):
+    """
+
+    should_change: bool
+    value: list[str] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        should_change = self.should_change
+
+        value: list[str] | Unset = UNSET
+        if not isinstance(self.value, Unset):
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "should_change": should_change,
+            }
+        )
+        if value is not UNSET:
+            field_dict["value"] = value
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        should_change = d.pop("should_change")
+
+        value = cast(list[str], d.pop("value", UNSET))
+
+        big_plan_update_args_dependency_ref_ids = cls(
+            should_change=should_change,
+            value=value,
+        )
+
+        big_plan_update_args_dependency_ref_ids.additional_properties = d
+        return big_plan_update_args_dependency_ref_ids
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/ts/webapi-client/gen/models/BigPlan.ts
+++ b/gen/ts/webapi-client/gen/models/BigPlan.ts
@@ -33,5 +33,6 @@ export type BigPlan = {
     due_date?: (ADate | null);
     working_time?: (Timestamp | null);
     completed_time?: (Timestamp | null);
+    dependency_ref_ids: Array<EntityId>;
 };
 

--- a/gen/ts/webapi-client/gen/models/BigPlanCreateArgs.ts
+++ b/gen/ts/webapi-client/gen/models/BigPlanCreateArgs.ts
@@ -25,5 +25,6 @@ export type BigPlanCreateArgs = {
     goal_ref_id?: (EntityId | null);
     actionable_date?: (ADate | null);
     due_date?: (ADate | null);
+    dependency_ref_ids?: (Array<EntityId> | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/BigPlanUpdateArgs.ts
+++ b/gen/ts/webapi-client/gen/models/BigPlanUpdateArgs.ts
@@ -53,5 +53,9 @@ export type BigPlanUpdateArgs = {
         should_change: boolean;
         value?: (ADate | null);
     };
+    dependency_ref_ids: {
+        should_change: boolean;
+        value?: Array<EntityId>;
+    };
 };
 

--- a/itests/api/big_plans.test.py
+++ b/itests/api/big_plans.test.py
@@ -185,6 +185,7 @@ def test_api_big_plan_update(api_url: str, api_key: str, create_big_plan) -> Non
             "aspect_ref_id": {"should_change": False},
             "chapter_ref_id": {"should_change": False},
             "goal_ref_id": {"should_change": False},
+            "dependency_ref_ids": {"should_change": False},
         },
         timeout=10,
     )
@@ -197,6 +198,75 @@ def test_api_big_plan_update(api_url: str, api_key: str, create_big_plan) -> Non
     )
     assert response2.status_code == 200
     assert response2.json()["big_plan"]["name"] == "New Plan"
+
+
+def test_api_big_plan_update_dependencies(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    dependency = create_big_plan("Dependency Plan")
+    created = create_big_plan("Dependent Plan")
+
+    response = requests.put(
+        f"{api_url}/v1/big-plans/{created.ref_id}",
+        headers=_headers(api_key),
+        json={
+            "ref_id": created.ref_id,
+            "name": {"should_change": False},
+            "status": {"should_change": False},
+            "is_key": {"should_change": False},
+            "eisen": {"should_change": False},
+            "difficulty": {"should_change": False},
+            "actionable_date": {"should_change": False},
+            "due_date": {"should_change": False},
+            "aspect_ref_id": {"should_change": False},
+            "chapter_ref_id": {"should_change": False},
+            "goal_ref_id": {"should_change": False},
+            "dependency_ref_ids": {
+                "should_change": True,
+                "value": [dependency.ref_id, dependency.ref_id],
+            },
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    response2 = requests.get(
+        f"{api_url}/v1/big-plans/{created.ref_id}?allow_archived=false",
+        headers=_headers(api_key),
+        timeout=10,
+    )
+    assert response2.status_code == 200
+    assert response2.json()["big_plan"]["dependency_ref_ids"] == [dependency.ref_id]
+
+
+def test_api_big_plan_update_cannot_depend_on_itself(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    created = create_big_plan("Self Dependent Plan")
+
+    response = requests.put(
+        f"{api_url}/v1/big-plans/{created.ref_id}",
+        headers=_headers(api_key),
+        json={
+            "ref_id": created.ref_id,
+            "name": {"should_change": False},
+            "status": {"should_change": False},
+            "is_key": {"should_change": False},
+            "eisen": {"should_change": False},
+            "difficulty": {"should_change": False},
+            "actionable_date": {"should_change": False},
+            "due_date": {"should_change": False},
+            "aspect_ref_id": {"should_change": False},
+            "chapter_ref_id": {"should_change": False},
+            "goal_ref_id": {"should_change": False},
+            "dependency_ref_ids": {
+                "should_change": True,
+                "value": [created.ref_id],
+            },
+        },
+        timeout=10,
+    )
+    assert response.status_code != 200
 
 
 def test_api_big_plan_archive(api_url: str, api_key: str, create_big_plan) -> None:

--- a/itests/api/big_plans.test.py
+++ b/itests/api/big_plans.test.py
@@ -1,6 +1,7 @@
 """Tests for the API for big plans."""
 
 from collections.abc import Iterator
+from typing import cast
 
 import pytest
 import requests
@@ -200,17 +201,14 @@ def test_api_big_plan_update(api_url: str, api_key: str, create_big_plan) -> Non
     assert response2.json()["big_plan"]["name"] == "New Plan"
 
 
-def test_api_big_plan_update_dependencies(
-    api_url: str, api_key: str, create_big_plan
-) -> None:
-    dependency = create_big_plan("Dependency Plan")
-    created = create_big_plan("Dependent Plan")
-
-    response = requests.put(
-        f"{api_url}/v1/big-plans/{created.ref_id}",
+def _set_dependencies(
+    api_url: str, api_key: str, ref_id: str, dependency_ref_ids: list[str]
+) -> requests.Response:
+    return requests.put(
+        f"{api_url}/v1/big-plans/{ref_id}",
         headers=_headers(api_key),
         json={
-            "ref_id": created.ref_id,
+            "ref_id": ref_id,
             "name": {"should_change": False},
             "status": {"should_change": False},
             "is_key": {"should_change": False},
@@ -223,20 +221,76 @@ def test_api_big_plan_update_dependencies(
             "goal_ref_id": {"should_change": False},
             "dependency_ref_ids": {
                 "should_change": True,
-                "value": [dependency.ref_id, dependency.ref_id],
+                "value": dependency_ref_ids,
             },
+        },
+        timeout=10,
+    )
+
+
+def _load_dependencies(api_url: str, api_key: str, ref_id: str) -> list[str]:
+    response = requests.get(
+        f"{api_url}/v1/big-plans/{ref_id}?allow_archived=true",
+        headers=_headers(api_key),
+        timeout=10,
+    )
+    assert response.status_code == 200
+    return cast(list[str], response.json()["big_plan"]["dependency_ref_ids"])
+
+
+def test_api_big_plan_create_with_dependencies(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    dependency = create_big_plan("Create Dependency Plan")
+
+    response = requests.post(
+        f"{api_url}/v1/big-plans",
+        headers=_headers(api_key),
+        json={
+            "name": "Plan With Dependencies",
+            "is_key": False,
+            "eisen": "regular",
+            "difficulty": "easy",
+            "dependency_ref_ids": [dependency.ref_id, dependency.ref_id],
         },
         timeout=10,
     )
     assert response.status_code == 200
 
-    response2 = requests.get(
-        f"{api_url}/v1/big-plans/{created.ref_id}?allow_archived=false",
+    bp = response.json()["new_big_plan"]
+    assert bp["dependency_ref_ids"] == [dependency.ref_id]
+    assert _load_dependencies(api_url, api_key, bp["ref_id"]) == [dependency.ref_id]
+
+
+def test_api_big_plan_create_with_missing_dependency(
+    api_url: str, api_key: str
+) -> None:
+    response = requests.post(
+        f"{api_url}/v1/big-plans",
         headers=_headers(api_key),
+        json={
+            "name": "Plan With Bad Dependency",
+            "is_key": False,
+            "eisen": "regular",
+            "difficulty": "easy",
+            "dependency_ref_ids": ["30234"],
+        },
         timeout=10,
     )
-    assert response2.status_code == 200
-    assert response2.json()["big_plan"]["dependency_ref_ids"] == [dependency.ref_id]
+    assert response.status_code != 200
+
+
+def test_api_big_plan_update_dependencies(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    dependency = create_big_plan("Dependency Plan")
+    created = create_big_plan("Dependent Plan")
+
+    response = _set_dependencies(
+        api_url, api_key, created.ref_id, [dependency.ref_id, dependency.ref_id]
+    )
+    assert response.status_code == 200
+    assert _load_dependencies(api_url, api_key, created.ref_id) == [dependency.ref_id]
 
 
 def test_api_big_plan_update_cannot_depend_on_itself(
@@ -244,29 +298,115 @@ def test_api_big_plan_update_cannot_depend_on_itself(
 ) -> None:
     created = create_big_plan("Self Dependent Plan")
 
-    response = requests.put(
-        f"{api_url}/v1/big-plans/{created.ref_id}",
+    response = _set_dependencies(api_url, api_key, created.ref_id, [created.ref_id])
+    assert response.status_code != 200
+
+
+def test_api_big_plan_update_rejects_dependency_cycle(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    first = create_big_plan("Cycle Plan First")
+    second = create_big_plan("Cycle Plan Second")
+
+    response = _set_dependencies(api_url, api_key, second.ref_id, [first.ref_id])
+    assert response.status_code == 200
+
+    response = _set_dependencies(api_url, api_key, first.ref_id, [second.ref_id])
+    assert response.status_code != 200
+    assert _load_dependencies(api_url, api_key, first.ref_id) == []
+
+
+def test_api_big_plan_update_rejects_transitive_dependency_cycle(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    first = create_big_plan("Long Cycle Plan First")
+    second = create_big_plan("Long Cycle Plan Second")
+    third = create_big_plan("Long Cycle Plan Third")
+
+    assert (
+        _set_dependencies(api_url, api_key, second.ref_id, [first.ref_id]).status_code
+        == 200
+    )
+    assert (
+        _set_dependencies(api_url, api_key, third.ref_id, [second.ref_id]).status_code
+        == 200
+    )
+
+    # first -> third closes first -> third -> second -> first.
+    response = _set_dependencies(api_url, api_key, first.ref_id, [third.ref_id])
+    assert response.status_code != 200
+    assert _load_dependencies(api_url, api_key, first.ref_id) == []
+
+
+def test_api_big_plan_update_allows_diamond_dependencies(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    base = create_big_plan("Diamond Plan Base")
+    left = create_big_plan("Diamond Plan Left")
+    right = create_big_plan("Diamond Plan Right")
+    top = create_big_plan("Diamond Plan Top")
+
+    assert (
+        _set_dependencies(api_url, api_key, left.ref_id, [base.ref_id]).status_code
+        == 200
+    )
+    assert (
+        _set_dependencies(api_url, api_key, right.ref_id, [base.ref_id]).status_code
+        == 200
+    )
+
+    response = _set_dependencies(
+        api_url, api_key, top.ref_id, [left.ref_id, right.ref_id]
+    )
+    assert response.status_code == 200
+    assert _load_dependencies(api_url, api_key, top.ref_id) == [
+        left.ref_id,
+        right.ref_id,
+    ]
+
+
+def test_api_big_plan_archive_unlinks_it_from_dependents(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    dependency = create_big_plan("Archive Unlink Dependency")
+    other = create_big_plan("Archive Unlink Other")
+    dependent = create_big_plan("Archive Unlink Dependent")
+
+    response = _set_dependencies(
+        api_url, api_key, dependent.ref_id, [dependency.ref_id, other.ref_id]
+    )
+    assert response.status_code == 200
+
+    response = requests.delete(
+        f"{api_url}/v1/big-plans/{dependency.ref_id}",
         headers=_headers(api_key),
-        json={
-            "ref_id": created.ref_id,
-            "name": {"should_change": False},
-            "status": {"should_change": False},
-            "is_key": {"should_change": False},
-            "eisen": {"should_change": False},
-            "difficulty": {"should_change": False},
-            "actionable_date": {"should_change": False},
-            "due_date": {"should_change": False},
-            "aspect_ref_id": {"should_change": False},
-            "chapter_ref_id": {"should_change": False},
-            "goal_ref_id": {"should_change": False},
-            "dependency_ref_ids": {
-                "should_change": True,
-                "value": [created.ref_id],
-            },
-        },
         timeout=10,
     )
-    assert response.status_code != 200
+    assert response.status_code == 200
+
+    assert _load_dependencies(api_url, api_key, dependent.ref_id) == [other.ref_id]
+
+
+def test_api_big_plan_remove_unlinks_it_from_dependents(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    dependency = create_big_plan("Remove Unlink Dependency")
+    other = create_big_plan("Remove Unlink Other")
+    dependent = create_big_plan("Remove Unlink Dependent")
+
+    response = _set_dependencies(
+        api_url, api_key, dependent.ref_id, [dependency.ref_id, other.ref_id]
+    )
+    assert response.status_code == 200
+
+    response = requests.delete(
+        f"{api_url}/v1/big-plans/{dependency.ref_id}/remove",
+        headers=_headers(api_key),
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    assert _load_dependencies(api_url, api_key, dependent.ref_id) == [other.ref_id]
 
 
 def test_api_big_plan_archive(api_url: str, api_key: str, create_big_plan) -> None:
@@ -625,6 +765,7 @@ def _update_payload(ref_id: str, *, name: str | None = None) -> dict[str, object
         "aspect_ref_id": {"should_change": False},
         "chapter_ref_id": {"should_change": False},
         "goal_ref_id": {"should_change": False},
+        "dependency_ref_ids": {"should_change": False},
     }
 
 

--- a/itests/webui/entities/big_plans.test.py
+++ b/itests/webui/entities/big_plans.test.py
@@ -7,6 +7,9 @@ import pytest
 from jupiter_webapi_client.api.application.invite_users_to_entity import (
     sync_detailed as invite_users_to_entity_sync,
 )
+from jupiter_webapi_client.api.big_plans.big_plan_archive import (
+    sync_detailed as big_plan_archive_sync,
+)
 from jupiter_webapi_client.api.big_plans.big_plan_create import (
     sync_detailed as big_plan_create_sync,
 )
@@ -16,6 +19,7 @@ from jupiter_webapi_client.api.test_helper.workspace_set_feature import (
 from jupiter_webapi_client.client import AuthenticatedClient
 from jupiter_webapi_client.models.access_level import AccessLevel
 from jupiter_webapi_client.models.big_plan import BigPlan
+from jupiter_webapi_client.models.big_plan_archive_args import BigPlanArchiveArgs
 from jupiter_webapi_client.models.big_plan_create_args import BigPlanCreateArgs
 from jupiter_webapi_client.models.big_plan_create_result import BigPlanCreateResult
 from jupiter_webapi_client.models.difficulty import Difficulty
@@ -79,6 +83,7 @@ def create_big_plan(logged_in_client: AuthenticatedClient):
         due_date: str | None = None,
         time_plan_activity_kind: TimePlanActivityKind | None = None,
         time_plan_activity_feasability: TimePlanActivityFeasability | None = None,
+        dependency_ref_ids: list[str] | None = None,
     ) -> BigPlan:
         result = big_plan_create_sync(
             client=logged_in_client,
@@ -91,6 +96,7 @@ def create_big_plan(logged_in_client: AuthenticatedClient):
                 due_date=due_date,
                 time_plan_activity_kind=time_plan_activity_kind,
                 time_plan_activity_feasability=time_plan_activity_feasability,
+                dependency_ref_ids=dependency_ref_ids,
             ),
         )
         return get_parsed_from_response(BigPlanCreateResult, result).new_big_plan
@@ -127,6 +133,83 @@ def test_webui_big_plan_view_all(page: Page, create_big_plan) -> None:
     expect(page.locator(f"#big-plan-{big_plan1.ref_id}")).to_contain_text("Big Plan 1")
     expect(page.locator(f"#big-plan-{big_plan2.ref_id}")).to_contain_text("Big Plan 2")
     expect(page.locator(f"#big-plan-{big_plan3.ref_id}")).to_contain_text("Big Plan 3")
+
+
+def _pick_dependency(page: Page, name: str) -> None:
+    page.get_by_label("Depends On", exact=True).click()
+    page.keyboard.type(name)
+    page.get_by_role("option").filter(has_text=name).first.click()
+    page.keyboard.press("Escape")
+
+
+def test_webui_big_plan_create_with_dependency(page: Page, create_big_plan) -> None:
+    create_big_plan("Create Dep Target")
+
+    page.goto("/app/workspace/apps/big-plans/new")
+    page.wait_for_selector("#leaf-panel")
+
+    page.locator('input[name="name"]').fill("Create Dep Owner")
+    _pick_dependency(page, "Create Dep Target")
+    page.locator("button[id='big-plan-create']").click()
+
+    page.wait_for_url(re.compile(r".*/big-plans/(?!new$)[^/]+$"))
+    page.wait_for_selector("#leaf-panel")
+
+    expect(page.locator('input[name="name"]')).to_have_value("Create Dep Owner")
+    expect(page.locator("#leaf-panel")).to_contain_text("Create Dep Target")
+
+
+def test_webui_big_plan_update_dependencies(page: Page, create_big_plan) -> None:
+    create_big_plan("Update Dep Target")
+    dependent = create_big_plan("Update Dep Owner")
+
+    page.goto(f"/app/workspace/apps/big-plans/{dependent.ref_id}")
+    page.wait_for_selector("#leaf-panel")
+
+    _pick_dependency(page, "Update Dep Target")
+    page.locator("button[id='big-plan-editor-save']").click()
+
+    page.wait_for_url("/app/workspace/apps/big-plans")
+    page.goto(f"/app/workspace/apps/big-plans/{dependent.ref_id}")
+    page.wait_for_selector("#leaf-panel")
+
+    expect(page.locator("#leaf-panel")).to_contain_text("Update Dep Target")
+
+
+def test_webui_big_plan_cannot_depend_on_itself(page: Page, create_big_plan) -> None:
+    create_big_plan("Self Dep Other")
+    big_plan = create_big_plan("Self Dep Owner")
+
+    page.goto(f"/app/workspace/apps/big-plans/{big_plan.ref_id}")
+    page.wait_for_selector("#leaf-panel")
+
+    page.get_by_label("Depends On", exact=True).click()
+    page.keyboard.type("Self Dep Owner")
+    expect(page.get_by_role("option").filter(has_text="Self Dep Owner")).to_have_count(
+        0
+    )
+
+
+def test_webui_big_plan_archiving_a_dependency_unlinks_it(
+    page: Page, create_big_plan, logged_in_client: AuthenticatedClient
+) -> None:
+    dependency = create_big_plan("Archived Dep Target")
+    dependent = create_big_plan(
+        "Archived Dep Owner", dependency_ref_ids=[dependency.ref_id]
+    )
+
+    page.goto(f"/app/workspace/apps/big-plans/{dependent.ref_id}")
+    page.wait_for_selector("#leaf-panel")
+    expect(page.locator("#leaf-panel")).to_contain_text("Archived Dep Target")
+
+    response = big_plan_archive_sync(
+        client=logged_in_client, body=BigPlanArchiveArgs(ref_id=dependency.ref_id)
+    )
+    assert response.status_code == 200
+
+    page.goto(f"/app/workspace/apps/big-plans/{dependent.ref_id}")
+    page.wait_for_selector("#leaf-panel")
+    expect(page.locator("#leaf-panel")).not_to_contain_text("Archived Dep Target")
 
 
 def test_webui_big_plan_publish_and_view_public(page: Page, create_big_plan) -> None:

--- a/itests/webui/entities/time_plans.test.py
+++ b/itests/webui/entities/time_plans.test.py
@@ -61,6 +61,9 @@ from jupiter_webapi_client.models.big_plan_update_args_aspect_ref_id import (
 from jupiter_webapi_client.models.big_plan_update_args_chapter_ref_id import (
     BigPlanUpdateArgsChapterRefId,
 )
+from jupiter_webapi_client.models.big_plan_update_args_dependency_ref_ids import (
+    BigPlanUpdateArgsDependencyRefIds,
+)
 from jupiter_webapi_client.models.big_plan_update_args_difficulty import (
     BigPlanUpdateArgsDifficulty,
 )
@@ -2744,6 +2747,7 @@ def _mark_big_plan_done(
             is_key=BigPlanUpdateArgsIsKey(should_change=False),
             eisen=BigPlanUpdateArgsEisen(should_change=False),
             difficulty=BigPlanUpdateArgsDifficulty(should_change=False),
+            dependency_ref_ids=BigPlanUpdateArgsDependencyRefIds(should_change=False),
         ),
     )
 
@@ -2767,6 +2771,7 @@ def _clear_big_plan_dates(
             is_key=BigPlanUpdateArgsIsKey(should_change=False),
             eisen=BigPlanUpdateArgsEisen(should_change=False),
             difficulty=BigPlanUpdateArgsDifficulty(should_change=False),
+            dependency_ref_ids=BigPlanUpdateArgsDependencyRefIds(should_change=False),
         ),
     )
 

--- a/src/core/jupiter/core/apps/big_plans/component/multi-select.tsx
+++ b/src/core/jupiter/core/apps/big_plans/component/multi-select.tsx
@@ -1,0 +1,165 @@
+import type { BigPlanSummary, EntityId } from "@jupiter/webapi-client";
+import { Autocomplete, TextField } from "@mui/material";
+import { useEffect, useMemo, useState } from "react";
+
+import { autocompleteSingleLineSx } from "#/core/common/component/autocomplete-sx";
+import { useBigScreen } from "#/core/infra/component/use-big-screen";
+
+interface BigPlanOption {
+  big_plan_ref_id: EntityId;
+  label: string;
+  bigName: string;
+}
+
+interface BigPlanMultiSelectProps {
+  name: string;
+  label: string;
+  inputsEnabled: boolean;
+  disabled: boolean;
+  allBigPlans: BigPlanSummary[];
+  exceptRefId?: EntityId;
+  defaultValue?: EntityId[];
+  value?: EntityId[];
+  onChange?: (value: EntityId[]) => void;
+  maxSelections?: number;
+}
+
+export function BigPlanMultiSelect(props: BigPlanMultiSelectProps) {
+  const isBigScreen = useBigScreen();
+
+  const selectedRefIds = useMemo(
+    () => props.value ?? props.defaultValue ?? [],
+    [props.value, props.defaultValue],
+  );
+
+  // A selected big plan can be missing from the summaries - it might be
+  // archived, or live in another workspace. Keep an option for it around so
+  // saving doesn't silently drop it.
+  const allBigPlansAsOptions: BigPlanOption[] = useMemo(() => {
+    const options = [...props.allBigPlans]
+      .filter((bigPlan) => bigPlan.ref_id !== props.exceptRefId)
+      .sort((b1, b2) => String(b1.name).localeCompare(String(b2.name)))
+      .map((bigPlan) => bigPlanToOption(bigPlan));
+    for (const refId of selectedRefIds) {
+      if (options.some((option) => option.big_plan_ref_id === refId)) {
+        continue;
+      }
+      options.push(unknownBigPlanToOption(refId));
+    }
+    return options;
+  }, [props.allBigPlans, props.exceptRefId, selectedRefIds]);
+
+  const optionsByRefId = useMemo(
+    () =>
+      new Map(
+        allBigPlansAsOptions.map((option) => [option.big_plan_ref_id, option]),
+      ),
+    [allBigPlansAsOptions],
+  );
+
+  const [selectedBigPlans, setSelectedBigPlans] = useState<BigPlanOption[]>(
+    () => selectedRefIdsToOptions(selectedRefIds, optionsByRefId),
+  );
+
+  useEffect(() => {
+    setSelectedBigPlans(
+      selectedRefIdsToOptions(selectedRefIds, optionsByRefId),
+    );
+  }, [selectedRefIds, optionsByRefId]);
+
+  return (
+    <>
+      <Autocomplete
+        autoHighlight
+        id={props.name}
+        limitTags={isBigScreen ? 2 : 1}
+        size="small"
+        options={allBigPlansAsOptions}
+        readOnly={!props.inputsEnabled}
+        disabled={props.disabled || allBigPlansAsOptions.length === 0}
+        multiple
+        disableCloseOnSelect
+        sx={autocompleteSingleLineSx}
+        value={selectedBigPlans}
+        getOptionDisabled={(o) => {
+          const maxSelections = props.maxSelections ?? null;
+          if (!maxSelections) {
+            return false;
+          }
+          const selectedCount = selectedBigPlans.length;
+          const alreadySelected = selectedBigPlans.some(
+            (x) => x.big_plan_ref_id === o.big_plan_ref_id,
+          );
+          return selectedCount >= maxSelections && !alreadySelected;
+        }}
+        onChange={(_, v) => {
+          const maxSelections = props.maxSelections ?? null;
+          if (
+            maxSelections &&
+            v.length > maxSelections &&
+            v.length > selectedBigPlans.length
+          ) {
+            // User is trying to add more than allowed; ignore.
+            return;
+          }
+          setSelectedBigPlans(v);
+          if (props.onChange) {
+            props.onChange(v.map((x) => x.big_plan_ref_id));
+          }
+        }}
+        isOptionEqualToValue={(o, v) => o.big_plan_ref_id === v.big_plan_ref_id}
+        getOptionLabel={(o) => o.bigName}
+        renderOption={(optionProps, option) => {
+          const { key, ...restProps } = optionProps;
+          return (
+            <li {...restProps} key={key}>
+              {option.bigName}
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={props.label}
+            helperText={
+              props.maxSelections
+                ? `Select up to ${props.maxSelections}.`
+                : undefined
+            }
+          />
+        )}
+      />
+
+      <input
+        type="hidden"
+        name={props.name}
+        value={selectedBigPlans.map((b) => b.big_plan_ref_id).join(",")}
+      />
+    </>
+  );
+}
+
+function bigPlanToOption(bigPlan: BigPlanSummary): BigPlanOption {
+  return {
+    big_plan_ref_id: bigPlan.ref_id,
+    label: String(bigPlan.name),
+    bigName: String(bigPlan.name),
+  };
+}
+
+function unknownBigPlanToOption(refId: EntityId): BigPlanOption {
+  return {
+    big_plan_ref_id: refId,
+    label: `Big Plan #${refId}`,
+    bigName: `Big Plan #${refId}`,
+  };
+}
+
+function selectedRefIdsToOptions(
+  refIds: EntityId[],
+  optionsByRefId: Map<EntityId, BigPlanOption>,
+): BigPlanOption[] {
+  return refIds
+    .map((refId) => optionsByRefId.get(refId))
+    .filter((o): o is BigPlanOption => Boolean(o));
+}

--- a/src/core/jupiter/core/apps/big_plans/component/properties-editor.tsx
+++ b/src/core/jupiter/core/apps/big_plans/component/properties-editor.tsx
@@ -3,6 +3,7 @@ import type {
   AspectSummary,
   BigPlan,
   BigPlanLoadResult,
+  BigPlanSummary,
   Chapter,
   ChapterSummary,
   Contact,
@@ -41,6 +42,7 @@ import { isWorkspaceFeatureAvailable } from "#/core/workspaces/root";
 import { bigPlanDonePct } from "#/core/apps/big_plans/root";
 import { BigPlanStatusBigTag } from "#/core/apps/big_plans/component/status-big-tag";
 import { BigPlanDonePctBigTag } from "#/core/apps/big_plans/component/done-pct-big-tag";
+import { BigPlanMultiSelect } from "#/core/apps/big_plans/component/multi-select";
 import { DifficultySelect } from "#/core/common/component/difficulty-select";
 import { EisenhowerSelect } from "#/core/common/component/eisenhower-select";
 import { IsKeySelect } from "#/core/common/component/is-key-select";
@@ -77,6 +79,7 @@ interface BigPlanPropertiesEditorProps {
   allChapters: ChapterSummary[];
   allGoals: GoalSummary[];
   allMilestones: MilestoneSummary[];
+  allBigPlans?: BigPlanSummary[];
   allTags?: Array<Tag>;
   tags?: Array<Tag>;
   allContacts?: Array<Contact>;
@@ -324,6 +327,27 @@ export function BigPlanPropertiesEditor(props: BigPlanPropertiesEditorProps) {
               fieldName={constructFieldErrorName(
                 props.fieldsPrefix,
                 "goal_ref_id",
+              )}
+            />
+          </FormControl>
+        )}
+
+        {props.allBigPlans && (
+          <FormControl fullWidth>
+            <BigPlanMultiSelect
+              name={constructFieldName(props.namePrefix, "dependencyRefIds")}
+              label="Depends On"
+              inputsEnabled={props.inputsEnabled}
+              disabled={!props.inputsEnabled}
+              allBigPlans={props.allBigPlans}
+              exceptRefId={props.bigPlan.ref_id}
+              defaultValue={props.bigPlan.dependency_ref_ids}
+            />
+            <FieldError
+              actionResult={props.actionData}
+              fieldName={constructFieldErrorName(
+                props.fieldsPrefix,
+                "dependency_ref_ids",
               )}
             />
           </FormControl>

--- a/src/core/jupiter/core/apps/big_plans/root.py
+++ b/src/core/jupiter/core/apps/big_plans/root.py
@@ -92,9 +92,11 @@ class BigPlan(LeafEntity):
         difficulty: Difficulty,
         actionable_date: ADate | None,
         due_date: ADate | None,
+        dependency_ref_ids: list[EntityId],
     ) -> "BigPlan":
         """Create a big plan."""
         BigPlan._check_actionable_and_due_dates(actionable_date, due_date)
+        new_dependency_ref_ids = BigPlan._check_dependencies(dependency_ref_ids)
         working_time = ctx.action_timestamp if status.is_working_or_more else None
         completed_time = ctx.action_timestamp if status.is_completed else None
 
@@ -113,7 +115,7 @@ class BigPlan(LeafEntity):
             due_date=due_date,
             working_time=working_time,
             completed_time=completed_time,
-            dependency_ref_ids=[],
+            dependency_ref_ids=new_dependency_ref_ids,
         )
 
     @update_entity_action
@@ -137,8 +139,9 @@ class BigPlan(LeafEntity):
             actionable_date.or_else(self.actionable_date),
             due_date.or_else(self.due_date),
         )
-        new_dependency_ref_ids = self._check_dependencies(
+        new_dependency_ref_ids = BigPlan._check_dependencies(
             dependency_ref_ids.or_else(self.dependency_ref_ids),
+            self.ref_id,
         )
         new_name = name.or_else(self.name)
 
@@ -215,14 +218,15 @@ class BigPlan(LeafEntity):
         """Whether the big plan is completed or not."""
         return self.status.is_completed
 
+    @staticmethod
     def _check_dependencies(
-        self,
         dependency_ref_ids: list[EntityId],
+        ref_id: EntityId | None = None,
     ) -> list[EntityId]:
         """Normalise the big plans this one depends on, dropping duplicates."""
-        new_dependency_ref_ids = []
+        new_dependency_ref_ids: list[EntityId] = []
         for dependency_ref_id in dependency_ref_ids:
-            if dependency_ref_id == self.ref_id:
+            if ref_id is not None and dependency_ref_id == ref_id:
                 raise InputValidationError(
                     "A big plan cannot depend on itself",
                 )

--- a/src/core/jupiter/core/apps/big_plans/root.py
+++ b/src/core/jupiter/core/apps/big_plans/root.py
@@ -57,6 +57,7 @@ class BigPlan(LeafEntity):
     due_date: ADate | None
     working_time: Timestamp | None
     completed_time: Timestamp | None
+    dependency_ref_ids: list[EntityId]
 
     milestones = ContainsMany(BigPlanMilestone, big_plan_ref_id=IsRefId())
     inbox_tasks = OwnsMany(
@@ -112,6 +113,7 @@ class BigPlan(LeafEntity):
             due_date=due_date,
             working_time=working_time,
             completed_time=completed_time,
+            dependency_ref_ids=[],
         )
 
     @update_entity_action
@@ -128,11 +130,15 @@ class BigPlan(LeafEntity):
         difficulty: UpdateAction[Difficulty],
         actionable_date: UpdateAction[ADate | None],
         due_date: UpdateAction[ADate | None],
+        dependency_ref_ids: UpdateAction[list[EntityId]],
     ) -> "BigPlan":
         """Update the big plan."""
         BigPlan._check_actionable_and_due_dates(
             actionable_date.or_else(self.actionable_date),
             due_date.or_else(self.due_date),
+        )
+        new_dependency_ref_ids = self._check_dependencies(
+            dependency_ref_ids.or_else(self.dependency_ref_ids),
         )
         new_name = name.or_else(self.name)
 
@@ -177,6 +183,7 @@ class BigPlan(LeafEntity):
             completed_time=new_completed_time,
             actionable_date=new_actionable_date,
             due_date=new_due_date,
+            dependency_ref_ids=new_dependency_ref_ids,
         )
 
     @update_entity_action
@@ -207,6 +214,22 @@ class BigPlan(LeafEntity):
     def is_completed(self) -> bool:
         """Whether the big plan is completed or not."""
         return self.status.is_completed
+
+    def _check_dependencies(
+        self,
+        dependency_ref_ids: list[EntityId],
+    ) -> list[EntityId]:
+        """Normalise the big plans this one depends on, dropping duplicates."""
+        new_dependency_ref_ids = []
+        for dependency_ref_id in dependency_ref_ids:
+            if dependency_ref_id == self.ref_id:
+                raise InputValidationError(
+                    "A big plan cannot depend on itself",
+                )
+            if dependency_ref_id in new_dependency_ref_ids:
+                continue
+            new_dependency_ref_ids.append(dependency_ref_id)
+        return new_dependency_ref_ids
 
     @staticmethod
     def _check_actionable_and_due_dates(

--- a/src/core/jupiter/core/apps/big_plans/service/archive.py
+++ b/src/core/jupiter/core/apps/big_plans/service/archive.py
@@ -2,6 +2,9 @@
 
 from jupiter.core.apps.big_plans.collection import BigPlanCollection
 from jupiter.core.apps.big_plans.root import BigPlan
+from jupiter.core.apps.big_plans.service.unlink_dependencies import (
+    BigPlanUnlinkDependenciesService,
+)
 from jupiter.core.apps.big_plans.sub.milestones.root import BigPlanMilestone
 from jupiter.core.archival_reason import JupiterArchivalReason
 from jupiter.core.common.sub.inbox_tasks.collection import (
@@ -103,6 +106,13 @@ class BigPlanArchiveService:
             uow,
             EntityLink.std(NamedEntityTag.BIG_PLAN.value, big_plan.ref_id),
             archival_reason,
+        )
+
+        await BigPlanUnlinkDependenciesService().unlink_dependencies(
+            ctx,
+            uow,
+            progress_reporter,
+            big_plan,
         )
 
         big_plan = big_plan.mark_archived(ctx, archival_reason)

--- a/src/core/jupiter/core/apps/big_plans/service/check_cycles.py
+++ b/src/core/jupiter/core/apps/big_plans/service/check_cycles.py
@@ -1,0 +1,41 @@
+"""A service that checks for cycles in the big plan dependency graph."""
+
+from jupiter.core.apps.big_plans.root import BigPlan
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.storage.repository import DomainUnitOfWork
+
+
+class BigPlanDependenciesHaveCyclesError(Exception):
+    """Exception raised when the big plan dependency graph has cycles."""
+
+
+class BigPlanCheckCyclesService:
+    """A service that checks for cycles in the big plan dependency graph."""
+
+    async def check_for_cycles(self, uow: DomainUnitOfWork, big_plan: BigPlan) -> None:
+        """Check for cycles in the big plan dependency graph."""
+        # Dependencies form a graph and not a tree, so this walks it one level
+        # at a time, out from the big plan, until it either comes back to the
+        # big plan or runs out of new ones to look at.
+        seen: set[EntityId] = {big_plan.ref_id}
+        to_visit = list(big_plan.dependency_ref_ids)
+
+        while to_visit:
+            if big_plan.ref_id in to_visit:
+                raise BigPlanDependenciesHaveCyclesError
+
+            next_ref_ids = [ref_id for ref_id in to_visit if ref_id not in seen]
+            if not next_ref_ids:
+                return
+            seen.update(next_ref_ids)
+
+            # A dependency that no longer exists just drops out here.
+            dependencies = await uow.get_for(BigPlan).find_all_generic(
+                allow_archived=True,
+                ref_id=next_ref_ids,
+            )
+            to_visit = [
+                dependency_ref_id
+                for dependency in dependencies
+                for dependency_ref_id in dependency.dependency_ref_ids
+            ]

--- a/src/core/jupiter/core/apps/big_plans/service/remove.py
+++ b/src/core/jupiter/core/apps/big_plans/service/remove.py
@@ -1,6 +1,9 @@
 """Shared module for removing a big plan."""
 
 from jupiter.core.apps.big_plans.root import BigPlan
+from jupiter.core.apps.big_plans.service.unlink_dependencies import (
+    BigPlanUnlinkDependenciesService,
+)
 from jupiter.core.apps.big_plans.stats import BigPlanStatsRepository
 from jupiter.core.apps.big_plans.sub.milestones.root import BigPlanMilestone
 from jupiter.core.apps.time_plans.sub.activity.root import (
@@ -105,6 +108,13 @@ class BigPlanRemoveService:
                 ctx,
                 time_plan_activity.ref_id,
             )
+
+        await BigPlanUnlinkDependenciesService().unlink_dependencies(
+            ctx,
+            uow,
+            reporter,
+            big_plan,
+        )
 
         await uow.get(BigPlanStatsRepository).remove(big_plan.ref_id)
 

--- a/src/core/jupiter/core/apps/big_plans/service/unlink_dependencies.py
+++ b/src/core/jupiter/core/apps/big_plans/service/unlink_dependencies.py
@@ -1,0 +1,58 @@
+"""A service for unlinking a big plan from the big plans that depend on it."""
+
+from jupiter.core.apps.big_plans.root import BigPlan
+from jupiter.framework.context import DomainContext
+from jupiter.framework.progress_reporter.reporter import ProgressReporter
+from jupiter.framework.storage.repository import DomainUnitOfWork
+from jupiter.framework.update_action import UpdateAction
+
+
+class BigPlanUnlinkDependenciesService:
+    """A service for unlinking a big plan from the big plans that depend on it."""
+
+    async def unlink_dependencies(
+        self,
+        ctx: DomainContext,
+        uow: DomainUnitOfWork,
+        progress_reporter: ProgressReporter,
+        big_plan: BigPlan,
+    ) -> None:
+        """Drop the big plan from the dependencies of every other big plan.
+
+        Callers must have already authorized write access to the big plan being
+        unlinked. The big plans that depend on it live in the same collection
+        and are updated without a separate ACL check each.
+        """
+        # Dependencies are a list in a JSON column, so there's nothing to filter
+        # on in the query - the whole collection is scanned instead.
+        all_big_plans = await uow.get_for(BigPlan).find_all_generic(
+            parent_ref_id=big_plan.big_plan_collection.ref_id,
+            allow_archived=True,
+        )
+
+        for other_big_plan in all_big_plans:
+            if big_plan.ref_id not in other_big_plan.dependency_ref_ids:
+                continue
+
+            updated_big_plan = other_big_plan.update(
+                ctx,
+                name=UpdateAction.do_nothing(),
+                status=UpdateAction.do_nothing(),
+                aspect_ref_id=UpdateAction.do_nothing(),
+                chapter_ref_id=UpdateAction.do_nothing(),
+                goal_ref_id=UpdateAction.do_nothing(),
+                is_key=UpdateAction.do_nothing(),
+                eisen=UpdateAction.do_nothing(),
+                difficulty=UpdateAction.do_nothing(),
+                actionable_date=UpdateAction.do_nothing(),
+                due_date=UpdateAction.do_nothing(),
+                dependency_ref_ids=UpdateAction.change_to(
+                    [
+                        dependency_ref_id
+                        for dependency_ref_id in other_big_plan.dependency_ref_ids
+                        if dependency_ref_id != big_plan.ref_id
+                    ]
+                ),
+            )
+            await uow.get_for(BigPlan).save(updated_big_plan)
+            await progress_reporter.mark_updated(updated_big_plan)

--- a/src/core/jupiter/core/apps/big_plans/use_case/create.py
+++ b/src/core/jupiter/core/apps/big_plans/use_case/create.py
@@ -19,6 +19,10 @@ from jupiter.core.apps.time_plans.sub.activity.kind import (
 from jupiter.core.apps.time_plans.sub.activity.root import TimePlanActivity
 from jupiter.core.common.difficulty import Difficulty
 from jupiter.core.common.eisen import Eisen
+from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.access.sub.status.service.check_for_acl import (
+    CheckForAclService,
+)
 from jupiter.core.config import (
     JupiterLoggedInMutationContext,
 )
@@ -61,6 +65,7 @@ class BigPlanCreateArgs(JupiterCreateCrownEntityArgs):
     goal_ref_id: EntityId | None
     actionable_date: ADate | None
     due_date: ADate | None
+    dependency_ref_ids: list[EntityId] | None = None
 
 
 @use_case_result
@@ -131,6 +136,28 @@ class BigPlanCreateUseCase(
                     f"Goal does not belong to aspect '{the_aspect.name}'"
                 )
 
+        dependency_ref_ids = list(dict.fromkeys(args.dependency_ref_ids or []))
+        if dependency_ref_ids:
+            # Reader access is enough - a dependency points at another big plan,
+            # it doesn't change it.
+            await CheckForAclService().do_it_for_many(
+                uow,
+                BigPlan,
+                dependency_ref_ids,
+                context.user.ref_id,
+                AccessLevel.READER,
+            )
+            dependencies = await uow.get_for(BigPlan).find_all_generic(
+                allow_archived=False,
+                ref_id=dependency_ref_ids,
+            )
+            if len(dependencies) != len(dependency_ref_ids):
+                raise InputValidationError(
+                    "Some of the big plans to depend on could not be found"
+                )
+            # There is no cycle check here, unlike on update - nothing can point
+            # at a big plan that is only now being created.
+
         big_plan_collection = await uow.get_for(BigPlanCollection).load_by_parent(
             workspace.ref_id,
         )
@@ -148,6 +175,7 @@ class BigPlanCreateUseCase(
             difficulty=args.difficulty,
             actionable_date=args.actionable_date,
             due_date=args.due_date,
+            dependency_ref_ids=dependency_ref_ids,
         )
         new_big_plan = await self.create_entity(
             context.domain_context,

--- a/src/core/jupiter/core/apps/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/apps/big_plans/use_case/update.py
@@ -9,6 +9,7 @@ from jupiter.core.apps.life_plan.sub.chapters.root import Chapter
 from jupiter.core.apps.life_plan.sub.goals.root import Goal
 from jupiter.core.common.difficulty import Difficulty
 from jupiter.core.common.eisen import Eisen
+from jupiter.core.common.sub.access.access_level import AccessLevel
 from jupiter.core.common.sub.inbox_tasks.collection import InboxTaskCollection
 from jupiter.core.common.sub.inbox_tasks.root import InboxTask, InboxTaskRepository
 from jupiter.core.config import (
@@ -57,6 +58,7 @@ class BigPlanUpdateArgs(JupiterUpdateCrownEntityArgs):
     difficulty: UpdateAction[Difficulty]
     actionable_date: UpdateAction[ADate | None]
     due_date: UpdateAction[ADate | None]
+    dependency_ref_ids: UpdateAction[list[EntityId]] = UpdateAction.do_nothing()
 
 
 @use_case_result
@@ -168,6 +170,37 @@ class BigPlanUpdateUseCase(
                             f"Goal does not belong to aspect '{aspect.name}'"
                         )
 
+        if args.dependency_ref_ids.should_change:
+            desired_dependency_ref_ids = list(
+                dict.fromkeys(args.dependency_ref_ids.just_the_value)
+            )
+            if big_plan.ref_id in desired_dependency_ref_ids:
+                raise InputValidationError("A big plan cannot depend on itself")
+
+            # Only the newly added dependencies are checked. An old one might
+            # meanwhile have been archived or removed, and that shouldn't block
+            # saving the big plan - dropping it should be enough.
+            existing_dependency_ref_ids = set(big_plan.dependency_ref_ids)
+            newly_added_dependency_ref_ids = [
+                dependency_ref_id
+                for dependency_ref_id in desired_dependency_ref_ids
+                if dependency_ref_id not in existing_dependency_ref_ids
+            ]
+            if newly_added_dependency_ref_ids:
+                # Reader access is enough - a dependency points at another big
+                # plan, it doesn't change it.
+                dependencies = await self.find_all_entities(
+                    uow,
+                    context.user.ref_id,
+                    BigPlan,
+                    newly_added_dependency_ref_ids,
+                    minimum_access_level=AccessLevel.READER,
+                )
+                if len(dependencies) != len(newly_added_dependency_ref_ids):
+                    raise InputValidationError(
+                        "Some of the big plans to depend on could not be found"
+                    )
+
         big_plan = big_plan.update(
             context.domain_context,
             name=args.name,
@@ -180,6 +213,7 @@ class BigPlanUpdateUseCase(
             difficulty=args.difficulty,
             actionable_date=args.actionable_date,
             due_date=args.due_date,
+            dependency_ref_ids=args.dependency_ref_ids,
         )
 
         await uow.get_for(BigPlan).save(big_plan)

--- a/src/core/jupiter/core/apps/big_plans/use_case/update.py
+++ b/src/core/jupiter/core/apps/big_plans/use_case/update.py
@@ -2,6 +2,10 @@
 
 from jupiter.core.apps.big_plans.name import BigPlanName
 from jupiter.core.apps.big_plans.root import BigPlan
+from jupiter.core.apps.big_plans.service.check_cycles import (
+    BigPlanCheckCyclesService,
+    BigPlanDependenciesHaveCyclesError,
+)
 from jupiter.core.apps.big_plans.status import BigPlanStatus
 from jupiter.core.apps.big_plans.sub.milestones.root import BigPlanMilestone
 from jupiter.core.apps.life_plan.sub.aspects.root import Aspect
@@ -10,6 +14,9 @@ from jupiter.core.apps.life_plan.sub.goals.root import Goal
 from jupiter.core.common.difficulty import Difficulty
 from jupiter.core.common.eisen import Eisen
 from jupiter.core.common.sub.access.access_level import AccessLevel
+from jupiter.core.common.sub.access.sub.status.service.check_for_acl import (
+    CheckForAclService,
+)
 from jupiter.core.common.sub.inbox_tasks.collection import InboxTaskCollection
 from jupiter.core.common.sub.inbox_tasks.root import InboxTask, InboxTaskRepository
 from jupiter.core.config import (
@@ -189,12 +196,16 @@ class BigPlanUpdateUseCase(
             if newly_added_dependency_ref_ids:
                 # Reader access is enough - a dependency points at another big
                 # plan, it doesn't change it.
-                dependencies = await self.find_all_entities(
+                await CheckForAclService().do_it_for_many(
                     uow,
-                    context.user.ref_id,
                     BigPlan,
                     newly_added_dependency_ref_ids,
-                    minimum_access_level=AccessLevel.READER,
+                    context.user.ref_id,
+                    AccessLevel.READER,
+                )
+                dependencies = await uow.get_for(BigPlan).find_all_generic(
+                    allow_archived=False,
+                    ref_id=newly_added_dependency_ref_ids,
                 )
                 if len(dependencies) != len(newly_added_dependency_ref_ids):
                     raise InputValidationError(
@@ -215,6 +226,17 @@ class BigPlanUpdateUseCase(
             due_date=args.due_date,
             dependency_ref_ids=args.dependency_ref_ids,
         )
+
+        if args.dependency_ref_ids.should_change:
+            # The check runs against the updated big plan, but before it is
+            # saved - a use case that raises part way through keeps whatever it
+            # has already written.
+            try:
+                await BigPlanCheckCyclesService().check_for_cycles(uow, big_plan)
+            except BigPlanDependenciesHaveCyclesError as err:
+                raise InputValidationError(
+                    "The big plan dependencies have cycles."
+                ) from err
 
         await uow.get_for(BigPlan).save(big_plan)
         await progress_reporter.mark_updated(big_plan)

--- a/src/core/jupiter/core/apps/life_plan/sub/aspects/service/reassign_linked_entities.py
+++ b/src/core/jupiter/core/apps/life_plan/sub/aspects/service/reassign_linked_entities.py
@@ -63,6 +63,7 @@ class AspectReassignLinkedEntitiesService:
                 difficulty=UpdateAction.do_nothing(),
                 actionable_date=UpdateAction.do_nothing(),
                 due_date=UpdateAction.do_nothing(),
+                dependency_ref_ids=UpdateAction.do_nothing(),
             )
             await uow.get_for(BigPlan).save(updated_big_plan)
             await progress_reporter.mark_updated(updated_big_plan)

--- a/src/core/jupiter/core/apps/life_plan/sub/chapters/service/unlink_entities.py
+++ b/src/core/jupiter/core/apps/life_plan/sub/chapters/service/unlink_entities.py
@@ -72,6 +72,7 @@ class ChapterUnlinkEntitiesService:
                 difficulty=UpdateAction.do_nothing(),
                 actionable_date=UpdateAction.do_nothing(),
                 due_date=UpdateAction.do_nothing(),
+                dependency_ref_ids=UpdateAction.do_nothing(),
             )
             await uow.get_for(BigPlan).save(updated_big_plan)
             await progress_reporter.mark_updated(updated_big_plan)

--- a/src/core/jupiter/core/apps/life_plan/sub/goals/service/unlink_entities.py
+++ b/src/core/jupiter/core/apps/life_plan/sub/goals/service/unlink_entities.py
@@ -71,6 +71,7 @@ class GoalUnlinkEntitiesService:
                 difficulty=UpdateAction.do_nothing(),
                 actionable_date=UpdateAction.do_nothing(),
                 due_date=UpdateAction.do_nothing(),
+                dependency_ref_ids=UpdateAction.do_nothing(),
             )
             await uow.get_for(BigPlan).save(updated_big_plan)
             await progress_reporter.mark_updated(updated_big_plan)

--- a/src/core/migrations/postgres/versions/2026_08_28_10_00_big_plan_dependencies.py
+++ b/src/core/migrations/postgres/versions/2026_08_28_10_00_big_plan_dependencies.py
@@ -1,0 +1,27 @@
+"""big plan dependencies
+
+Revision ID: b7c4e5f2a318
+Revises: a4b2c8d1e059
+Create Date: 2026-08-28 10:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "b7c4e5f2a318"
+down_revision = "a4b2c8d1e059"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE big_plan
+            ADD COLUMN dependency_ref_ids JSONB NOT NULL DEFAULT '[]'::jsonb
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE big_plan DROP COLUMN dependency_ref_ids")

--- a/src/core/migrations/sqlite/versions/2026_08_28_10_00_big_plan_dependencies.py
+++ b/src/core/migrations/sqlite/versions/2026_08_28_10_00_big_plan_dependencies.py
@@ -1,0 +1,32 @@
+"""big plan dependencies
+
+Revision ID: b7c4e5f2a318
+Revises: a4b2c8d1e059
+Create Date: 2026-08-28 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b7c4e5f2a318"
+down_revision = "a4b2c8d1e059"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("big_plan") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "dependency_ref_ids",
+                sa.JSON(),
+                nullable=False,
+                server_default="[]",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("big_plan") as batch_op:
+        batch_op.drop_column("dependency_ref_ids")

--- a/src/docs/material/concepts/big-plans.md
+++ b/src/docs/material/concepts/big-plans.md
@@ -70,9 +70,17 @@ A big plan can declare the other big plans it depends on. This is just a
 record of which pieces of work need to happen before this one can move
 forward - like "Sell the old house" before "Buy a new house".
 
+Dependencies can be set when a big plan is created, and changed afterwards
+from its properties, via a multi select box listing the other big plans in
+the workspace.
+
 A big plan can't depend on itself, and the same big plan can't be listed
-twice. Dependencies are edited from the big plan's properties, via a
-multi select box with all the other big plans in the workspace.
+twice. Dependencies also can't go in circles - if "Buy a new house" depends
+on "Sell the old house", then "Sell the old house" can't be made to depend
+on "Buy a new house", however long the chain between them is.
+
+Archiving or removing a big plan drops it from the dependencies of every
+big plan that pointed at it.
 
 ## Stats
 

--- a/src/docs/material/concepts/big-plans.md
+++ b/src/docs/material/concepts/big-plans.md
@@ -64,6 +64,16 @@ The milestone must occur before the start date and end date of the big plan
 ifthese exist. Once milestones are added, the start and end date can only be
 addedbefore the earliest milestone, or after the latest one, respectively.
 
+## Dependencies
+
+A big plan can declare the other big plans it depends on. This is just a
+record of which pieces of work need to happen before this one can move
+forward - like "Sell the old house" before "Buy a new house".
+
+A big plan can't depend on itself, and the same big plan can't be listed
+twice. Dependencies are edited from the big plan's properties, via a
+multi select box with all the other big plans in the workspace.
+
 ## Stats
 
 Big plans have a notion of progress associated with them, which is quantified by

--- a/src/webui/app/routes/app/workspace/apps/big-plans/$id.tsx
+++ b/src/webui/app/routes/app/workspace/apps/big-plans/$id.tsx
@@ -1,4 +1,5 @@
 import type {
+  BigPlanSummary,
   ChapterSummary,
   Contact,
   GoalSummary,
@@ -87,6 +88,10 @@ import {
   handleLoaderApiError,
 } from "@jupiter/core/infra/errors.server";
 import { accessStatusAllowsWriterOrAbove } from "#/core/common/sub/access/access-level";
+import {
+  fixSelectOutputEntityId,
+  selectZod,
+} from "@jupiter/core/common/select-form";
 
 import { useLoaderDataSafeForAnimation } from "~/rendering/use-loader-data-for-animation";
 import { basicShouldRevalidate } from "~/rendering/standard-should-revalidate";
@@ -120,6 +125,7 @@ const CommonParamsSchema = {
   difficulty: z.nativeEnum(Difficulty),
   actionableDate: z.string().optional(),
   dueDate: z.string().optional(),
+  dependencyRefIds: selectZod(z.string()),
 };
 
 const UpdateFormSchema = z.discriminatedUnion("intent", [
@@ -196,6 +202,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     include_chapters: true,
     include_goals: true,
     include_milestones: true,
+    include_big_plans: true,
   });
 
   const allTags = await apiClient.tags.tagFind({
@@ -248,6 +255,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       allGoals: summaryResponse.goals as Array<GoalSummary> | null,
       allMilestones:
         summaryResponse.milestones as Array<MilestoneSummary> | null,
+      allBigPlans: summaryResponse.big_plans as Array<BigPlanSummary> | null,
       allTags: allTags.tags as Array<Tag>,
       allContacts: allContacts.contacts as Array<Contact>,
       publishEntity: result.publish_entity ?? null,
@@ -350,6 +358,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
               form.dueDate !== undefined && form.dueDate !== ""
                 ? form.dueDate
                 : undefined,
+          },
+          dependency_ref_ids: {
+            should_change: true,
+            value: fixSelectOutputEntityId(form.dependencyRefIds) || [],
           },
         });
 
@@ -665,6 +677,7 @@ export default function BigPlan() {
           allChapters={loaderData.allChapters ?? []}
           allGoals={loaderData.allGoals ?? []}
           allMilestones={loaderData.allMilestones ?? []}
+          allBigPlans={loaderData.allBigPlans ?? []}
           allTags={loaderData.allTags}
           tags={loaderData.tags}
           allContacts={loaderData.allContacts}

--- a/src/webui/app/routes/app/workspace/apps/big-plans/new.tsx
+++ b/src/webui/app/routes/app/workspace/apps/big-plans/new.tsx
@@ -1,4 +1,5 @@
 import type {
+  BigPlanSummary,
   ChapterSummary,
   GoalSummary,
   LifePlan,
@@ -46,6 +47,11 @@ import {
   ActionSingle,
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
+import { BigPlanMultiSelect } from "@jupiter/core/apps/big_plans/component/multi-select";
+import {
+  fixSelectOutputEntityId,
+  selectZod,
+} from "@jupiter/core/common/select-form";
 import { LifePlanAssociations } from "@jupiter/core/apps/life_plan/components/life-plan-associations";
 import { findActiveChaptersForSuggestions } from "@jupiter/core/apps/life_plan/sub/chapters/root";
 import { TimePlanActivityFeasabilitySelect } from "@jupiter/core/apps/time_plans/sub/activity/component/feasability-select";
@@ -85,6 +91,7 @@ const CreateFormSchema = z.object({
   difficulty: z.nativeEnum(Difficulty),
   actionableDate: z.string().optional(),
   dueDate: z.string().optional(),
+  dependencyRefIds: selectZod(z.string()),
   timePlanActivityKind: z.nativeEnum(TimePlanActivityKind).optional(),
   timePlanActivityFeasability: z
     .nativeEnum(TimePlanActivityFeasability)
@@ -124,6 +131,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     include_chapters: true,
     include_goals: true,
     include_milestones: true,
+    include_big_plans: true,
   });
 
   return json({
@@ -135,6 +143,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     allChapters: summaryResponse.chapters as Array<ChapterSummary> | null,
     allGoals: summaryResponse.goals as Array<GoalSummary> | null,
     allMilestones: summaryResponse.milestones as Array<MilestoneSummary> | null,
+    allBigPlans: summaryResponse.big_plans as Array<BigPlanSummary> | null,
   });
 }
 
@@ -172,6 +181,7 @@ export async function action({ request }: ActionFunctionArgs) {
         form.dueDate !== undefined && form.dueDate !== ""
           ? form.dueDate
           : undefined,
+      dependency_ref_ids: fixSelectOutputEntityId(form.dependencyRefIds) || [],
     });
 
     if (isCreateAndAnother(form.intent)) {
@@ -308,6 +318,20 @@ export default function NewBigPlan() {
             <FieldError actionResult={actionData} fieldName="/goal_ref_id" />
           </FormControl>
         )}
+
+        <FormControl fullWidth>
+          <BigPlanMultiSelect
+            name="dependencyRefIds"
+            label="Depends On"
+            inputsEnabled={inputsEnabled}
+            disabled={!inputsEnabled}
+            allBigPlans={loaderData.allBigPlans ?? []}
+          />
+          <FieldError
+            actionResult={actionData}
+            fieldName="/dependency_ref_ids"
+          />
+        </FormControl>
 
         <FormControl fullWidth>
           <FormLabel id="eisen">Eisenhower</FormLabel>

--- a/src/webui/app/routes/app/workspace/apps/big-plans/update-status.tsx
+++ b/src/webui/app/routes/app/workspace/apps/big-plans/update-status.tsx
@@ -31,6 +31,7 @@ export async function action({ request }: ActionFunctionArgs) {
       difficulty: { should_change: false },
       actionable_date: { should_change: false },
       due_date: { should_change: false },
+      dependency_ref_ids: { should_change: false },
     });
 
     if (result.record_score_result) {

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id/$activityId.tsx
@@ -46,6 +46,10 @@ import {
   sortInboxTasksNaturally,
 } from "#/core/common/sub/inbox_tasks/root";
 import { BigPlanPropertiesEditor } from "@jupiter/core/apps/big_plans/component/properties-editor";
+import {
+  fixSelectOutputEntityId,
+  selectZod,
+} from "@jupiter/core/common/select-form";
 import { HabitPropertiesEditor } from "@jupiter/core/apps/habits/component/properties-editor";
 import { ChorePropertiesEditor } from "@jupiter/core/apps/chores/component/properties-editor";
 import { InboxTaskPropertiesEditor } from "@jupiter/core/common/sub/inbox_tasks/component/properties-editor";
@@ -114,6 +118,7 @@ const UpdateFormTargetBigPlanSchema = {
   targetBigPlanDifficulty: z.nativeEnum(Difficulty),
   targetBigPlanActionableDate: z.string().optional(),
   targetBigPlanDueDate: z.string().optional(),
+  targetBigPlanDependencyRefIds: selectZod(z.string()),
 };
 
 const UpdateFormTargetTodoTaskSchema = {
@@ -383,6 +388,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       allChapters: summaryResponse.chapters,
       allGoals: summaryResponse.goals,
       allMilestones: summaryResponse.milestones,
+      allBigPlans: summaryResponse.big_plans,
       allTags: allTags.tags,
       allContacts: allContacts.contacts,
       timePlanActivity: result.time_plan_activity,
@@ -720,6 +726,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
               form.targetBigPlanDueDate !== ""
                 ? form.targetBigPlanDueDate
                 : undefined,
+          },
+          dependency_ref_ids: {
+            should_change: true,
+            value:
+              fixSelectOutputEntityId(form.targetBigPlanDependencyRefIds) || [],
           },
         });
 
@@ -1475,6 +1486,7 @@ export default function TimePlanActivity() {
               allChapters={loaderData.allChapters ?? []}
               allGoals={loaderData.allGoals ?? []}
               allMilestones={loaderData.allMilestones ?? []}
+              allBigPlans={loaderData.allBigPlans ?? []}
               inputsEnabled={
                 inputsEnabled && !loaderData.targetBigPlan.archived
               }

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
@@ -1,4 +1,5 @@
 import type {
+  BigPlanSummary,
   ChapterSummary,
   GoalSummary,
   InboxTask,
@@ -50,6 +51,10 @@ import {
   timeEventInDayBlockParamsToUtc,
 } from "@jupiter/core/common/sub/time_events/time-event";
 import { BigPlanPropertiesEditor } from "@jupiter/core/apps/big_plans/component/properties-editor";
+import {
+  fixSelectOutputEntityId,
+  selectZod,
+} from "@jupiter/core/common/select-form";
 import { InboxTaskPropertiesEditor } from "@jupiter/core/common/sub/inbox_tasks/component/properties-editor";
 import {
   isInboxTaskCoreFieldEditable,
@@ -97,6 +102,7 @@ const UpdateFormBigPlanSchema = {
   bigPlanDifficulty: z.nativeEnum(Difficulty),
   bigPlanActionableDate: z.string().optional(),
   bigPlanDueDate: z.string().optional(),
+  bigPlanDependencyRefIds: selectZod(z.string()),
 };
 
 const UpdateFormTodoTaskSchema = {
@@ -373,6 +379,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       allChapters: summaryResponse.chapters as Array<ChapterSummary>,
       allGoals: summaryResponse.goals as Array<GoalSummary>,
       allMilestones: summaryResponse.milestones as Array<MilestoneSummary>,
+      allBigPlans: summaryResponse.big_plans as Array<BigPlanSummary>,
       inDayBlock: response.in_day_block,
       scheduleEvent: response.schedule_event,
       bigPlan: bigPlan,
@@ -526,6 +533,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
               form.bigPlanDueDate !== undefined && form.bigPlanDueDate !== ""
                 ? form.bigPlanDueDate
                 : undefined,
+          },
+          dependency_ref_ids: {
+            should_change: true,
+            value: fixSelectOutputEntityId(form.bigPlanDependencyRefIds) || [],
           },
         });
 
@@ -1133,6 +1144,7 @@ export default function TimeEventInDayBlockViewOne() {
           allChapters={loaderData.allChapters}
           allGoals={loaderData.allGoals}
           allMilestones={loaderData.allMilestones}
+          allBigPlans={loaderData.allBigPlans ?? []}
           inputsEnabled={inputsEnabled && !loaderData.bigPlan.archived}
           entityOwner={loaderData.bigPlanInfo?.owner}
           bigPlan={loaderData.bigPlan}


### PR DESCRIPTION
A big plan can now declare the other big plans it depends on. On the model
side this is a plain list of entity ids on the big plan, persisted as a JSON
column and defaulting to empty on creation.

- `BigPlan.dependency_ref_ids`, normalised on update: duplicates are dropped
  and a big plan cannot depend on itself.
- `BigPlanUpdateArgs.dependency_ref_ids` takes the new list. Newly added
  dependencies are checked for existence and reader access; ones already on
  the big plan are left alone so an archived or removed dependency doesn't
  block saving - dropping it is enough.
- Migrations for sqlite and postgres.
- A `BigPlanMultiSelect` component, wired into the big plan properties
  editor and the three WebUI routes that edit a big plan. A selected big
  plan missing from the workspace summaries still gets an option, so saving
  never silently drops it.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LcEC8Dw5iEdiDNJwkpix7J