### PR TITLE
Fix the big plan -> project rename for existing databases

### DIFF
--- a/src/core/migrations/chain.test.py
+++ b/src/core/migrations/chain.test.py
@@ -1,0 +1,171 @@
+"""Tests that the SQLite migration chain runs end to end.
+
+The ``BigPlan`` -> ``Project`` rename rewrote a few already-released migrations
+in place, which is only safe as long as every revision still works against the
+schema that actually exists when it runs. These tests walk the chain for both
+populations: a database created from scratch, and one that predates the rename.
+"""
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_ALEMBIC_INI = _REPO_ROOT / "src" / "core" / "migrations" / "alembic.sqlite.ini"
+_MIGRATIONS = _REPO_ROOT / "src" / "core" / "migrations" / "sqlite"
+
+# The last revision before the dependencies migration, which is where a database
+# that has not been touched since before the rename sits.
+_BEFORE_DEPENDENCIES = "a4b2c8d1e059"
+
+_PRE_RENAME_TABLES = (
+    ("project_collection", "big_plan_collection"),
+    ("project", "big_plan"),
+    ("project_stats", "big_plan_stats"),
+    ("project_milestone", "big_plan_milestone"),
+)
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Iterator[Path]:
+    """A throwaway SQLite database file."""
+    yield tmp_path / "test.sqlite"
+
+
+def _upgrade(db_path: Path, target: str) -> None:
+    config = Config(str(_ALEMBIC_INI))
+    config.set_main_option("script_location", str(_MIGRATIONS))
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as connection:
+            config.attributes["connection"] = connection
+            command.upgrade(config, target)
+    finally:
+        engine.dispose()
+
+
+def _tables(db_path: Path) -> set[str]:
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as connection:
+            return set(sa.inspect(connection).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as connection:
+            return {c["name"] for c in sa.inspect(connection).get_columns(table)}
+    finally:
+        engine.dispose()
+
+
+def _rewind_to_pre_rename_names(db_path: Path) -> None:
+    """Put the project tables back under their pre-rename names.
+
+    The pre-rename migration files no longer exist in the repository - the
+    rename rewrote them - so a database from before the rename is emulated by
+    walking the chain to just before the dependencies migration and undoing the
+    naming there.
+    """
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as connection:
+            for new_name, old_name in _PRE_RENAME_TABLES:
+                connection.execute(
+                    sa.text(f'ALTER TABLE "{new_name}" RENAME TO "{old_name}"')
+                )
+            connection.execute(
+                sa.text(
+                    'ALTER TABLE "big_plan" '
+                    'RENAME COLUMN "project_collection_ref_id" '
+                    'TO "big_plan_collection_ref_id"'
+                )
+            )
+    finally:
+        engine.dispose()
+
+
+def test_migration_chain_runs_on_a_fresh_database(db_path: Path) -> None:
+    """A database created from scratch reaches head."""
+    _upgrade(db_path, "head")
+
+    tables = _tables(db_path)
+    assert "project" in tables
+    assert "big_plan" not in tables
+    assert "dependency_ref_ids" in _columns(db_path, "project")
+
+
+def test_migration_chain_runs_on_a_pre_rename_database(db_path: Path) -> None:
+    """A database that still has the big_plan tables reaches head too.
+
+    This is the case the rename broke: the dependencies migration runs one
+    revision before the rename, so at that point the table is still called
+    ``big_plan`` on any database that has been around for a while.
+    """
+    _upgrade(db_path, _BEFORE_DEPENDENCIES)
+    _rewind_to_pre_rename_names(db_path)
+    assert "big_plan" in _tables(db_path)
+
+    _upgrade(db_path, "head")
+
+    tables = _tables(db_path)
+    assert "project" in tables
+    assert "big_plan" not in tables
+    assert "dependency_ref_ids" in _columns(db_path, "project")
+
+
+def test_follow_up_rename_rewrites_the_columns_the_rename_missed(
+    db_path: Path,
+) -> None:
+    """The columns holding the old name as data are rewritten."""
+    _upgrade(db_path, "f3a91c62d70e")
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                sa.text(
+                    "INSERT INTO time_plan_activity "
+                    "(ref_id, version, archived, created_time, last_modified_time, "
+                    " time_plan_ref_id, name, target, kind, feasability) "
+                    "VALUES (1, 1, 0, '2026-08-29', '2026-08-29', 1, "
+                    " 'Work on big-plan 1', 'BigPlan:std:1', 'finish', 'must-do')"
+                )
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO journal_stats "
+                    "(created_time, last_modified_time, journal_ref_id, report) "
+                    "VALUES ('2026-08-29', '2026-08-29', 1, "
+                    """ '{"sources": ["BigPlan:std"], "global_big_plans_summary": {}}')"""
+                )
+            )
+    finally:
+        engine.dispose()
+
+    _upgrade(db_path, "head")
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as connection:
+            name, target = connection.execute(
+                sa.text("SELECT name, target FROM time_plan_activity WHERE ref_id = 1")
+            ).one()
+            report = connection.execute(
+                sa.text("SELECT report FROM journal_stats WHERE journal_ref_id = 1")
+            ).scalar_one()
+    finally:
+        engine.dispose()
+
+    assert target == "Project:std:1"
+    assert name == "Work on project 1"
+    assert not re.search(r"BigPlan|big_plan|big-plan", str(report))
+    assert "global_projects_summary" in str(report)

--- a/src/core/migrations/postgres/versions/2026_06_13_22_16_backfill_owner_access_grants_and_.py
+++ b/src/core/migrations/postgres/versions/2026_06_13_22_16_backfill_owner_access_grants_and_.py
@@ -128,6 +128,33 @@ PARENT_CHAIN = {
 }
 
 
+def _use_pre_rename_names_if_needed(inspector: sa.engine.reflection.Inspector) -> None:
+    """Fall back to the pre-rename table names when the database still has them.
+
+    ``BigPlan`` only becomes ``Project`` in a much later revision
+    (``f3a91c62d70e``). A database created fresh from the initial reset already
+    has ``project`` by the time this runs, but one that predates the rename
+    still has ``big_plan`` - and skipping it here would leave every big plan
+    without an owner grant once the rename does happen.
+    """
+    global CROWN_ENTITIES, PARENT_CHAIN
+
+    if inspector.has_table("project") or not inspector.has_table("big_plan"):
+        return
+
+    CROWN_ENTITIES = tuple(
+        ("BigPlan", "big_plan") if entry == ("Project", "project") else entry
+        for entry in CROWN_ENTITIES
+    )
+    PARENT_CHAIN = {
+        key: value
+        for key, value in PARENT_CHAIN.items()
+        if key not in ("project", "project_collection")
+    }
+    PARENT_CHAIN["big_plan"] = ("big_plan_collection_ref_id", "big_plan_collection")
+    PARENT_CHAIN["big_plan_collection"] = ("workspace_ref_id", "workspace")
+
+
 def _format_duration(seconds: float) -> str:
     """Human-readable duration for migration progress logs."""
     if seconds < 60:
@@ -282,6 +309,7 @@ def upgrade():
     migration_start = time.monotonic()
     conn = op.get_bind()
     inspector = sa.inspect(conn)
+    _use_pre_rename_names_if_needed(inspector)
     postgres = conn.dialect.name == "postgresql"
 
     tables_to_process: list[tuple[str, str, int]] = []

--- a/src/core/migrations/postgres/versions/2026_08_02_10_11_backfill_missing_owner_access_grants.py
+++ b/src/core/migrations/postgres/versions/2026_08_02_10_11_backfill_missing_owner_access_grants.py
@@ -130,6 +130,33 @@ PARENT_CHAIN = {
 }
 
 
+def _use_pre_rename_names_if_needed(inspector: sa.engine.reflection.Inspector) -> None:
+    """Fall back to the pre-rename table names when the database still has them.
+
+    ``BigPlan`` only becomes ``Project`` in a much later revision
+    (``f3a91c62d70e``). A database created fresh from the initial reset already
+    has ``project`` by the time this runs, but one that predates the rename
+    still has ``big_plan`` - and skipping it here would leave every big plan
+    without an owner grant once the rename does happen.
+    """
+    global CROWN_ENTITIES, PARENT_CHAIN
+
+    if inspector.has_table("project") or not inspector.has_table("big_plan"):
+        return
+
+    CROWN_ENTITIES = tuple(
+        ("BigPlan", "big_plan") if entry == ("Project", "project") else entry
+        for entry in CROWN_ENTITIES
+    )
+    PARENT_CHAIN = {
+        key: value
+        for key, value in PARENT_CHAIN.items()
+        if key not in ("project", "project_collection")
+    }
+    PARENT_CHAIN["big_plan"] = ("big_plan_collection_ref_id", "big_plan_collection")
+    PARENT_CHAIN["big_plan_collection"] = ("workspace_ref_id", "workspace")
+
+
 def _format_duration(seconds: float) -> str:
     """Human-readable duration for migration progress logs."""
     if seconds < 60:
@@ -298,6 +325,7 @@ def upgrade():
     migration_start = time.monotonic()
     conn = op.get_bind()
     inspector = sa.inspect(conn)
+    _use_pre_rename_names_if_needed(inspector)
     postgres = conn.dialect.name == "postgresql"
 
     grants_created = 0

--- a/src/core/migrations/postgres/versions/2026_08_28_10_00_project_dependencies.py
+++ b/src/core/migrations/postgres/versions/2026_08_28_10_00_project_dependencies.py
@@ -4,8 +4,20 @@ Revision ID: b7c4e5f2a318
 Revises: a4b2c8d1e059
 Create Date: 2026-08-28 10:00:00.000000
 
+This revision predates the ``BigPlan`` -> ``Project`` rename (``f3a91c62d70e``),
+so the table it has to touch depends on where the database is coming from:
+
+* a database created fresh from the initial reset migration already has
+  ``project``, because that migration was rewritten to use the new names;
+* a database that has been around since before the rename still has
+  ``big_plan`` at this point in the chain, and only gets renamed one
+  revision later.
+
+So the table is resolved at run time rather than hardcoded. Hardcoding either
+name breaks one of the two populations.
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 revision = "b7c4e5f2a318"
@@ -14,14 +26,37 @@ branch_labels = None
 depends_on = None
 
 
+def _resolve_table(conn: sa.engine.Connection) -> str | None:
+    """The project table under whichever name it has at this revision."""
+    tables = set(sa.inspect(conn).get_table_names())
+    for candidate in ("project", "big_plan"):
+        if candidate in tables:
+            return candidate
+    return None
+
+
+def _quote(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
 def upgrade() -> None:
+    conn = op.get_bind()
+    table = _resolve_table(conn)
+    if table is None:
+        return
+
     op.execute(
-        """
-        ALTER TABLE project
-            ADD COLUMN dependency_ref_ids JSONB NOT NULL DEFAULT '[]'::jsonb
+        f"""
+        ALTER TABLE {_quote(table)}
+            ADD COLUMN IF NOT EXISTS dependency_ref_ids JSONB NOT NULL DEFAULT '[]'::jsonb
         """
     )
 
 
 def downgrade() -> None:
-    op.execute("ALTER TABLE project DROP COLUMN dependency_ref_ids")
+    conn = op.get_bind()
+    table = _resolve_table(conn)
+    if table is None:
+        return
+
+    op.execute(f"ALTER TABLE {_quote(table)} DROP COLUMN IF EXISTS dependency_ref_ids")

--- a/src/core/migrations/postgres/versions/2026_08_29_18_00_finish_rename_big_plan_to_project.py
+++ b/src/core/migrations/postgres/versions/2026_08_29_18_00_finish_rename_big_plan_to_project.py
@@ -1,0 +1,184 @@
+"""finish rename big plan to project
+
+Revision ID: c1d5e93a7b26
+Revises: f3a91c62d70e
+Create Date: 2026-08-29 18:00:00.000000
+
+``f3a91c62d70e`` renamed the ``BigPlan`` entity family to ``Project``, but it
+missed a handful of columns that also carry the old name as *data*:
+
+* ``journal_stats.report`` is a serialized ``ReportPeriodResult``. Its field
+  names changed with the rename (``global_big_plans_summary`` ->
+  ``global_projects_summary``, ``per_big_plan_breakdown`` ->
+  ``per_project_breakdown``, ``not_done_big_plans`` -> ``not_done_projects``,
+  ...) and it embeds ``BigPlan:std`` source tags and ``big_plan_cnt`` counters.
+  Left alone, every journal that has stats fails to load with
+  ``Expected value of type ReportPeriodResult to have field
+  global_projects_summary``.
+
+* ``time_plan_activity.target`` holds an ``EntityLink`` wire string such as
+  ``BigPlan:std:12``, not the kebab-case ``big-plan`` the previous migration
+  matched on, so it was never rewritten. Left alone, an activity that targets a
+  project silently resolves to nothing.
+
+* ``mutation_invocation_record.name`` / ``.args`` keep the undo/redo history of
+  each invocation, with names like ``BigPlanCreateUseCase`` and args that embed
+  the old identifiers.
+
+* ``time_plan_activity.name`` and ``stats_log_entry.name`` are generated
+  display strings ("Work on big-plan 12", "Stats Log Entry for ...,big-plans,
+  ... at 2026-08-29") that still read as the old name.
+
+Every step is guarded on the table and column being present and is a plain
+token substitution, so this is idempotent and a no-op on a database that has
+nothing left to rewrite.
+
+As in the original rename, user-authored free text is left alone: only the
+separator-bearing forms (``BigPlan``, ``big_plan``, ``big-plan``) are rewritten,
+never the prose form ``big plan``.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1d5e93a7b26"
+down_revision = "f3a91c62d70e"
+branch_labels = None
+depends_on = None
+
+
+# Columns holding an entity type name ("BigPlan") or an EntityLink wire string
+# ("BigPlan:std:12"), missed by the original rename.
+PASCAL_COLUMNS: list[tuple[str, str]] = [
+    ("time_plan_activity", "target"),
+    ("mutation_invocation_record", "name"),
+]
+
+# Generated display strings that embed the kebab-case name. Longest first, so
+# the plural form is not left as "projects" + a dangling "s".
+TEXT_COLUMN_TOKENS: list[tuple[str, str, list[tuple[str, str]]]] = [
+    (
+        "time_plan_activity",
+        "name",
+        [("big-plans", "projects"), ("big-plan", "project")],
+    ),
+    ("stats_log_entry", "name", [("big-plans", "projects"), ("big-plan", "project")]),
+]
+
+# JSON columns that can embed any of the above forms, missed by the original
+# rename.
+JSON_COLUMNS: list[tuple[str, str]] = [
+    ("journal_stats", "report"),
+    ("mutation_invocation_record", "args"),
+]
+
+# Applied to raw JSON text, longest first. The prose form "big plan" is
+# intentionally absent so user-authored names are never touched.
+JSON_TOKENS: list[tuple[str, str]] = [
+    ("key-big-plans-progress", "key-projects-progress"),
+    ("BigPlan", "Project"),
+    ("big_plans", "projects"),
+    ("big_plan", "project"),
+    ("big-plans", "projects"),
+    ("big-plan", "project"),
+]
+
+
+def _tables(conn: sa.engine.Connection) -> set[str]:
+    return set(sa.inspect(conn).get_table_names())
+
+
+def _columns(conn: sa.engine.Connection, table: str) -> set[str]:
+    try:
+        return {c["name"] for c in sa.inspect(conn).get_columns(table)}
+    except sa.exc.NoSuchTableError:
+        return set()
+
+
+def _quote(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _replace_in_columns(
+    conn: sa.engine.Connection,
+    columns: list[tuple[str, str]],
+    old: str,
+    new: str,
+) -> None:
+    tables = _tables(conn)
+    for table, column in columns:
+        if table not in tables or column not in _columns(conn, table):
+            continue
+        op.execute(
+            sa.text(
+                f"UPDATE {_quote(table)} "
+                f"SET {_quote(column)} = REPLACE({_quote(column)}, :old, :new) "
+                f"WHERE {_quote(column)} LIKE :pattern"
+            ).bindparams(old=old, new=new, pattern=f"%{old}%")
+        )
+
+
+def _replace_tokens_in_text_columns(
+    conn: sa.engine.Connection,
+    specs: list[tuple[str, str, list[tuple[str, str]]]],
+) -> None:
+    for table, column, tokens in specs:
+        for old, new in tokens:
+            _replace_in_columns(conn, [(table, column)], old, new)
+
+
+def _rewrite_json_columns(
+    conn: sa.engine.Connection,
+    columns: list[tuple[str, str]],
+    tokens: list[tuple[str, str]],
+) -> None:
+    """Rewrite embedded identifiers inside JSON columns.
+
+    Done as a text substitution on the serialized JSON: the tokens are plain
+    ASCII and only ever appear inside JSON string values or keys, so this
+    cannot change the document structure.
+    """
+    tables = _tables(conn)
+    is_postgres = conn.dialect.name == "postgresql"
+    for table, column in columns:
+        if table not in tables or column not in _columns(conn, table):
+            continue
+        quoted = _quote(column)
+        as_text = f"CAST({quoted} AS TEXT)" if is_postgres else quoted
+        for old, new in tokens:
+            replaced = f"REPLACE({as_text}, :old, :new)"
+            if is_postgres:
+                replaced = f"CAST({replaced} AS JSONB)"
+            op.execute(
+                sa.text(
+                    f"UPDATE {_quote(table)} SET {quoted} = {replaced} "
+                    f"WHERE {as_text} LIKE :pattern"
+                ).bindparams(old=old, new=new, pattern=f"%{old}%")
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    _replace_in_columns(conn, PASCAL_COLUMNS, "BigPlan", "Project")
+    _replace_tokens_in_text_columns(conn, TEXT_COLUMN_TOKENS)
+    _rewrite_json_columns(conn, JSON_COLUMNS, JSON_TOKENS)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    _rewrite_json_columns(
+        conn, JSON_COLUMNS, [(new, old) for old, new in reversed(JSON_TOKENS)]
+    )
+    _replace_tokens_in_text_columns(
+        conn,
+        [
+            (table, column, [(new, old) for old, new in reversed(tokens)])
+            for table, column, tokens in TEXT_COLUMN_TOKENS
+        ],
+    )
+    _replace_in_columns(conn, PASCAL_COLUMNS, "Project", "BigPlan")

--- a/src/core/migrations/sqlite/versions/2026_06_13_22_16_backfill_owner_access_grants_and_.py
+++ b/src/core/migrations/sqlite/versions/2026_06_13_22_16_backfill_owner_access_grants_and_.py
@@ -128,6 +128,33 @@ PARENT_CHAIN = {
 }
 
 
+def _use_pre_rename_names_if_needed(inspector: sa.engine.reflection.Inspector) -> None:
+    """Fall back to the pre-rename table names when the database still has them.
+
+    ``BigPlan`` only becomes ``Project`` in a much later revision
+    (``f3a91c62d70e``). A database created fresh from the initial reset already
+    has ``project`` by the time this runs, but one that predates the rename
+    still has ``big_plan`` - and skipping it here would leave every big plan
+    without an owner grant once the rename does happen.
+    """
+    global CROWN_ENTITIES, PARENT_CHAIN
+
+    if inspector.has_table("project") or not inspector.has_table("big_plan"):
+        return
+
+    CROWN_ENTITIES = tuple(
+        ("BigPlan", "big_plan") if entry == ("Project", "project") else entry
+        for entry in CROWN_ENTITIES
+    )
+    PARENT_CHAIN = {
+        key: value
+        for key, value in PARENT_CHAIN.items()
+        if key not in ("project", "project_collection")
+    }
+    PARENT_CHAIN["big_plan"] = ("big_plan_collection_ref_id", "big_plan_collection")
+    PARENT_CHAIN["big_plan_collection"] = ("workspace_ref_id", "workspace")
+
+
 def _format_duration(seconds: float) -> str:
     """Human-readable duration for migration progress logs."""
     if seconds < 60:
@@ -282,6 +309,7 @@ def upgrade():
     migration_start = time.monotonic()
     conn = op.get_bind()
     inspector = sa.inspect(conn)
+    _use_pre_rename_names_if_needed(inspector)
     postgres = conn.dialect.name == "postgresql"
 
     tables_to_process: list[tuple[str, str, int]] = []

--- a/src/core/migrations/sqlite/versions/2026_08_02_10_11_backfill_missing_owner_access_grants.py
+++ b/src/core/migrations/sqlite/versions/2026_08_02_10_11_backfill_missing_owner_access_grants.py
@@ -130,6 +130,33 @@ PARENT_CHAIN = {
 }
 
 
+def _use_pre_rename_names_if_needed(inspector: sa.engine.reflection.Inspector) -> None:
+    """Fall back to the pre-rename table names when the database still has them.
+
+    ``BigPlan`` only becomes ``Project`` in a much later revision
+    (``f3a91c62d70e``). A database created fresh from the initial reset already
+    has ``project`` by the time this runs, but one that predates the rename
+    still has ``big_plan`` - and skipping it here would leave every big plan
+    without an owner grant once the rename does happen.
+    """
+    global CROWN_ENTITIES, PARENT_CHAIN
+
+    if inspector.has_table("project") or not inspector.has_table("big_plan"):
+        return
+
+    CROWN_ENTITIES = tuple(
+        ("BigPlan", "big_plan") if entry == ("Project", "project") else entry
+        for entry in CROWN_ENTITIES
+    )
+    PARENT_CHAIN = {
+        key: value
+        for key, value in PARENT_CHAIN.items()
+        if key not in ("project", "project_collection")
+    }
+    PARENT_CHAIN["big_plan"] = ("big_plan_collection_ref_id", "big_plan_collection")
+    PARENT_CHAIN["big_plan_collection"] = ("workspace_ref_id", "workspace")
+
+
 def _format_duration(seconds: float) -> str:
     """Human-readable duration for migration progress logs."""
     if seconds < 60:
@@ -298,6 +325,7 @@ def upgrade():
     migration_start = time.monotonic()
     conn = op.get_bind()
     inspector = sa.inspect(conn)
+    _use_pre_rename_names_if_needed(inspector)
     postgres = conn.dialect.name == "postgresql"
 
     grants_created = 0

--- a/src/core/migrations/sqlite/versions/2026_08_28_10_00_project_dependencies.py
+++ b/src/core/migrations/sqlite/versions/2026_08_28_10_00_project_dependencies.py
@@ -4,6 +4,17 @@ Revision ID: b7c4e5f2a318
 Revises: a4b2c8d1e059
 Create Date: 2026-08-28 10:00:00.000000
 
+This revision predates the ``BigPlan`` -> ``Project`` rename (``f3a91c62d70e``),
+so the table it has to touch depends on where the database is coming from:
+
+* a database created fresh from the initial reset migration already has
+  ``project``, because that migration was rewritten to use the new names;
+* a database that has been around since before the rename still has
+  ``big_plan`` at this point in the chain, and only gets renamed one
+  revision later.
+
+So the table is resolved at run time rather than hardcoded. Hardcoding either
+name breaks one of the two populations.
 """
 
 import sqlalchemy as sa
@@ -15,8 +26,26 @@ branch_labels = None
 depends_on = None
 
 
+def _resolve_table(conn: sa.engine.Connection) -> str | None:
+    """The project table under whichever name it has at this revision."""
+    tables = set(sa.inspect(conn).get_table_names())
+    for candidate in ("project", "big_plan"):
+        if candidate in tables:
+            return candidate
+    return None
+
+
+def _columns(conn: sa.engine.Connection, table: str) -> set[str]:
+    return {c["name"] for c in sa.inspect(conn).get_columns(table)}
+
+
 def upgrade() -> None:
-    with op.batch_alter_table("project") as batch_op:
+    conn = op.get_bind()
+    table = _resolve_table(conn)
+    if table is None or "dependency_ref_ids" in _columns(conn, table):
+        return
+
+    with op.batch_alter_table(table) as batch_op:
         batch_op.add_column(
             sa.Column(
                 "dependency_ref_ids",
@@ -28,5 +57,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("project") as batch_op:
+    conn = op.get_bind()
+    table = _resolve_table(conn)
+    if table is None or "dependency_ref_ids" not in _columns(conn, table):
+        return
+
+    with op.batch_alter_table(table) as batch_op:
         batch_op.drop_column("dependency_ref_ids")

--- a/src/core/migrations/sqlite/versions/2026_08_29_18_00_finish_rename_big_plan_to_project.py
+++ b/src/core/migrations/sqlite/versions/2026_08_29_18_00_finish_rename_big_plan_to_project.py
@@ -1,0 +1,184 @@
+"""finish rename big plan to project
+
+Revision ID: c1d5e93a7b26
+Revises: f3a91c62d70e
+Create Date: 2026-08-29 18:00:00.000000
+
+``f3a91c62d70e`` renamed the ``BigPlan`` entity family to ``Project``, but it
+missed a handful of columns that also carry the old name as *data*:
+
+* ``journal_stats.report`` is a serialized ``ReportPeriodResult``. Its field
+  names changed with the rename (``global_big_plans_summary`` ->
+  ``global_projects_summary``, ``per_big_plan_breakdown`` ->
+  ``per_project_breakdown``, ``not_done_big_plans`` -> ``not_done_projects``,
+  ...) and it embeds ``BigPlan:std`` source tags and ``big_plan_cnt`` counters.
+  Left alone, every journal that has stats fails to load with
+  ``Expected value of type ReportPeriodResult to have field
+  global_projects_summary``.
+
+* ``time_plan_activity.target`` holds an ``EntityLink`` wire string such as
+  ``BigPlan:std:12``, not the kebab-case ``big-plan`` the previous migration
+  matched on, so it was never rewritten. Left alone, an activity that targets a
+  project silently resolves to nothing.
+
+* ``mutation_invocation_record.name`` / ``.args`` keep the undo/redo history of
+  each invocation, with names like ``BigPlanCreateUseCase`` and args that embed
+  the old identifiers.
+
+* ``time_plan_activity.name`` and ``stats_log_entry.name`` are generated
+  display strings ("Work on big-plan 12", "Stats Log Entry for ...,big-plans,
+  ... at 2026-08-29") that still read as the old name.
+
+Every step is guarded on the table and column being present and is a plain
+token substitution, so this is idempotent and a no-op on a database that has
+nothing left to rewrite.
+
+As in the original rename, user-authored free text is left alone: only the
+separator-bearing forms (``BigPlan``, ``big_plan``, ``big-plan``) are rewritten,
+never the prose form ``big plan``.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1d5e93a7b26"
+down_revision = "f3a91c62d70e"
+branch_labels = None
+depends_on = None
+
+
+# Columns holding an entity type name ("BigPlan") or an EntityLink wire string
+# ("BigPlan:std:12"), missed by the original rename.
+PASCAL_COLUMNS: list[tuple[str, str]] = [
+    ("time_plan_activity", "target"),
+    ("mutation_invocation_record", "name"),
+]
+
+# Generated display strings that embed the kebab-case name. Longest first, so
+# the plural form is not left as "projects" + a dangling "s".
+TEXT_COLUMN_TOKENS: list[tuple[str, str, list[tuple[str, str]]]] = [
+    (
+        "time_plan_activity",
+        "name",
+        [("big-plans", "projects"), ("big-plan", "project")],
+    ),
+    ("stats_log_entry", "name", [("big-plans", "projects"), ("big-plan", "project")]),
+]
+
+# JSON columns that can embed any of the above forms, missed by the original
+# rename.
+JSON_COLUMNS: list[tuple[str, str]] = [
+    ("journal_stats", "report"),
+    ("mutation_invocation_record", "args"),
+]
+
+# Applied to raw JSON text, longest first. The prose form "big plan" is
+# intentionally absent so user-authored names are never touched.
+JSON_TOKENS: list[tuple[str, str]] = [
+    ("key-big-plans-progress", "key-projects-progress"),
+    ("BigPlan", "Project"),
+    ("big_plans", "projects"),
+    ("big_plan", "project"),
+    ("big-plans", "projects"),
+    ("big-plan", "project"),
+]
+
+
+def _tables(conn: sa.engine.Connection) -> set[str]:
+    return set(sa.inspect(conn).get_table_names())
+
+
+def _columns(conn: sa.engine.Connection, table: str) -> set[str]:
+    try:
+        return {c["name"] for c in sa.inspect(conn).get_columns(table)}
+    except sa.exc.NoSuchTableError:
+        return set()
+
+
+def _quote(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _replace_in_columns(
+    conn: sa.engine.Connection,
+    columns: list[tuple[str, str]],
+    old: str,
+    new: str,
+) -> None:
+    tables = _tables(conn)
+    for table, column in columns:
+        if table not in tables or column not in _columns(conn, table):
+            continue
+        op.execute(
+            sa.text(
+                f"UPDATE {_quote(table)} "
+                f"SET {_quote(column)} = REPLACE({_quote(column)}, :old, :new) "
+                f"WHERE {_quote(column)} LIKE :pattern"
+            ).bindparams(old=old, new=new, pattern=f"%{old}%")
+        )
+
+
+def _replace_tokens_in_text_columns(
+    conn: sa.engine.Connection,
+    specs: list[tuple[str, str, list[tuple[str, str]]]],
+) -> None:
+    for table, column, tokens in specs:
+        for old, new in tokens:
+            _replace_in_columns(conn, [(table, column)], old, new)
+
+
+def _rewrite_json_columns(
+    conn: sa.engine.Connection,
+    columns: list[tuple[str, str]],
+    tokens: list[tuple[str, str]],
+) -> None:
+    """Rewrite embedded identifiers inside JSON columns.
+
+    Done as a text substitution on the serialized JSON: the tokens are plain
+    ASCII and only ever appear inside JSON string values or keys, so this
+    cannot change the document structure.
+    """
+    tables = _tables(conn)
+    is_postgres = conn.dialect.name == "postgresql"
+    for table, column in columns:
+        if table not in tables or column not in _columns(conn, table):
+            continue
+        quoted = _quote(column)
+        as_text = f"CAST({quoted} AS TEXT)" if is_postgres else quoted
+        for old, new in tokens:
+            replaced = f"REPLACE({as_text}, :old, :new)"
+            if is_postgres:
+                replaced = f"CAST({replaced} AS JSONB)"
+            op.execute(
+                sa.text(
+                    f"UPDATE {_quote(table)} SET {quoted} = {replaced} "
+                    f"WHERE {as_text} LIKE :pattern"
+                ).bindparams(old=old, new=new, pattern=f"%{old}%")
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    _replace_in_columns(conn, PASCAL_COLUMNS, "BigPlan", "Project")
+    _replace_tokens_in_text_columns(conn, TEXT_COLUMN_TOKENS)
+    _rewrite_json_columns(conn, JSON_COLUMNS, JSON_TOKENS)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    _rewrite_json_columns(
+        conn, JSON_COLUMNS, [(new, old) for old, new in reversed(JSON_TOKENS)]
+    )
+    _replace_tokens_in_text_columns(
+        conn,
+        [
+            (table, column, [(new, old) for old, new in reversed(tokens)])
+            for table, column, tokens in TEXT_COLUMN_TOKENS
+        ],
+    )
+    _replace_in_columns(conn, PASCAL_COLUMNS, "Project", "BigPlan")


### PR DESCRIPTION
The rename PR rewrote already-released migrations in place, which broke
upgrades for any database that was not already at the newest revision, and
it also missed several columns that store the old name as data.

Migration chain
- The dependencies migration (b7c4e5f2a318) was rewritten to alter table
  "project", but it runs one revision *before* the rename, so on any
  database older than 2026-08-28 the table is still "big_plan" and the
  upgrade dies with "no such table: project". Since the connection's
  prepare() propagates that, the webapi never starts. It now resolves the
  table at run time, which works for both a fresh database (already
  "project") and an older one (still "big_plan").
- The two owner-access-grant backfills were rewritten the same way. They
  skip missing tables rather than failing, so on an older database they
  silently left every big plan without an owner grant. They now fall back
  to the pre-rename names when those are what the database has.

Data the rename missed (new migration c1d5e93a7b26)
- journal_stats.report is a serialized ReportPeriodResult whose field names
  changed with the rename, so every journal with stats failed to load with
  "Expected value of type ReportPeriodResult to have field
  global_projects_summary".
- time_plan_activity.target holds an EntityLink wire string
  ("BigPlan:std:12"), not the kebab-case "big-plan" the rename matched on,
  so activities targeting a project silently resolved to nothing.
- mutation_invocation_record.name / .args keep the undo/redo history.
- time_plan_activity.name and stats_log_entry.name are generated display
  strings that still read as the old name.

Adds tests walking the SQLite chain for both populations, plus one over the
data fix-up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FTkPVAsbvhP1tARjn2mATj