### PR TITLE
Add buffers to time events in day

### DIFF
--- a/docs/adrs/0012.undo-redo-sessions-and-groups.md
+++ b/docs/adrs/0012.undo-redo-sessions-and-groups.md
@@ -19,7 +19,7 @@ thing the user thinks of as one action."
 
 ### Recording levels today *(exists)*
 
-```
+```text
 trace      ← one top-level action, per request      (config.py, TraceId.new())
  └─ mutation  ← one use case invocation
      └─ event    ← one change to one entity
@@ -68,7 +68,7 @@ The consequences that matter for undo:
 
 ### 1. Two new levels above trace
 
-```
+```text
 session   ← one client instance                    (new)
  └─ group    ← one undo step                       (new)
      └─ trace       ← one request                  (exists)
@@ -186,7 +186,7 @@ move to an operation list, keyed on the `correlation_id` each block already
 carries (`common/sub/notes/content_block.py:54`), which round-trips through
 EditorJS as the block id (`infra/component/block-editor.tsx:224,327`).
 
-```
+```text
 SetBlock(correlation_id, block, before)
 InsertBlock(correlation_id, block, after_correlation_id)
 RemoveBlock(correlation_id, before)

--- a/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/__init__.py
@@ -773,6 +773,8 @@ from .schedule_event_in_day_load_public_from_schedule_stream_args import (
 from .schedule_event_in_day_load_result import ScheduleEventInDayLoadResult
 from .schedule_event_in_day_remove_args import ScheduleEventInDayRemoveArgs
 from .schedule_event_in_day_update_args import ScheduleEventInDayUpdateArgs
+from .schedule_event_in_day_update_args_buffer_after_mins import ScheduleEventInDayUpdateArgsBufferAfterMins
+from .schedule_event_in_day_update_args_buffer_before_mins import ScheduleEventInDayUpdateArgsBufferBeforeMins
 from .schedule_event_in_day_update_args_duration_mins import ScheduleEventInDayUpdateArgsDurationMins
 from .schedule_event_in_day_update_args_name import ScheduleEventInDayUpdateArgsName
 from .schedule_event_in_day_update_args_start_date import ScheduleEventInDayUpdateArgsStartDate
@@ -951,6 +953,8 @@ from .time_event_in_day_block_remove_args import TimeEventInDayBlockRemoveArgs
 from .time_event_in_day_block_stats import TimeEventInDayBlockStats
 from .time_event_in_day_block_stats_per_group import TimeEventInDayBlockStatsPerGroup
 from .time_event_in_day_block_update_args import TimeEventInDayBlockUpdateArgs
+from .time_event_in_day_block_update_args_buffer_after_mins import TimeEventInDayBlockUpdateArgsBufferAfterMins
+from .time_event_in_day_block_update_args_buffer_before_mins import TimeEventInDayBlockUpdateArgsBufferBeforeMins
 from .time_event_in_day_block_update_args_duration_mins import TimeEventInDayBlockUpdateArgsDurationMins
 from .time_event_in_day_block_update_args_start_date import TimeEventInDayBlockUpdateArgsStartDate
 from .time_event_in_day_block_update_args_start_time_in_day import TimeEventInDayBlockUpdateArgsStartTimeInDay
@@ -1909,6 +1913,8 @@ __all__ = (
     "ScheduleEventInDayLoadResult",
     "ScheduleEventInDayRemoveArgs",
     "ScheduleEventInDayUpdateArgs",
+    "ScheduleEventInDayUpdateArgsBufferAfterMins",
+    "ScheduleEventInDayUpdateArgsBufferBeforeMins",
     "ScheduleEventInDayUpdateArgsDurationMins",
     "ScheduleEventInDayUpdateArgsName",
     "ScheduleEventInDayUpdateArgsStartDate",
@@ -2083,6 +2089,8 @@ __all__ = (
     "TimeEventInDayBlockStats",
     "TimeEventInDayBlockStatsPerGroup",
     "TimeEventInDayBlockUpdateArgs",
+    "TimeEventInDayBlockUpdateArgsBufferAfterMins",
+    "TimeEventInDayBlockUpdateArgsBufferBeforeMins",
     "TimeEventInDayBlockUpdateArgsDurationMins",
     "TimeEventInDayBlockUpdateArgsStartDate",
     "TimeEventInDayBlockUpdateArgsStartTimeInDay",

--- a/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_create_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_create_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ScheduleEventInDayCreateArgs")
 
@@ -19,6 +21,8 @@ class ScheduleEventInDayCreateArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     schedule_stream_ref_id: str
@@ -26,6 +30,8 @@ class ScheduleEventInDayCreateArgs:
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -39,6 +45,18 @@ class ScheduleEventInDayCreateArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -50,6 +68,10 @@ class ScheduleEventInDayCreateArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -66,12 +88,32 @@ class ScheduleEventInDayCreateArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         schedule_event_in_day_create_args = cls(
             schedule_stream_ref_id=schedule_stream_ref_id,
             name=name,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         schedule_event_in_day_create_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args.py
@@ -7,6 +7,10 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
+    from ..models.schedule_event_in_day_update_args_buffer_after_mins import ScheduleEventInDayUpdateArgsBufferAfterMins
+    from ..models.schedule_event_in_day_update_args_buffer_before_mins import (
+        ScheduleEventInDayUpdateArgsBufferBeforeMins,
+    )
     from ..models.schedule_event_in_day_update_args_duration_mins import ScheduleEventInDayUpdateArgsDurationMins
     from ..models.schedule_event_in_day_update_args_name import ScheduleEventInDayUpdateArgsName
     from ..models.schedule_event_in_day_update_args_start_date import ScheduleEventInDayUpdateArgsStartDate
@@ -26,6 +30,8 @@ class ScheduleEventInDayUpdateArgs:
         start_date (ScheduleEventInDayUpdateArgsStartDate):
         start_time_in_day (ScheduleEventInDayUpdateArgsStartTimeInDay):
         duration_mins (ScheduleEventInDayUpdateArgsDurationMins):
+        buffer_before_mins (ScheduleEventInDayUpdateArgsBufferBeforeMins):
+        buffer_after_mins (ScheduleEventInDayUpdateArgsBufferAfterMins):
     """
 
     ref_id: str
@@ -33,6 +39,8 @@ class ScheduleEventInDayUpdateArgs:
     start_date: ScheduleEventInDayUpdateArgsStartDate
     start_time_in_day: ScheduleEventInDayUpdateArgsStartTimeInDay
     duration_mins: ScheduleEventInDayUpdateArgsDurationMins
+    buffer_before_mins: ScheduleEventInDayUpdateArgsBufferBeforeMins
+    buffer_after_mins: ScheduleEventInDayUpdateArgsBufferAfterMins
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -46,6 +54,10 @@ class ScheduleEventInDayUpdateArgs:
 
         duration_mins = self.duration_mins.to_dict()
 
+        buffer_before_mins = self.buffer_before_mins.to_dict()
+
+        buffer_after_mins = self.buffer_after_mins.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -55,6 +67,8 @@ class ScheduleEventInDayUpdateArgs:
                 "start_date": start_date,
                 "start_time_in_day": start_time_in_day,
                 "duration_mins": duration_mins,
+                "buffer_before_mins": buffer_before_mins,
+                "buffer_after_mins": buffer_after_mins,
             }
         )
 
@@ -62,6 +76,12 @@ class ScheduleEventInDayUpdateArgs:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.schedule_event_in_day_update_args_buffer_after_mins import (
+            ScheduleEventInDayUpdateArgsBufferAfterMins,
+        )
+        from ..models.schedule_event_in_day_update_args_buffer_before_mins import (
+            ScheduleEventInDayUpdateArgsBufferBeforeMins,
+        )
         from ..models.schedule_event_in_day_update_args_duration_mins import ScheduleEventInDayUpdateArgsDurationMins
         from ..models.schedule_event_in_day_update_args_name import ScheduleEventInDayUpdateArgsName
         from ..models.schedule_event_in_day_update_args_start_date import ScheduleEventInDayUpdateArgsStartDate
@@ -80,12 +100,18 @@ class ScheduleEventInDayUpdateArgs:
 
         duration_mins = ScheduleEventInDayUpdateArgsDurationMins.from_dict(d.pop("duration_mins"))
 
+        buffer_before_mins = ScheduleEventInDayUpdateArgsBufferBeforeMins.from_dict(d.pop("buffer_before_mins"))
+
+        buffer_after_mins = ScheduleEventInDayUpdateArgsBufferAfterMins.from_dict(d.pop("buffer_after_mins"))
+
         schedule_event_in_day_update_args = cls(
             ref_id=ref_id,
             name=name,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         schedule_event_in_day_update_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args_buffer_after_mins.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args_buffer_after_mins.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ScheduleEventInDayUpdateArgsBufferAfterMins")
+
+
+@_attrs_define
+class ScheduleEventInDayUpdateArgsBufferAfterMins:
+    """
+    Attributes:
+        should_change (bool):
+        value (int | None | Unset):
+    """
+
+    should_change: bool
+    value: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        should_change = self.should_change
+
+        value: int | None | Unset
+        if isinstance(self.value, Unset):
+            value = UNSET
+        else:
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "should_change": should_change,
+            }
+        )
+        if value is not UNSET:
+            field_dict["value"] = value
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        should_change = d.pop("should_change")
+
+        def _parse_value(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        value = _parse_value(d.pop("value", UNSET))
+
+        schedule_event_in_day_update_args_buffer_after_mins = cls(
+            should_change=should_change,
+            value=value,
+        )
+
+        schedule_event_in_day_update_args_buffer_after_mins.additional_properties = d
+        return schedule_event_in_day_update_args_buffer_after_mins
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args_buffer_before_mins.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/schedule_event_in_day_update_args_buffer_before_mins.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ScheduleEventInDayUpdateArgsBufferBeforeMins")
+
+
+@_attrs_define
+class ScheduleEventInDayUpdateArgsBufferBeforeMins:
+    """
+    Attributes:
+        should_change (bool):
+        value (int | None | Unset):
+    """
+
+    should_change: bool
+    value: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        should_change = self.should_change
+
+        value: int | None | Unset
+        if isinstance(self.value, Unset):
+            value = UNSET
+        else:
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "should_change": should_change,
+            }
+        )
+        if value is not UNSET:
+            field_dict["value"] = value
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        should_change = d.pop("should_change")
+
+        def _parse_value(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        value = _parse_value(d.pop("value", UNSET))
+
+        schedule_event_in_day_update_args_buffer_before_mins = cls(
+            should_change=should_change,
+            value=value,
+        )
+
+        schedule_event_in_day_update_args_buffer_before_mins.additional_properties = d
+        return schedule_event_in_day_update_args_buffer_before_mins
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block.py
@@ -29,6 +29,8 @@ class TimeEventInDayBlock:
         duration_mins (int):
         archival_reason (None | str | Unset):
         archived_time (None | str | Unset):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     ref_id: str
@@ -44,6 +46,8 @@ class TimeEventInDayBlock:
     duration_mins: int
     archival_reason: None | str | Unset = UNSET
     archived_time: None | str | Unset = UNSET
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -81,6 +85,18 @@ class TimeEventInDayBlock:
         else:
             archived_time = self.archived_time
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -102,6 +118,10 @@ class TimeEventInDayBlock:
             field_dict["archival_reason"] = archival_reason
         if archived_time is not UNSET:
             field_dict["archived_time"] = archived_time
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -148,6 +168,24 @@ class TimeEventInDayBlock:
 
         archived_time = _parse_archived_time(d.pop("archived_time", UNSET))
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block = cls(
             ref_id=ref_id,
             version=version,
@@ -162,6 +200,8 @@ class TimeEventInDayBlock:
             duration_mins=duration_mins,
             archival_reason=archival_reason,
             archived_time=archived_time,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_big_plan_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_big_plan_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TimeEventInDayBlockCreateForBigPlanArgs")
 
@@ -18,12 +20,16 @@ class TimeEventInDayBlockCreateForBigPlanArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     big_plan_ref_id: str
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +41,18 @@ class TimeEventInDayBlockCreateForBigPlanArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +63,10 @@ class TimeEventInDayBlockCreateForBigPlanArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -59,11 +81,31 @@ class TimeEventInDayBlockCreateForBigPlanArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block_create_for_big_plan_args = cls(
             big_plan_ref_id=big_plan_ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_create_for_big_plan_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_chore_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_chore_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TimeEventInDayBlockCreateForChoreArgs")
 
@@ -18,12 +20,16 @@ class TimeEventInDayBlockCreateForChoreArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     chore_ref_id: str
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +41,18 @@ class TimeEventInDayBlockCreateForChoreArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +63,10 @@ class TimeEventInDayBlockCreateForChoreArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -59,11 +81,31 @@ class TimeEventInDayBlockCreateForChoreArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block_create_for_chore_args = cls(
             chore_ref_id=chore_ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_create_for_chore_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_habit_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_habit_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TimeEventInDayBlockCreateForHabitArgs")
 
@@ -18,12 +20,16 @@ class TimeEventInDayBlockCreateForHabitArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     habit_ref_id: str
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +41,18 @@ class TimeEventInDayBlockCreateForHabitArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +63,10 @@ class TimeEventInDayBlockCreateForHabitArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -59,11 +81,31 @@ class TimeEventInDayBlockCreateForHabitArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block_create_for_habit_args = cls(
             habit_ref_id=habit_ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_create_for_habit_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_time_plan_activity_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_time_plan_activity_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TimeEventInDayBlockCreateForTimePlanActivityArgs")
 
@@ -18,12 +20,16 @@ class TimeEventInDayBlockCreateForTimePlanActivityArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     time_plan_activity_ref_id: str
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +41,18 @@ class TimeEventInDayBlockCreateForTimePlanActivityArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +63,10 @@ class TimeEventInDayBlockCreateForTimePlanActivityArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -59,11 +81,31 @@ class TimeEventInDayBlockCreateForTimePlanActivityArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block_create_for_time_plan_activity_args = cls(
             time_plan_activity_ref_id=time_plan_activity_ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_create_for_time_plan_activity_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_todo_task_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_create_for_todo_task_args.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TimeEventInDayBlockCreateForTodoTaskArgs")
 
@@ -18,12 +20,16 @@ class TimeEventInDayBlockCreateForTodoTaskArgs:
         start_date (str): A date or possibly a datetime for the application.
         start_time_in_day (str): The time in hh:mm format.
         duration_mins (int):
+        buffer_before_mins (int | None | Unset):
+        buffer_after_mins (int | None | Unset):
     """
 
     todo_task_ref_id: str
     start_date: str
     start_time_in_day: str
     duration_mins: int
+    buffer_before_mins: int | None | Unset = UNSET
+    buffer_after_mins: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,6 +41,18 @@ class TimeEventInDayBlockCreateForTodoTaskArgs:
 
         duration_mins = self.duration_mins
 
+        buffer_before_mins: int | None | Unset
+        if isinstance(self.buffer_before_mins, Unset):
+            buffer_before_mins = UNSET
+        else:
+            buffer_before_mins = self.buffer_before_mins
+
+        buffer_after_mins: int | None | Unset
+        if isinstance(self.buffer_after_mins, Unset):
+            buffer_after_mins = UNSET
+        else:
+            buffer_after_mins = self.buffer_after_mins
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +63,10 @@ class TimeEventInDayBlockCreateForTodoTaskArgs:
                 "duration_mins": duration_mins,
             }
         )
+        if buffer_before_mins is not UNSET:
+            field_dict["buffer_before_mins"] = buffer_before_mins
+        if buffer_after_mins is not UNSET:
+            field_dict["buffer_after_mins"] = buffer_after_mins
 
         return field_dict
 
@@ -59,11 +81,31 @@ class TimeEventInDayBlockCreateForTodoTaskArgs:
 
         duration_mins = d.pop("duration_mins")
 
+        def _parse_buffer_before_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_before_mins = _parse_buffer_before_mins(d.pop("buffer_before_mins", UNSET))
+
+        def _parse_buffer_after_mins(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        buffer_after_mins = _parse_buffer_after_mins(d.pop("buffer_after_mins", UNSET))
+
         time_event_in_day_block_create_for_todo_task_args = cls(
             todo_task_ref_id=todo_task_ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_create_for_todo_task_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args.py
@@ -7,6 +7,12 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
+    from ..models.time_event_in_day_block_update_args_buffer_after_mins import (
+        TimeEventInDayBlockUpdateArgsBufferAfterMins,
+    )
+    from ..models.time_event_in_day_block_update_args_buffer_before_mins import (
+        TimeEventInDayBlockUpdateArgsBufferBeforeMins,
+    )
     from ..models.time_event_in_day_block_update_args_duration_mins import TimeEventInDayBlockUpdateArgsDurationMins
     from ..models.time_event_in_day_block_update_args_start_date import TimeEventInDayBlockUpdateArgsStartDate
     from ..models.time_event_in_day_block_update_args_start_time_in_day import (
@@ -26,12 +32,16 @@ class TimeEventInDayBlockUpdateArgs:
         start_date (TimeEventInDayBlockUpdateArgsStartDate):
         start_time_in_day (TimeEventInDayBlockUpdateArgsStartTimeInDay):
         duration_mins (TimeEventInDayBlockUpdateArgsDurationMins):
+        buffer_before_mins (TimeEventInDayBlockUpdateArgsBufferBeforeMins):
+        buffer_after_mins (TimeEventInDayBlockUpdateArgsBufferAfterMins):
     """
 
     ref_id: str
     start_date: TimeEventInDayBlockUpdateArgsStartDate
     start_time_in_day: TimeEventInDayBlockUpdateArgsStartTimeInDay
     duration_mins: TimeEventInDayBlockUpdateArgsDurationMins
+    buffer_before_mins: TimeEventInDayBlockUpdateArgsBufferBeforeMins
+    buffer_after_mins: TimeEventInDayBlockUpdateArgsBufferAfterMins
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -43,6 +53,10 @@ class TimeEventInDayBlockUpdateArgs:
 
         duration_mins = self.duration_mins.to_dict()
 
+        buffer_before_mins = self.buffer_before_mins.to_dict()
+
+        buffer_after_mins = self.buffer_after_mins.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -51,6 +65,8 @@ class TimeEventInDayBlockUpdateArgs:
                 "start_date": start_date,
                 "start_time_in_day": start_time_in_day,
                 "duration_mins": duration_mins,
+                "buffer_before_mins": buffer_before_mins,
+                "buffer_after_mins": buffer_after_mins,
             }
         )
 
@@ -58,6 +74,12 @@ class TimeEventInDayBlockUpdateArgs:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.time_event_in_day_block_update_args_buffer_after_mins import (
+            TimeEventInDayBlockUpdateArgsBufferAfterMins,
+        )
+        from ..models.time_event_in_day_block_update_args_buffer_before_mins import (
+            TimeEventInDayBlockUpdateArgsBufferBeforeMins,
+        )
         from ..models.time_event_in_day_block_update_args_duration_mins import TimeEventInDayBlockUpdateArgsDurationMins
         from ..models.time_event_in_day_block_update_args_start_date import TimeEventInDayBlockUpdateArgsStartDate
         from ..models.time_event_in_day_block_update_args_start_time_in_day import (
@@ -73,11 +95,17 @@ class TimeEventInDayBlockUpdateArgs:
 
         duration_mins = TimeEventInDayBlockUpdateArgsDurationMins.from_dict(d.pop("duration_mins"))
 
+        buffer_before_mins = TimeEventInDayBlockUpdateArgsBufferBeforeMins.from_dict(d.pop("buffer_before_mins"))
+
+        buffer_after_mins = TimeEventInDayBlockUpdateArgsBufferAfterMins.from_dict(d.pop("buffer_after_mins"))
+
         time_event_in_day_block_update_args = cls(
             ref_id=ref_id,
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
         time_event_in_day_block_update_args.additional_properties = d

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args_buffer_after_mins.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args_buffer_after_mins.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TimeEventInDayBlockUpdateArgsBufferAfterMins")
+
+
+@_attrs_define
+class TimeEventInDayBlockUpdateArgsBufferAfterMins:
+    """
+    Attributes:
+        should_change (bool):
+        value (int | None | Unset):
+    """
+
+    should_change: bool
+    value: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        should_change = self.should_change
+
+        value: int | None | Unset
+        if isinstance(self.value, Unset):
+            value = UNSET
+        else:
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "should_change": should_change,
+            }
+        )
+        if value is not UNSET:
+            field_dict["value"] = value
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        should_change = d.pop("should_change")
+
+        def _parse_value(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        value = _parse_value(d.pop("value", UNSET))
+
+        time_event_in_day_block_update_args_buffer_after_mins = cls(
+            should_change=should_change,
+            value=value,
+        )
+
+        time_event_in_day_block_update_args_buffer_after_mins.additional_properties = d
+        return time_event_in_day_block_update_args_buffer_after_mins
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args_buffer_before_mins.py
+++ b/gen/py/webapi-client/jupiter_webapi_client/models/time_event_in_day_block_update_args_buffer_before_mins.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TimeEventInDayBlockUpdateArgsBufferBeforeMins")
+
+
+@_attrs_define
+class TimeEventInDayBlockUpdateArgsBufferBeforeMins:
+    """
+    Attributes:
+        should_change (bool):
+        value (int | None | Unset):
+    """
+
+    should_change: bool
+    value: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        should_change = self.should_change
+
+        value: int | None | Unset
+        if isinstance(self.value, Unset):
+            value = UNSET
+        else:
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "should_change": should_change,
+            }
+        )
+        if value is not UNSET:
+            field_dict["value"] = value
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        should_change = d.pop("should_change")
+
+        def _parse_value(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        value = _parse_value(d.pop("value", UNSET))
+
+        time_event_in_day_block_update_args_buffer_before_mins = cls(
+            should_change=should_change,
+            value=value,
+        )
+
+        time_event_in_day_block_update_args_buffer_before_mins.additional_properties = d
+        return time_event_in_day_block_update_args_buffer_before_mins
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/gen/ts/webapi-client/gen/models/ScheduleEventInDayCreateArgs.ts
+++ b/gen/ts/webapi-client/gen/models/ScheduleEventInDayCreateArgs.ts
@@ -15,5 +15,7 @@ export type ScheduleEventInDayCreateArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/ScheduleEventInDayUpdateArgs.ts
+++ b/gen/ts/webapi-client/gen/models/ScheduleEventInDayUpdateArgs.ts
@@ -27,5 +27,13 @@ export type ScheduleEventInDayUpdateArgs = {
         should_change: boolean;
         value?: number;
     };
+    buffer_before_mins: {
+        should_change: boolean;
+        value?: (number | null);
+    };
+    buffer_after_mins: {
+        should_change: boolean;
+        value?: (number | null);
+    };
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlock.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlock.ts
@@ -25,5 +25,7 @@ export type TimeEventInDayBlock = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForBigPlanArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForBigPlanArgs.ts
@@ -13,5 +13,7 @@ export type TimeEventInDayBlockCreateForBigPlanArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForChoreArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForChoreArgs.ts
@@ -13,5 +13,7 @@ export type TimeEventInDayBlockCreateForChoreArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForHabitArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForHabitArgs.ts
@@ -13,5 +13,7 @@ export type TimeEventInDayBlockCreateForHabitArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForTimePlanActivityArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForTimePlanActivityArgs.ts
@@ -13,5 +13,7 @@ export type TimeEventInDayBlockCreateForTimePlanActivityArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForTodoTaskArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockCreateForTodoTaskArgs.ts
@@ -13,5 +13,7 @@ export type TimeEventInDayBlockCreateForTodoTaskArgs = {
     start_date: ADate;
     start_time_in_day: TimeInDay;
     duration_mins: number;
+    buffer_before_mins?: (number | null);
+    buffer_after_mins?: (number | null);
 };
 

--- a/gen/ts/webapi-client/gen/models/TimeEventInDayBlockUpdateArgs.ts
+++ b/gen/ts/webapi-client/gen/models/TimeEventInDayBlockUpdateArgs.ts
@@ -22,5 +22,13 @@ export type TimeEventInDayBlockUpdateArgs = {
         should_change: boolean;
         value?: number;
     };
+    buffer_before_mins: {
+        should_change: boolean;
+        value?: (number | null);
+    };
+    buffer_after_mins: {
+        should_change: boolean;
+        value?: (number | null);
+    };
 };
 

--- a/itests/api/common/time_events_in_day_blocks_for_big_plans.test.py
+++ b/itests/api/common/time_events_in_day_blocks_for_big_plans.test.py
@@ -229,6 +229,8 @@ def test_api_common_time_event_in_day_block_update_for_big_plan(
             "start_date": {"should_change": True, "value": "2024-07-01"},
             "start_time_in_day": {"should_change": True, "value": "14:30"},
             "duration_mins": {"should_change": True, "value": 90},
+            "buffer_before_mins": {"should_change": False},
+            "buffer_after_mins": {"should_change": False},
         },
         timeout=10,
     )
@@ -244,6 +246,79 @@ def test_api_common_time_event_in_day_block_update_for_big_plan(
     assert loaded["start_date"] == "2024-07-01"
     assert loaded["start_time_in_day"] == "14:30"
     assert loaded["duration_mins"] == 90
+
+
+def test_api_common_time_event_in_day_block_buffers_for_big_plan(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    plan = create_big_plan("TE BP Buffers")
+
+    response = requests.post(
+        f"{api_url}/v1/common/time-events/in-day-blocks/for-big-plan",
+        headers=_headers(api_key),
+        json={
+            "big_plan_ref_id": plan.ref_id,
+            "start_date": "2024-07-15",
+            "start_time_in_day": "10:00",
+            "duration_mins": 45,
+            "buffer_before_mins": 15,
+            "buffer_after_mins": 30,
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200
+
+    block = response.json()["new_time_event"]
+    assert block["buffer_before_mins"] == 15
+    assert block["buffer_after_mins"] == 30
+
+    # Moving the event without saying anything about the buffers keeps them,
+    # and a buffer set to nothing is dropped.
+    response2 = requests.put(
+        f"{api_url}/v1/common/time-events/in-day-blocks/{block['ref_id']}",
+        headers=_headers(api_key),
+        json={
+            "ref_id": block["ref_id"],
+            "start_date": {"should_change": False},
+            "start_time_in_day": {"should_change": False},
+            "duration_mins": {"should_change": True, "value": 60},
+            "buffer_before_mins": {"should_change": False},
+            "buffer_after_mins": {"should_change": True, "value": None},
+        },
+        timeout=10,
+    )
+    assert response2.status_code == 200
+
+    response3 = requests.get(
+        f"{api_url}/v1/common/time-events/in-day-blocks/{block['ref_id']}?allow_archived=false",
+        headers=_headers(api_key),
+        timeout=10,
+    )
+    assert response3.status_code == 200
+    loaded = response3.json()["in_day_block"]
+    assert loaded["duration_mins"] == 60
+    assert loaded["buffer_before_mins"] == 15
+    assert loaded.get("buffer_after_mins") is None
+
+
+def test_api_common_time_event_in_day_block_rejects_a_zero_buffer(
+    api_url: str, api_key: str, create_big_plan
+) -> None:
+    plan = create_big_plan("TE BP Bad Buffer")
+
+    response = requests.post(
+        f"{api_url}/v1/common/time-events/in-day-blocks/for-big-plan",
+        headers=_headers(api_key),
+        json={
+            "big_plan_ref_id": plan.ref_id,
+            "start_date": "2024-07-15",
+            "start_time_in_day": "10:00",
+            "duration_mins": 45,
+            "buffer_before_mins": 0,
+        },
+        timeout=10,
+    )
+    assert response.status_code != 200
 
 
 def test_api_common_time_event_in_day_block_archive_for_big_plan(
@@ -349,6 +424,8 @@ def _assert_can_mutate_time_event_in_day(
             "start_date": {"should_change": True, "value": "2024-07-16"},
             "start_time_in_day": {"should_change": True, "value": "11:00"},
             "duration_mins": {"should_change": True, "value": 60},
+            "buffer_before_mins": {"should_change": False},
+            "buffer_after_mins": {"should_change": False},
         },
         timeout=10,
     )
@@ -416,6 +493,8 @@ def _assert_read_only_time_event_in_day(
             "start_date": {"should_change": True, "value": "2024-08-01"},
             "start_time_in_day": {"should_change": True, "value": "12:00"},
             "duration_mins": {"should_change": True, "value": 90},
+            "buffer_before_mins": {"should_change": False},
+            "buffer_after_mins": {"should_change": False},
         },
         timeout=10,
     )

--- a/itests/api/schedule.test.py
+++ b/itests/api/schedule.test.py
@@ -597,6 +597,8 @@ def test_api_schedule_event_in_day_update(
             "start_date": {"should_change": True, "value": "2024-09-05"},
             "start_time_in_day": {"should_change": True, "value": "11:30"},
             "duration_mins": {"should_change": True, "value": 90},
+            "buffer_before_mins": {"should_change": False},
+            "buffer_after_mins": {"should_change": False},
         },
         timeout=10,
     )
@@ -786,6 +788,8 @@ def _event_in_day_update_body(ref_id: str, *, name: str) -> dict[str, object]:
         "start_date": {"should_change": False},
         "start_time_in_day": {"should_change": False},
         "duration_mins": {"should_change": False},
+        "buffer_before_mins": {"should_change": False},
+        "buffer_after_mins": {"should_change": False},
     }
 
 

--- a/src/cli/jupiter/cli/command/calendar_show.py
+++ b/src/cli/jupiter/cli/command/calendar_show.py
@@ -16,10 +16,25 @@ from jupiter.core.calendar.service.load_for_date_and_period import (
 from jupiter.core.calendar.use_case.load_for_date_and_period import (
     CalendarLoadForDateAndPeriodUseCase,
 )
+from jupiter.core.common.sub.time_events.sub.in_day_block.root import (
+    TimeEventInDayBlock,
+)
 from jupiter.core.config import JupiterLoggedInReadonlyContext
 from rich.console import Console
 from rich.text import Text
 from rich.tree import Tree
+
+
+def _buffers_suffix(time_event: TimeEventInDayBlock) -> str:
+    """Describe the logistics time reserved around an event, if any."""
+    parts = []
+    if time_event.buffer_before_mins is not None:
+        parts.append(f"{time_event.buffer_before_mins} minutes before")
+    if time_event.buffer_after_mins is not None:
+        parts.append(f"{time_event.buffer_after_mins} minutes after")
+    if not parts:
+        return ""
+    return f" with a buffer of {' and '.join(parts)}"
 
 
 class CalendarShow(
@@ -151,6 +166,7 @@ class CalendarShow(
             )
             schedule_event_in_day_text.append(
                 f" that lasts for {time_event.duration_mins} minutes"
+                f"{_buffers_suffix(time_event)}"
             )
 
             schedule_event_in_day_text.append(" for stream ")

--- a/src/core/jupiter/core/apps/journals/sub/question/service/build_note.py
+++ b/src/core/jupiter/core/apps/journals/sub/question/service/build_note.py
@@ -92,4 +92,3 @@ class BuildNoteFromQuestionsService:
             ),
             content=_build_note_content(questions),
         )
-

--- a/src/core/jupiter/core/apps/schedule/service/external_sync_service.py
+++ b/src/core/jupiter/core/apps/schedule/service/external_sync_service.py
@@ -608,6 +608,8 @@ class ScheduleExternalSyncService:
                                         start_time.value.hour, start_time.value.minute
                                     ),
                                     duration_mins=total_duration,
+                                    buffer_before_mins=None,
+                                    buffer_after_mins=None,
                                 )
                                 time_event_in_day_block = await uow.get_for(
                                     TimeEventInDayBlock
@@ -672,22 +674,24 @@ class ScheduleExternalSyncService:
                                 time_event_in_day_block = all_time_event_in_day_blocks_by_source_entity_ref_id[
                                     schedule_event_in_day.ref_id
                                 ]
-                                time_event_in_day_block = (
-                                    time_event_in_day_block.update(
-                                        ctx,
-                                        start_date=UpdateAction.change_to(
-                                            ADate.from_date(start_time.as_date())
-                                        ),
-                                        start_time_in_day=UpdateAction.change_to(
-                                            TimeInDay.from_parts(
-                                                start_time.value.hour,
-                                                start_time.value.minute,
-                                            )
-                                        ),
-                                        duration_mins=UpdateAction.change_to(
-                                            total_duration
-                                        ),
-                                    )
+                                time_event_in_day_block = time_event_in_day_block.update(
+                                    ctx,
+                                    start_date=UpdateAction.change_to(
+                                        ADate.from_date(start_time.as_date())
+                                    ),
+                                    start_time_in_day=UpdateAction.change_to(
+                                        TimeInDay.from_parts(
+                                            start_time.value.hour,
+                                            start_time.value.minute,
+                                        )
+                                    ),
+                                    duration_mins=UpdateAction.change_to(
+                                        total_duration
+                                    ),
+                                    # Buffers are a local concern, so an
+                                    # external re-sync leaves them alone.
+                                    buffer_before_mins=UpdateAction.do_nothing(),
+                                    buffer_after_mins=UpdateAction.do_nothing(),
                                 )
                                 await uow.get_for(TimeEventInDayBlock).save(
                                     time_event_in_day_block

--- a/src/core/jupiter/core/apps/schedule/sub/event_in_day/component/editor.tsx
+++ b/src/core/jupiter/core/apps/schedule/sub/event_in_day/component/editor.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 
 import { entityLinkStd } from "#/core/common/entity-link";
+import { TimeEventBuffersEditor } from "#/core/common/sub/time_events/component/buffers-editor";
 import { TagsEditor } from "#/core/common/sub/tags/component/tags-editor";
 import { ContactsEditor } from "#/core/common/sub/contacts/component/contacts-editor";
 import type { ActionResult } from "#/core/infra/action-result";
@@ -46,9 +47,13 @@ interface ScheduleEventInDayEditorProps {
   startDate: string;
   startTimeInDay: string;
   durationMins: number;
+  bufferBeforeMins: number | null;
+  bufferAfterMins: number | null;
   onStartDateChange?: (value: string) => void;
   onStartTimeInDayChange?: (value: string) => void;
   onDurationMinsChange?: (value: number) => void;
+  onBufferBeforeMinsChange?: (value: number | null) => void;
+  onBufferAfterMinsChange?: (value: number | null) => void;
   actions?: JSX.Element;
 }
 
@@ -64,6 +69,8 @@ export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
     startDate,
     startTimeInDay,
     durationMins,
+    bufferBeforeMins,
+    bufferAfterMins,
   } = props;
   const editable = props.inputsEnabled && props.corePropertyEditable;
 
@@ -267,6 +274,15 @@ export function ScheduleEventInDayEditor(props: ScheduleEventInDayEditorProps) {
           />
         </FormControl>
       </Stack>
+
+      <TimeEventBuffersEditor
+        inputsEnabled={editable}
+        bufferBeforeMins={bufferBeforeMins}
+        bufferAfterMins={bufferAfterMins}
+        onBufferBeforeMinsChange={props.onBufferBeforeMinsChange}
+        onBufferAfterMinsChange={props.onBufferAfterMinsChange}
+        actionResult={props.actionResult}
+      />
     </SectionCard>
   );
 }

--- a/src/core/jupiter/core/apps/schedule/sub/event_in_day/use_case/create.py
+++ b/src/core/jupiter/core/apps/schedule/sub/event_in_day/use_case/create.py
@@ -43,6 +43,8 @@ class ScheduleEventInDayCreateArgs(JupiterCreateCrownEntityArgs):
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -115,6 +117,8 @@ class ScheduleEventInDayCreateUseCase(
                 start_date=args.start_date,
                 start_time_in_day=args.start_time_in_day,
                 duration_mins=args.duration_mins,
+                buffer_before_mins=args.buffer_before_mins,
+                buffer_after_mins=args.buffer_after_mins,
             )
         )
         new_time_event_in_day_block = await uow.get_for(TimeEventInDayBlock).create(

--- a/src/core/jupiter/core/apps/schedule/sub/event_in_day/use_case/update.py
+++ b/src/core/jupiter/core/apps/schedule/sub/event_in_day/use_case/update.py
@@ -39,6 +39,8 @@ class ScheduleEventInDayUpdateArgs(JupiterUpdateCrownEntityArgs):
     start_date: UpdateAction[ADate]
     start_time_in_day: UpdateAction[TimeInDay]
     duration_mins: UpdateAction[int]
+    buffer_before_mins: UpdateAction[int | None]
+    buffer_after_mins: UpdateAction[int | None]
 
 
 @mutation_use_case(WorkspaceFeature.SCHEDULE)
@@ -79,5 +81,7 @@ class ScheduleEventInDayUpdateUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         await uow.get(TimeEventInDayBlockRepository).save(time_event)

--- a/src/core/jupiter/core/calendar/component/shared.tsx
+++ b/src/core/jupiter/core/calendar/component/shared.tsx
@@ -78,6 +78,8 @@ import {
   timeEventInDayBlockOwnerTheType,
   findNearbyTimeEventInDayEntries,
   NEARBY_TIME_EVENT_WINDOW_MINS,
+  calendarTimeEventInDayBufferToRems,
+  timeEventInDayBuffersLabel,
 } from "#/core/common/sub/time_events/time-event";
 import {
   scheduleStreamColorContrastingHex,
@@ -808,6 +810,14 @@ export function ViewAsCalendarTimeEventInDayCell(
 
   return (
     <Fragment>
+      <ViewAsCalendarTimeEventInDayBuffers
+        layout={props.layout}
+        overlapStyle={props.overlapStyle}
+        startOfDay={props.startOfDay}
+        entry={props.entry}
+        deltaHour={props.deltaHour}
+      />
+
       <ViewAsCalendarTimeEventInDayCellContent
         {...props}
         eventTriggerProps={eventTriggerProps}
@@ -896,6 +906,141 @@ function OverlappingEventsPeekRow(props: OverlappingEventsPeekRowProps) {
   );
 }
 
+// The colour an in-day event is drawn in. The event's own box and the buffer
+// bands hugging it both read it from here, so the two never drift apart.
+function timeEventInDayEntryColorHex(
+  entry: CombinedTimeEventInDayEntry,
+): string {
+  switch (timeEventInDayBlockOwnerTheType(entry.time_event_in_tz)) {
+    case NamedEntityTag.SCHEDULE_EVENT_IN_DAY:
+      return scheduleStreamColorHex(
+        (entry.entry as ScheduleInDayEventEntry).stream.color,
+      );
+
+    case NamedEntityTag.BIG_PLAN: {
+      const bigPlan = (entry.entry as BigPlanEntry).big_plan;
+      return scheduleStreamColorHex(
+        BIG_PLAN_TIME_EVENT_COLOR,
+        bigPlan.status === BigPlanStatus.DONE
+          ? "lighter"
+          : bigPlan.status === BigPlanStatus.NOT_DONE
+            ? "darker"
+            : "normal",
+      );
+    }
+
+    case NamedEntityTag.TODO_TASK: {
+      const inboxTask = (entry.entry as TodoTaskEntry).inbox_task;
+      return scheduleStreamColorHex(
+        TODO_TASK_TIME_EVENT_COLOR,
+        inboxTask.status === InboxTaskStatus.DONE
+          ? "lighter"
+          : inboxTask.status === InboxTaskStatus.NOT_DONE
+            ? "darker"
+            : "normal",
+      );
+    }
+
+    case NamedEntityTag.HABIT:
+      return scheduleStreamColorHex(HABIT_TIME_EVENT_COLOR);
+
+    case NamedEntityTag.CHORE:
+      return scheduleStreamColorHex(CHORE_TIME_EVENT_COLOR);
+
+    case NamedEntityTag.TIME_PLAN_ACTIVITY:
+      return scheduleStreamColorHex(TIME_PLAN_ACTIVITY_TIME_EVENT_COLOR);
+
+    default:
+      throw new Error("Unknown time event in day owner type");
+  }
+}
+
+interface ViewAsCalendarTimeEventInDayBuffersProps {
+  layout: TimeBlockLayout;
+  overlapStyle: InDayEventOverlapStyle;
+  startOfDay: DateTime;
+  entry: CombinedTimeEventInDayEntry;
+  deltaHour: number;
+}
+
+// The logistics around an event - getting there beforehand, winding down
+// after - drawn as hatched bands hugging it, so the time they take is visible
+// without reading as part of the event itself.
+function ViewAsCalendarTimeEventInDayBuffers(
+  props: ViewAsCalendarTimeEventInDayBuffersProps,
+) {
+  const block = props.entry.time_event_in_tz;
+
+  if (
+    (block.buffer_before_mins ?? null) === null &&
+    (block.buffer_after_mins ?? null) === null
+  ) {
+    return null;
+  }
+
+  const startMins = calculateStartTimeForTimeEvent(block)
+    .diff(props.startOfDay)
+    .as("minutes");
+  const endMins = calculateEndTimeForTimeEvent(block)
+    .diff(props.startOfDay)
+    .as("minutes");
+
+  // A buffer running off either end of the day is drawn only as far as the
+  // day goes.
+  const bufferBeforeMins = Math.min(
+    block.buffer_before_mins ?? 0,
+    Math.max(0, startMins),
+  );
+  const bufferAfterMins = Math.min(
+    block.buffer_after_mins ?? 0,
+    Math.max(0, 24 * 60 - endMins),
+  );
+
+  const beforeTopRems = calendarTimeEventInDayStartMinutesToRems(
+    startMins - bufferBeforeMins,
+    props.deltaHour,
+  );
+  const afterTopRems = calendarTimeEventInDayStartMinutesToRems(
+    endMins,
+    props.deltaHour,
+  );
+
+  const colorHex = timeEventInDayEntryColorHex(props.entry);
+  const bandSx = {
+    position: "absolute" as const,
+    backgroundImage: `repeating-linear-gradient(45deg, ${colorHex}59, ${colorHex}59 4px, transparent 4px, transparent 8px)`,
+    border: `1px dashed ${colorHex}`,
+    borderRadius: "0.25rem",
+    boxSizing: "border-box" as const,
+    pointerEvents: "none" as const,
+    ...inDayEventLayoutSx(props.layout, props.overlapStyle),
+  };
+
+  return (
+    <Fragment>
+      {bufferBeforeMins > 0 && beforeTopRems !== undefined && (
+        <Box
+          sx={{
+            ...bandSx,
+            top: beforeTopRems,
+            height: calendarTimeEventInDayBufferToRems(bufferBeforeMins),
+          }}
+        ></Box>
+      )}
+
+      {bufferAfterMins > 0 && afterTopRems !== undefined && (
+        <Box
+          sx={{
+            ...bandSx,
+            top: afterTopRems,
+            height: calendarTimeEventInDayBufferToRems(bufferAfterMins),
+          }}
+        ></Box>
+      )}
+    </Fragment>
+  );
+}
+
 // Everything the box of an event needs to react to the pointer: peeking at
 // what's around it, and coming loose so it can be dragged elsewhere.
 type ViewAsCalendarTimeEventInDayTriggerProps =
@@ -969,7 +1114,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               scheduleEntry.time_event.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(scheduleEntry.stream.color),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1057,14 +1202,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               props.entry.time_event_in_tz.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(
-              BIG_PLAN_TIME_EVENT_COLOR,
-              bigPlanEntry.big_plan.status === BigPlanStatus.DONE
-                ? "lighter"
-                : bigPlanEntry.big_plan.status === BigPlanStatus.NOT_DONE
-                  ? "darker"
-                  : "normal",
-            ),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1151,14 +1289,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               props.entry.time_event_in_tz.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(
-              TODO_TASK_TIME_EVENT_COLOR,
-              todoTaskEntry.inbox_task.status === InboxTaskStatus.DONE
-                ? "lighter"
-                : todoTaskEntry.inbox_task.status === InboxTaskStatus.NOT_DONE
-                  ? "darker"
-                  : "normal",
-            ),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1242,7 +1373,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               props.entry.time_event_in_tz.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(HABIT_TIME_EVENT_COLOR),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1326,7 +1457,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               props.entry.time_event_in_tz.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(CHORE_TIME_EVENT_COLOR),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1410,9 +1541,7 @@ function ViewAsCalendarTimeEventInDayCellContent(
               minutesSinceStartOfDay,
               props.entry.time_event_in_tz.duration_mins,
             ),
-            backgroundColor: scheduleStreamColorHex(
-              TIME_PLAN_ACTIVITY_TIME_EVENT_COLOR,
-            ),
+            backgroundColor: timeEventInDayEntryColorHex(props.entry),
             borderRadius: "0.25rem",
             border: `1px solid ${theme.palette.background.paper}`,
             ...inDayEventLayoutSx(props.layout, props.overlapStyle),
@@ -1672,6 +1801,36 @@ export function ViewAsScheduleTimeEventFullDaysRows(
   }
 }
 
+interface ViewAsScheduleTimeEventInDayTimeCellProps {
+  period: RecurringTaskPeriod;
+  entry: CombinedTimeEventInDayEntry;
+  startTime: DateTime;
+  endTime: DateTime;
+}
+
+// When an event has buffers around it, the range it takes up on the day is
+// wider than the range it runs for, so the schedule says so under the times.
+function ViewAsScheduleTimeEventInDayTimeCell(
+  props: ViewAsScheduleTimeEventInDayTimeCellProps,
+) {
+  const isBigScreen = useBigScreen();
+  const buffersLabel = timeEventInDayBuffersLabel(props.entry.time_event_in_tz);
+
+  return (
+    <ViewAsScheduleTimeCell
+      period={props.period}
+      isbigscreen={isBigScreen.toString()}
+    >
+      [{props.startTime.toFormat("HH:mm")} - {props.endTime.toFormat("HH:mm")}]
+      {buffersLabel !== undefined && (
+        <Typography variant="caption" component="div" color="text.secondary">
+          {buffersLabel}
+        </Typography>
+      )}
+    </ViewAsScheduleTimeCell>
+  );
+}
+
 interface ViewAsScheduleTimeEventInDaysRowsProps {
   period: RecurringTaskPeriod;
   entry: CombinedTimeEventInDayEntry;
@@ -1681,7 +1840,6 @@ interface ViewAsScheduleTimeEventInDaysRowsProps {
 export function ViewAsScheduleTimeEventInDaysRows(
   props: ViewAsScheduleTimeEventInDaysRowsProps,
 ) {
-  const isBigScreen = useBigScreen();
   const topLevelInfo = useContext(TopLevelInfoContext);
 
   const startTime = calculateStartTimeForTimeEvent(
@@ -1694,12 +1852,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const scheduleEntry = props.entry.entry as ScheduleInDayEventEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(scheduleEntry.stream.color)}
@@ -1738,12 +1896,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const bigPlanEntry = props.entry.entry as BigPlanEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(
@@ -1782,12 +1940,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const todoTaskEntry = props.entry.entry as TodoTaskEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(
@@ -1829,12 +1987,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const habitEntry = props.entry.entry as HabitEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(HABIT_TIME_EVENT_COLOR)}
@@ -1866,12 +2024,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const choreEntry = props.entry.entry as ChoreEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(CHORE_TIME_EVENT_COLOR)}
@@ -1903,12 +2061,12 @@ export function ViewAsScheduleTimeEventInDaysRows(
       const activityEntry = props.entry.entry as TimePlanActivityEntry;
       return (
         <Fragment>
-          <ViewAsScheduleTimeCell
+          <ViewAsScheduleTimeEventInDayTimeCell
             period={props.period}
-            isbigscreen={isBigScreen.toString()}
-          >
-            [{startTime.toFormat("HH:mm")} - {endTime.toFormat("HH:mm")}]
-          </ViewAsScheduleTimeCell>
+            entry={props.entry}
+            startTime={startTime}
+            endTime={endTime}
+          />
 
           <ViewAsScheduleEventCell
             color={scheduleStreamColorHex(TIME_PLAN_ACTIVITY_TIME_EVENT_COLOR)}

--- a/src/core/jupiter/core/common/sub/time_events/component/buffers-editor.tsx
+++ b/src/core/jupiter/core/common/sub/time_events/component/buffers-editor.tsx
@@ -1,0 +1,120 @@
+import {
+  Button,
+  ButtonGroup,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+} from "@mui/material";
+
+import { TIME_EVENT_BUFFER_PRESETS_MINS } from "#/core/common/sub/time_events/time-event";
+import type { ActionResult } from "#/core/infra/action-result";
+import { FieldError } from "#/core/infra/component/errors";
+
+interface TimeEventBufferFieldProps {
+  name: string;
+  label: string;
+  fieldName: string;
+  inputsEnabled: boolean;
+  bufferMins: number | null;
+  onBufferMinsChange?: (bufferMins: number | null) => void;
+  actionResult?: ActionResult<unknown>;
+}
+
+// Like the duration field next to it, but a buffer is allowed to be nothing
+// at all - which is what an empty box means here.
+function TimeEventBufferField(props: TimeEventBufferFieldProps) {
+  return (
+    <Stack spacing={2} direction="row">
+      <ButtonGroup variant="outlined" disabled={!props.inputsEnabled}>
+        <Button
+          disabled={!props.inputsEnabled}
+          variant={props.bufferMins === null ? "contained" : "outlined"}
+          onClick={() => props.onBufferMinsChange?.(null)}
+        >
+          None
+        </Button>
+        {TIME_EVENT_BUFFER_PRESETS_MINS.map((presetMins) => (
+          <Button
+            key={presetMins}
+            disabled={!props.inputsEnabled}
+            variant={props.bufferMins === presetMins ? "contained" : "outlined"}
+            onClick={() => props.onBufferMinsChange?.(presetMins)}
+          >
+            {presetMins}m
+          </Button>
+        ))}
+      </ButtonGroup>
+
+      <FormControl fullWidth>
+        <InputLabel id={props.name} shrink margin="dense">
+          {props.label}
+        </InputLabel>
+        <OutlinedInput
+          type="number"
+          label={props.label}
+          name={props.name}
+          readOnly={!props.inputsEnabled}
+          value={props.bufferMins === null ? "" : props.bufferMins}
+          onChange={(e) => {
+            if (e.target.value === "") {
+              props.onBufferMinsChange?.(null);
+              return;
+            }
+
+            const bufferMins = parseInt(e.target.value, 10);
+            if (Number.isNaN(bufferMins)) {
+              props.onBufferMinsChange?.(null);
+              e.preventDefault();
+              return;
+            }
+
+            props.onBufferMinsChange?.(bufferMins);
+          }}
+        />
+
+        <FieldError
+          actionResult={props.actionResult}
+          fieldName={props.fieldName}
+        />
+      </FormControl>
+    </Stack>
+  );
+}
+
+interface TimeEventBuffersEditorProps {
+  inputsEnabled: boolean;
+  bufferBeforeMins: number | null;
+  bufferAfterMins: number | null;
+  onBufferBeforeMinsChange?: (bufferMins: number | null) => void;
+  onBufferAfterMinsChange?: (bufferMins: number | null) => void;
+  actionResult?: ActionResult<unknown>;
+}
+
+// The blocks of time around an event that are taken up by its logistics -
+// getting there before it, and winding down after it.
+export function TimeEventBuffersEditor(props: TimeEventBuffersEditorProps) {
+  return (
+    <>
+      <TimeEventBufferField
+        name="bufferBeforeMins"
+        label="Buffer Before (Mins)"
+        fieldName="/buffer_before_mins"
+        inputsEnabled={props.inputsEnabled}
+        bufferMins={props.bufferBeforeMins}
+        onBufferMinsChange={props.onBufferBeforeMinsChange}
+        actionResult={props.actionResult}
+      />
+
+      <TimeEventBufferField
+        name="bufferAfterMins"
+        label="Buffer After (Mins)"
+        fieldName="/buffer_after_mins"
+        inputsEnabled={props.inputsEnabled}
+        bufferMins={props.bufferAfterMins}
+        onBufferMinsChange={props.onBufferAfterMinsChange}
+        actionResult={props.actionResult}
+      />
+    </>
+  );
+}

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/component/properties-editor.tsx
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/component/properties-editor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 
+import { TimeEventBuffersEditor } from "#/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "#/core/common/sub/time_events/component/params-source";
 import { timeEventInDayBlockParamsToTimezone } from "#/core/common/sub/time_events/time-event";
 import type { SomeErrorNoData } from "#/core/infra/action-result";
@@ -48,6 +49,12 @@ export function TimeEventInDayBlockPropertiesEditor(
   const [durationMins, setDurationMins] = useState(
     props.inDayBlock.duration_mins,
   );
+  const [bufferBeforeMins, setBufferBeforeMins] = useState(
+    props.inDayBlock.buffer_before_mins ?? null,
+  );
+  const [bufferAfterMins, setBufferAfterMins] = useState(
+    props.inDayBlock.buffer_after_mins ?? null,
+  );
 
   useEffect(() => {
     const nextParams = timeEventInDayBlockParamsToTimezone(
@@ -60,6 +67,8 @@ export function TimeEventInDayBlockPropertiesEditor(
     setStartDate(nextParams.startDate!);
     setStartTimeInDay(nextParams.startTimeInDay!);
     setDurationMins(props.inDayBlock.duration_mins);
+    setBufferBeforeMins(props.inDayBlock.buffer_before_mins ?? null);
+    setBufferAfterMins(props.inDayBlock.buffer_after_mins ?? null);
   }, [props.inDayBlock, props.timezone]);
 
   return (
@@ -201,6 +210,15 @@ export function TimeEventInDayBlockPropertiesEditor(
             />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={props.inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={props.actionData}
+        />
       </SectionCard>
     </>
   );

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.py
@@ -25,6 +25,8 @@ from jupiter.framework.value import CompositeValue, value
 # Define constants at the top level
 MIN_DURATION_MINS = 1
 MAX_DURATION_MINS = 2 * 24 * 60  # 48 hours
+MIN_BUFFER_MINS = 1
+MAX_BUFFER_MINS = 24 * 60  # 24 hours
 
 ALLOWED_TIME_EVENT_IN_DAY_OWNER_TYPES: Final[frozenset[str]] = frozenset(
     {
@@ -48,6 +50,21 @@ class TimeEventInDayBlock(LeafSupportEntity):
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
+
+    @staticmethod
+    def _check_buffer_mins(label: str, buffer_mins: int | None) -> None:
+        if buffer_mins is None:
+            return
+        if buffer_mins < MIN_BUFFER_MINS:
+            raise InputValidationError(
+                f"The {label} buffer must be at least {MIN_BUFFER_MINS} minute."
+            )
+        if buffer_mins > MAX_BUFFER_MINS:
+            raise InputValidationError(
+                f"The {label} buffer must be at most {MAX_BUFFER_MINS // 60} hours."
+            )
 
     @staticmethod
     def _new_with_owner(
@@ -57,6 +74,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         if duration_mins < MIN_DURATION_MINS:
             raise InputValidationError(
@@ -66,6 +85,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             raise InputValidationError(
                 f"Duration must be at most {MAX_DURATION_MINS // 60} hours."
             )
+        TimeEventInDayBlock._check_buffer_mins("before", buffer_before_mins)
+        TimeEventInDayBlock._check_buffer_mins("after", buffer_after_mins)
         if owner.the_type not in ALLOWED_TIME_EVENT_IN_DAY_OWNER_TYPES:
             raise InputValidationError(
                 f"Invalid time event in day block owner entity type: {owner.the_type!r}",
@@ -82,6 +103,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date=start_date,
             start_time_in_day=start_time_in_day,
             duration_mins=duration_mins,
+            buffer_before_mins=buffer_before_mins,
+            buffer_after_mins=buffer_after_mins,
         )
 
     @staticmethod
@@ -93,6 +116,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event."""
         return TimeEventInDayBlock._new_with_owner(
@@ -104,6 +129,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @staticmethod
@@ -115,6 +142,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event for a big plan."""
         return TimeEventInDayBlock._new_with_owner(
@@ -124,6 +153,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @staticmethod
@@ -135,6 +166,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event for a todo task."""
         return TimeEventInDayBlock._new_with_owner(
@@ -144,6 +177,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @staticmethod
@@ -155,6 +190,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event for a habit."""
         return TimeEventInDayBlock._new_with_owner(
@@ -164,6 +201,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @staticmethod
@@ -175,6 +214,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event for a chore."""
         return TimeEventInDayBlock._new_with_owner(
@@ -184,6 +225,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @staticmethod
@@ -195,6 +238,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: ADate,
         start_time_in_day: TimeInDay,
         duration_mins: int,
+        buffer_before_mins: int | None,
+        buffer_after_mins: int | None,
     ) -> "TimeEventInDayBlock":
         """Create a new time event for a time plan activity."""
         return TimeEventInDayBlock._new_with_owner(
@@ -206,6 +251,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
             start_date,
             start_time_in_day,
             duration_mins,
+            buffer_before_mins,
+            buffer_after_mins,
         )
 
     @update_entity_action
@@ -215,6 +262,8 @@ class TimeEventInDayBlock(LeafSupportEntity):
         start_date: UpdateAction[ADate],
         start_time_in_day: UpdateAction[TimeInDay],
         duration_mins: UpdateAction[int],
+        buffer_before_mins: UpdateAction[int | None],
+        buffer_after_mins: UpdateAction[int | None],
     ) -> "TimeEventInDayBlock":
         """Update the time event."""
         if duration_mins.test(lambda t: t < MIN_DURATION_MINS):
@@ -225,11 +274,17 @@ class TimeEventInDayBlock(LeafSupportEntity):
             raise InputValidationError(
                 f"Duration must be at most {MAX_DURATION_MINS // 60} hours."
             )
+        if buffer_before_mins.should_change:
+            self._check_buffer_mins("before", buffer_before_mins.just_the_value)
+        if buffer_after_mins.should_change:
+            self._check_buffer_mins("after", buffer_after_mins.just_the_value)
         return self._new_version(
             ctx,
             start_date=start_date.or_else(self.start_date),
             start_time_in_day=start_time_in_day.or_else(self.start_time_in_day),
             duration_mins=duration_mins.or_else(self.duration_mins),
+            buffer_before_mins=buffer_before_mins.or_else(self.buffer_before_mins),
+            buffer_after_mins=buffer_after_mins.or_else(self.buffer_after_mins),
         )
 
     @property

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.test.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/root.test.py
@@ -1,0 +1,114 @@
+"""Tests for the buffers around a time event in day block."""
+
+import pytest
+from jupiter.core.common.sub.time_events.sub.in_day_block.root import (
+    MAX_BUFFER_MINS,
+    TimeEventInDayBlock,
+)
+from jupiter.core.common.time_in_day import TimeInDay
+from jupiter.framework.base.adate import ADate
+from jupiter.framework.base.entity_id import EntityId
+from jupiter.framework.base.mutation_id import MutationId
+from jupiter.framework.base.timestamp import Timestamp
+from jupiter.framework.base.trace_id import TraceId
+from jupiter.framework.context import DomainContext
+from jupiter.framework.errors import InputValidationError
+from jupiter.framework.update_action import UpdateAction
+
+
+def _ctx() -> DomainContext:
+    return DomainContext(
+        trace_id=TraceId.new(),
+        mutation_id=MutationId.new(),
+        event_source="test",
+        action_timestamp=Timestamp.from_unix_timestamp(0),
+        _context_str="test",
+    )
+
+
+def _new_block(
+    buffer_before_mins: int | None = None,
+    buffer_after_mins: int | None = None,
+) -> TimeEventInDayBlock:
+    return TimeEventInDayBlock.new_time_event_for_big_plan(
+        _ctx(),
+        time_event_domain_ref_id=EntityId("1"),
+        big_plan_ref_id=EntityId("2"),
+        start_date=ADate.from_str("2026-01-01"),
+        start_time_in_day=TimeInDay.from_parts(10, 0),
+        duration_mins=60,
+        buffer_before_mins=buffer_before_mins,
+        buffer_after_mins=buffer_after_mins,
+    )
+
+
+def test_new_block_has_no_buffers_by_default() -> None:
+    block = _new_block()
+
+    assert block.buffer_before_mins is None
+    assert block.buffer_after_mins is None
+
+
+def test_new_block_keeps_the_buffers_it_was_given() -> None:
+    block = _new_block(buffer_before_mins=15, buffer_after_mins=30)
+
+    assert block.buffer_before_mins == 15
+    assert block.buffer_after_mins == 30
+
+
+@pytest.mark.parametrize("buffer_mins", [0, -5, MAX_BUFFER_MINS + 1])
+def test_new_block_rejects_a_buffer_outside_the_allowed_range(
+    buffer_mins: int,
+) -> None:
+    with pytest.raises(InputValidationError):
+        _new_block(buffer_before_mins=buffer_mins)
+
+    with pytest.raises(InputValidationError):
+        _new_block(buffer_after_mins=buffer_mins)
+
+
+def test_update_leaves_the_buffers_alone_when_asked_to_do_nothing() -> None:
+    block = _new_block(buffer_before_mins=15, buffer_after_mins=30)
+
+    block = block.update(
+        _ctx(),
+        start_date=UpdateAction.do_nothing(),
+        start_time_in_day=UpdateAction.do_nothing(),
+        duration_mins=UpdateAction.change_to(90),
+        buffer_before_mins=UpdateAction.do_nothing(),
+        buffer_after_mins=UpdateAction.do_nothing(),
+    )
+
+    assert block.duration_mins == 90
+    assert block.buffer_before_mins == 15
+    assert block.buffer_after_mins == 30
+
+
+def test_update_can_clear_a_buffer() -> None:
+    block = _new_block(buffer_before_mins=15, buffer_after_mins=30)
+
+    block = block.update(
+        _ctx(),
+        start_date=UpdateAction.do_nothing(),
+        start_time_in_day=UpdateAction.do_nothing(),
+        duration_mins=UpdateAction.do_nothing(),
+        buffer_before_mins=UpdateAction.change_to(None),
+        buffer_after_mins=UpdateAction.change_to(45),
+    )
+
+    assert block.buffer_before_mins is None
+    assert block.buffer_after_mins == 45
+
+
+def test_update_rejects_a_buffer_outside_the_allowed_range() -> None:
+    block = _new_block()
+
+    with pytest.raises(InputValidationError):
+        block.update(
+            _ctx(),
+            start_date=UpdateAction.do_nothing(),
+            start_time_in_day=UpdateAction.do_nothing(),
+            duration_mins=UpdateAction.do_nothing(),
+            buffer_before_mins=UpdateAction.change_to(MAX_BUFFER_MINS + 1),
+            buffer_after_mins=UpdateAction.do_nothing(),
+        )

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_big_plan.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_big_plan.py
@@ -35,6 +35,8 @@ class TimeEventInDayBlockCreateForBigPlanArgs(JupiterCreateLeafSupportEntityArgs
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -75,6 +77,8 @@ class TimeEventInDayBlockCreateForBigPlanUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         new_time_event = await uow.get_for(TimeEventInDayBlock).create(new_time_event)
 

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_chore.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_chore.py
@@ -35,6 +35,8 @@ class TimeEventInDayBlockCreateForChoreArgs(JupiterCreateLeafSupportEntityArgs):
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -75,6 +77,8 @@ class TimeEventInDayBlockCreateForChoreUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         new_time_event = await uow.get_for(TimeEventInDayBlock).create(new_time_event)
 

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_habit.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_habit.py
@@ -35,6 +35,8 @@ class TimeEventInDayBlockCreateForHabitArgs(JupiterCreateLeafSupportEntityArgs):
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -75,6 +77,8 @@ class TimeEventInDayBlockCreateForHabitUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         new_time_event = await uow.get_for(TimeEventInDayBlock).create(new_time_event)
 

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_time_plan_activity.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_time_plan_activity.py
@@ -37,6 +37,8 @@ class TimeEventInDayBlockCreateForTimePlanActivityArgs(
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -77,6 +79,8 @@ class TimeEventInDayBlockCreateForTimePlanActivityUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         new_time_event = await uow.get_for(TimeEventInDayBlock).create(new_time_event)
 

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_todo_task.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/create_for_todo_task.py
@@ -35,6 +35,8 @@ class TimeEventInDayBlockCreateForTodoTaskArgs(JupiterCreateLeafSupportEntityArg
     start_date: ADate
     start_time_in_day: TimeInDay
     duration_mins: int
+    buffer_before_mins: int | None
+    buffer_after_mins: int | None
 
 
 @use_case_result
@@ -75,6 +77,8 @@ class TimeEventInDayBlockCreateForTodoTaskUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         new_time_event = await uow.get_for(TimeEventInDayBlock).create(new_time_event)
 

--- a/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/update.py
+++ b/src/core/jupiter/core/common/sub/time_events/sub/in_day_block/use_case/update.py
@@ -34,6 +34,8 @@ class TimeEventInDayBlockUpdateArgs(JupiterUpdateLeafSupportEntityArgs):
     start_date: UpdateAction[ADate]
     start_time_in_day: UpdateAction[TimeInDay]
     duration_mins: UpdateAction[int]
+    buffer_before_mins: UpdateAction[int | None]
+    buffer_after_mins: UpdateAction[int | None]
 
 
 @mutation_use_case()
@@ -67,5 +69,7 @@ class TimeEventInDayBlockUpdateUseCase(
             start_date=args.start_date,
             start_time_in_day=args.start_time_in_day,
             duration_mins=args.duration_mins,
+            buffer_before_mins=args.buffer_before_mins,
+            buffer_after_mins=args.buffer_after_mins,
         )
         time_event_block = await uow.get_for(TimeEventInDayBlock).save(time_event_block)

--- a/src/core/jupiter/core/common/sub/time_events/time-event.ts
+++ b/src/core/jupiter/core/common/sub/time_events/time-event.ts
@@ -197,6 +197,46 @@ export function calculateEndTimeForTimeEvent(
   return endTime;
 }
 
+// The buffers are the logistics around an event - getting there, and winding
+// down after - so they sit outside the event proper and are optional.
+export const TIME_EVENT_BUFFER_PRESETS_MINS = [5, 15, 30];
+
+export function timeEventInDayBuffersLabel(
+  timeEvent: Pick<
+    TimeEventInDayBlock,
+    "buffer_before_mins" | "buffer_after_mins"
+  >,
+): string | undefined {
+  const before = timeEvent.buffer_before_mins ?? null;
+  const after = timeEvent.buffer_after_mins ?? null;
+
+  if (before !== null && after !== null) {
+    return `+${before}m before, +${after}m after`;
+  }
+  if (before !== null) {
+    return `+${before}m before`;
+  }
+  if (after !== null) {
+    return `+${after}m after`;
+  }
+  return undefined;
+}
+
+// Forms hand back an empty string when the field is left blank, which is how
+// a buffer says it isn't there at all.
+export function parseTimeEventBufferMins(
+  rawBufferMins: string | undefined,
+): number | null {
+  if (rawBufferMins === undefined || rawBufferMins.trim() === "") {
+    return null;
+  }
+  const bufferMins = parseInt(rawBufferMins, 10);
+  if (Number.isNaN(bufferMins)) {
+    return null;
+  }
+  return bufferMins;
+}
+
 export function timeEventInDayBlockToTimezone(
   timeEvent: TimeEventInDayBlock,
   timezone: Timezone,
@@ -302,6 +342,12 @@ export function calendarTimeEventInDayDurationToRems(
     durationMins,
   );
   return `${durationInQuarters}rem`;
+}
+
+// A buffer is drawn to its true size rather than rounded up to a quarter
+// hour, so a short one doesn't swallow the event it hangs off.
+export function calendarTimeEventInDayBufferToRems(bufferMins: number): string {
+  return `${bufferMins / 15}rem`;
 }
 
 export function scheduleTimeEventInDayDurationToRems(
@@ -441,6 +487,8 @@ export function splitTimeEventInDayEntryIntoPerDayEntries(
       duration_mins:
         -1 *
         startTime.diff(startTime.set({ hour: 23, minute: 59 })).as("minutes"),
+      // Only the piece holding an edge of the event carries the buffer there.
+      buffer_after_mins: null,
     };
     const day2TimeEvent = {
       ...entry.time_event_in_tz,
@@ -449,6 +497,7 @@ export function splitTimeEventInDayEntryIntoPerDayEntries(
       duration_mins: endTime
         .diff(endTime.set({ hour: 0, minute: 0 }))
         .as("minutes"),
+      buffer_before_mins: null,
     };
 
     return {
@@ -482,12 +531,16 @@ export function splitTimeEventInDayEntryIntoPerDayEntries(
       duration_mins:
         -1 *
         startTime.diff(startTime.set({ hour: 23, minute: 59 })).as("minutes"),
+      // Only the piece holding an edge of the event carries the buffer there.
+      buffer_after_mins: null,
     };
     const day2TimeEvent = {
       ...entry.time_event_in_tz,
       start_date: startTime.plus({ days: 1 }).toISODate(),
       start_time_in_day: "00:00",
       duration_mins: 24 * 60,
+      buffer_before_mins: null,
+      buffer_after_mins: null,
     };
     const day3TimeEvent = {
       ...entry.time_event_in_tz,
@@ -496,6 +549,7 @@ export function splitTimeEventInDayEntryIntoPerDayEntries(
       duration_mins: endTime
         .diff(endTime.set({ hour: 0, minute: 0 }))
         .as("minutes"),
+      buffer_before_mins: null,
     };
 
     return {

--- a/src/core/migrations/postgres/versions/2026_08_30_12_00_time_event_in_day_block_buffers.py
+++ b/src/core/migrations/postgres/versions/2026_08_30_12_00_time_event_in_day_block_buffers.py
@@ -1,0 +1,34 @@
+"""time event in day block buffers
+
+Revision ID: c8d5f6a3b429
+Revises: b7c4e5f2a318
+Create Date: 2026-08-30 12:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "c8d5f6a3b429"
+down_revision = "b7c4e5f2a318"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE time_event_in_day_block
+            ADD COLUMN buffer_before_mins INTEGER,
+            ADD COLUMN buffer_after_mins INTEGER
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE time_event_in_day_block
+            DROP COLUMN buffer_after_mins,
+            DROP COLUMN buffer_before_mins
+        """
+    )

--- a/src/core/migrations/sqlite/versions/2026_08_30_12_00_time_event_in_day_block_buffers.py
+++ b/src/core/migrations/sqlite/versions/2026_08_30_12_00_time_event_in_day_block_buffers.py
@@ -1,0 +1,29 @@
+"""time event in day block buffers
+
+Revision ID: c8d5f6a3b429
+Revises: b7c4e5f2a318
+Create Date: 2026-08-30 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c8d5f6a3b429"
+down_revision = "b7c4e5f2a318"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("time_event_in_day_block") as batch_op:
+        batch_op.add_column(
+            sa.Column("buffer_before_mins", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("buffer_after_mins", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("time_event_in_day_block") as batch_op:
+        batch_op.drop_column("buffer_after_mins")
+        batch_op.drop_column("buffer_before_mins")

--- a/src/desktop/src/error.html
+++ b/src/desktop/src/error.html
@@ -4,7 +4,8 @@
     <title>{{title}} - Error</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
           "Helvetica Neue", Arial, sans-serif;
         font-size: 20px;
         background-color: #fcfaf9;

--- a/src/desktop/src/index.html
+++ b/src/desktop/src/index.html
@@ -4,7 +4,8 @@
     <title>{{title}} - Loading</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
           "Helvetica Neue", Arial, sans-serif;
         font-size: 28px;
         background-color: #fcfaf9;

--- a/src/docs/material/concepts/calendar.md
+++ b/src/docs/material/concepts/calendar.md
@@ -21,6 +21,10 @@ Calendar events have a name, and some notion of duration. Full day events start
 on aparticular day, and last 1 or more full days. In day events start on a
 particular dayand time, and last some amount of time, no greater than 48 hours.
 
+In day events can also reserve a buffer before and a buffer after, each an
+optional number of minutes, for the logistics around the event. See
+[Events](./core-entities/events.md) for more.
+
 Editing a calendar looks like this:
 
 ![Event](../assets/calendar-event-view.png)

--- a/src/docs/material/concepts/core-entities/events.md
+++ b/src/docs/material/concepts/core-entities/events.md
@@ -18,6 +18,17 @@ An event can be one of:
 * _Full day_: starts on a day and spans one or more full days.
 * _In day_: starts at a specific date and time, with a bounded duration.
 
+## Buffers
+
+An in-day event can also carry a _buffer before_ and a _buffer after_, each a
+number of minutes. These are optional, and they hold the logistics around the
+event -- travelling to it, or winding down from it -- so that time reads as
+taken up without becoming part of the event itself.
+
+Buffers show up in the calendar as hatched bands hugging the event, and can be
+set wherever an in-day event is created or edited. Leaving a buffer field empty
+means the event has no buffer on that side.
+
 ## Event Sources
 
 Events can be created directly by users, or generated from other concepts.

--- a/src/mobile/src/index.html
+++ b/src/mobile/src/index.html
@@ -4,7 +4,8 @@
     <title>{{title}} - Loading</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter",
           "Helvetica Neue", Arial, sans-serif;
         font-size: 28px;
         background-color: #fcfaf9;

--- a/src/published/app/routes/publish/schedule-event-in-day/$externalId.tsx
+++ b/src/published/app/routes/publish/schedule-event-in-day/$externalId.tsx
@@ -113,6 +113,8 @@ export default function PublishedScheduleEventInDay() {
         startDate={blockParamsInTz.startDate}
         startTimeInDay={blockParamsInTz.startTimeInDay!}
         durationMins={timeEventInDayBlock.duration_mins}
+        bufferBeforeMins={timeEventInDayBlock.buffer_before_mins ?? null}
+        bufferAfterMins={timeEventInDayBlock.buffer_after_mins ?? null}
       />
 
       <SectionCard title="Note">

--- a/src/published/app/routes/publish/schedule-stream/$externalId/in-day-event/$eventId.tsx
+++ b/src/published/app/routes/publish/schedule-stream/$externalId/in-day-event/$eventId.tsx
@@ -110,6 +110,12 @@ export default function PublishedScheduleStreamInDayEvent() {
         startDate={blockParamsInTz.startDate}
         startTimeInDay={blockParamsInTz.startTimeInDay!}
         durationMins={loaderData.timeEventInDayBlock.duration_mins}
+        bufferBeforeMins={
+          loaderData.timeEventInDayBlock.buffer_before_mins ?? null
+        }
+        bufferAfterMins={
+          loaderData.timeEventInDayBlock.buffer_after_mins ?? null
+        }
       />
 
       <SectionCard title="Note">

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id/$activityId.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id/$activityId.tsx
@@ -36,6 +36,7 @@ import { CheckboxAsString, parseForm, parseParams } from "zodix";
 import { TodoTaskPropertiesEditor } from "@jupiter/core/apps/todo/components/properties-editor";
 import { isWorkspaceFeatureAvailable } from "@jupiter/core/workspaces/root";
 import {
+  parseTimeEventBufferMins,
   sortInboxTaskTimeEventsNaturally,
   timeEventInDayBlockParamsToUtc,
   timeEventInDayBlockToTimezone,
@@ -196,6 +197,8 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
     startDate: z.string(),
     startTimeInDay: z.string().optional(),
     durationMins: z.string().transform((v) => parseInt(v, 10)),
+    bufferBeforeMins: z.string().optional(),
+    bufferAfterMins: z.string().optional(),
   }),
   z.object({
     intent: z.literal("remove-time-event"),
@@ -476,6 +479,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
           duration_mins: {
             should_change: true,
             value: form.durationMins,
+          },
+          buffer_before_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferBeforeMins),
+          },
+          buffer_after_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferAfterMins),
           },
         });
 

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id/calendar-event/$kind/$refId.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id/calendar-event/$kind/$refId.tsx
@@ -29,6 +29,7 @@ import { useContext } from "react";
 import { z } from "zod";
 import { parseParams } from "zodix";
 import { parseEntityLinkStd } from "@jupiter/core/common/entity-link";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventSourceLink } from "@jupiter/core/common/sub/time_events/component/source-link";
 import {
   occasionTimeEventName,
@@ -384,6 +385,10 @@ function ScheduleEventInDayProperties({
       startDate={local.startDate!}
       startTimeInDay={local.startTimeInDay!}
       durationMins={loaderData.timeEventInDayBlock.duration_mins}
+      bufferBeforeMins={
+        loaderData.timeEventInDayBlock.buffer_before_mins ?? null
+      }
+      bufferAfterMins={loaderData.timeEventInDayBlock.buffer_after_mins ?? null}
       actions={openOriginalActions(
         "schedule-event-in-day-properties",
         topLevelInfo,
@@ -523,6 +528,12 @@ function TimeEventInDayProperties({
           />
         </FormControl>
       </Stack>
+
+      <TimeEventBuffersEditor
+        inputsEnabled={false}
+        bufferBeforeMins={inDayBlock.buffer_before_mins ?? null}
+        bufferAfterMins={inDayBlock.buffer_after_mins ?? null}
+      />
     </SectionCard>
   );
 }

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id/new-activity-time-event.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id/new-activity-time-event.tsx
@@ -19,7 +19,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -28,6 +31,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
@@ -57,6 +61,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -101,6 +107,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     return redirect(
@@ -138,6 +146,8 @@ export default function TimePlanActivityTimeEventNew() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -293,6 +303,15 @@ export default function TimePlanActivityTimeEventNew() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/apps/time-plans/$id/new-schedule-event-in-day.tsx
+++ b/src/webui/app/routes/app/workspace/apps/time-plans/$id/new-schedule-event-in-day.tsx
@@ -20,7 +20,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -33,6 +36,7 @@ import {
   SectionCard,
 } from "@jupiter/core/infra/component/section-card";
 import { ScheduleStreamSelect } from "@jupiter/core/apps/schedule/component/select";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { LeafPanelExpansionState } from "@jupiter/core/infra/leaf-panel-expansion";
@@ -62,6 +66,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -100,6 +106,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     return redirect(
@@ -136,6 +144,8 @@ export default function TimePlanScheduleEventInDayNew() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(30);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -295,6 +305,15 @@ export default function TimePlanScheduleEventInDayNew() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/reschedule.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/reschedule.tsx
@@ -35,6 +35,9 @@ export async function action({ request }: ActionFunctionArgs) {
     form.durationMins === undefined
       ? { should_change: false as const }
       : { should_change: true as const, value: form.durationMins };
+  // Moving or stretching an event says nothing about its buffers, which stay
+  // whatever they were.
+  const keepBuffers = { should_change: false as const };
 
   try {
     switch (form.kind) {
@@ -53,6 +56,8 @@ export async function action({ request }: ActionFunctionArgs) {
             value: startTimeInDay ?? "",
           },
           duration_mins: durationMins,
+          buffer_before_mins: keepBuffers,
+          buffer_after_mins: keepBuffers,
         });
         break;
       }
@@ -69,6 +74,8 @@ export async function action({ request }: ActionFunctionArgs) {
             value: startTimeInDay ?? "",
           },
           duration_mins: durationMins,
+          buffer_before_mins: keepBuffers,
+          buffer_after_mins: keepBuffers,
         });
         break;
       }

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/$id.tsx
@@ -12,6 +12,7 @@ import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseParams } from "zodix";
 import {
+  parseTimeEventBufferMins,
   timeEventInDayBlockParamsToTimezone,
   timeEventInDayBlockParamsToUtc,
 } from "@jupiter/core/common/sub/time_events/time-event";
@@ -53,6 +54,8 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
     startDate: z.string(),
     startTimeInDay: z.string().optional(),
     durationMins: z.string().transform((v) => parseInt(v, 10)),
+    bufferBeforeMins: z.string().optional(),
+    bufferAfterMins: z.string().optional(),
   }),
   z.object({
     intent: z.literal("change-schedule-stream"),
@@ -168,6 +171,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
             should_change: true,
             value: form.durationMins,
           },
+          buffer_before_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferBeforeMins),
+          },
+          buffer_after_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferAfterMins),
+          },
         });
         return redirect(calendarLeafReturnLocation(url.searchParams));
       }
@@ -274,6 +285,12 @@ export default function ScheduleEventInDayViewOne() {
   const [durationMins, setDurationMins] = useState(
     loaderData.timeEventInDayBlock.duration_mins,
   );
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(
+    loaderData.timeEventInDayBlock.buffer_before_mins ?? null,
+  );
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(
+    loaderData.timeEventInDayBlock.buffer_after_mins ?? null,
+  );
 
   useEffect(() => {
     const blockParamsInTz = timeEventInDayBlockParamsToTimezone(
@@ -286,6 +303,12 @@ export default function ScheduleEventInDayViewOne() {
     setStartDate(blockParamsInTz.startDate);
     setStartTimeInDay(blockParamsInTz.startTimeInDay!);
     setDurationMins(loaderData.timeEventInDayBlock.duration_mins);
+    setBufferBeforeMins(
+      loaderData.timeEventInDayBlock.buffer_before_mins ?? null,
+    );
+    setBufferAfterMins(
+      loaderData.timeEventInDayBlock.buffer_after_mins ?? null,
+    );
   }, [loaderData.timeEventInDayBlock, topLevelInfo.user.timezone]);
 
   const [debounceForeign, setDeoubceForeign] = useState(false);
@@ -342,9 +365,13 @@ export default function ScheduleEventInDayViewOne() {
         startDate={startDate}
         startTimeInDay={startTimeInDay}
         durationMins={durationMins}
+        bufferBeforeMins={bufferBeforeMins}
+        bufferAfterMins={bufferAfterMins}
         onStartDateChange={setStartDate}
         onStartTimeInDayChange={setStartTimeInDay}
         onDurationMinsChange={setDurationMins}
+        onBufferBeforeMinsChange={setBufferBeforeMins}
+        onBufferAfterMinsChange={setBufferAfterMins}
       />
 
       <SectionCard

--- a/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/new.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/schedule/event-in-day/new.tsx
@@ -19,7 +19,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
@@ -33,6 +36,7 @@ import {
   SectionCard,
 } from "@jupiter/core/infra/component/section-card";
 import { ScheduleStreamSelect } from "@jupiter/core/apps/schedule/component/select";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -69,6 +73,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -106,6 +112,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     if (isCreateAndAnother(form.intent)) {
@@ -139,6 +147,8 @@ export default function ScheduleEventInDayNew() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(30);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -298,6 +308,15 @@ export default function ScheduleEventInDayNew() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/$id.tsx
@@ -46,6 +46,7 @@ import { z } from "zod";
 import { CheckboxAsString, parseForm, parseParams } from "zodix";
 import {
   isTimeEventInDayBlockEditable,
+  parseTimeEventBufferMins,
   timeEventInDayBlockOwnerTheType,
   timeEventInDayBlockParamsToTimezone,
   timeEventInDayBlockParamsToUtc,
@@ -72,6 +73,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { TimeEventSourceLink } from "@jupiter/core/common/sub/time_events/component/source-link";
 import { saveScoreAction } from "@jupiter/core/gamification/scores.server";
@@ -138,6 +140,8 @@ const UpdateFormSchema = z.discriminatedUnion("intent", [
     startDate: z.string(),
     startTimeInDay: z.string().optional(),
     durationMins: z.string().transform((v) => parseInt(v, 10)),
+    bufferBeforeMins: z.string().optional(),
+    bufferAfterMins: z.string().optional(),
   }),
   z.object({
     intent: z.literal("archive"),
@@ -435,6 +439,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
           duration_mins: {
             should_change: true,
             value: form.durationMins,
+          },
+          buffer_before_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferBeforeMins),
+          },
+          buffer_after_mins: {
+            should_change: true,
+            value: parseTimeEventBufferMins(form.bufferAfterMins),
           },
         });
         return redirect(calendarLeafReturnLocation(url.searchParams));
@@ -955,6 +967,12 @@ export default function TimeEventInDayBlockViewOne() {
   const [durationMins, setDurationMins] = useState(
     loaderData.inDayBlock.duration_mins,
   );
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(
+    loaderData.inDayBlock.buffer_before_mins ?? null,
+  );
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(
+    loaderData.inDayBlock.buffer_after_mins ?? null,
+  );
   useEffect(() => {
     const blockParamsInTz = timeEventInDayBlockParamsToTimezone(
       {
@@ -966,6 +984,8 @@ export default function TimeEventInDayBlockViewOne() {
     setStartDate(blockParamsInTz.startDate);
     setStartTimeInDay(blockParamsInTz.startTimeInDay!);
     setDurationMins(loaderData.inDayBlock.duration_mins);
+    setBufferBeforeMins(loaderData.inDayBlock.buffer_before_mins ?? null);
+    setBufferAfterMins(loaderData.inDayBlock.buffer_after_mins ?? null);
   }, [loaderData.inDayBlock, topLevelInfo.user.timezone]);
 
   const [debounceForeign, setDeoubceForeign] = useState(false);
@@ -1130,6 +1150,15 @@ export default function TimeEventInDayBlockViewOne() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled && corePropertyEditable}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
 
       {loaderData.bigPlan && (

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-big-plan.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-big-plan.tsx
@@ -18,7 +18,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -27,6 +30,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -54,6 +58,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -115,6 +121,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     switch (timePlanReason) {
@@ -150,6 +158,8 @@ export default function TimeEventInDayBlockCreateForBigPlan() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -294,6 +304,15 @@ export default function TimeEventInDayBlockCreateForBigPlan() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-chore.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-chore.tsx
@@ -18,7 +18,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -27,6 +30,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -54,6 +58,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -115,6 +121,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     switch (timePlanReason) {
@@ -150,6 +158,8 @@ export default function TimeEventInDayBlockCreateForChore() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -294,6 +304,15 @@ export default function TimeEventInDayBlockCreateForChore() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-habit.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-habit.tsx
@@ -18,7 +18,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -27,6 +30,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -54,6 +58,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -115,6 +121,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     switch (timePlanReason) {
@@ -150,6 +158,8 @@ export default function TimeEventInDayBlockCreateForHabit() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -294,6 +304,15 @@ export default function TimeEventInDayBlockCreateForHabit() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-time-plan-activity.tsx
@@ -18,7 +18,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { calendarLeafReturnLocation } from "@jupiter/core/calendar/component/calendar-navigation";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
@@ -28,6 +31,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -54,6 +58,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -96,6 +102,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     return redirect(
@@ -126,6 +134,8 @@ export default function TimeEventInDayBlockCreateForTimePlanActivity() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -277,6 +287,15 @@ export default function TimeEventInDayBlockCreateForTimePlanActivity() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );

--- a/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-todo-task.tsx
+++ b/src/webui/app/routes/app/workspace/calendar/time-event/in-day-block/new-for-todo-task.tsx
@@ -18,7 +18,10 @@ import { DateTime } from "luxon";
 import { useContext, useEffect, useState } from "react";
 import { z } from "zod";
 import { parseForm, parseQuery } from "zodix";
-import { timeEventInDayBlockParamsToUtc } from "@jupiter/core/common/sub/time_events/time-event";
+import {
+  parseTimeEventBufferMins,
+  timeEventInDayBlockParamsToUtc,
+} from "@jupiter/core/common/sub/time_events/time-event";
 import { makeLeafErrorBoundary } from "@jupiter/core/infra/component/error-boundary";
 import { FieldError, GlobalError } from "@jupiter/core/infra/component/errors";
 import { LeafPanel } from "@jupiter/core/infra/component/layout/leaf-panel";
@@ -27,6 +30,7 @@ import {
   SectionActions,
 } from "@jupiter/core/infra/component/section-actions";
 import { SectionCard } from "@jupiter/core/infra/component/section-card";
+import { TimeEventBuffersEditor } from "@jupiter/core/common/sub/time_events/component/buffers-editor";
 import { TimeEventParamsSource } from "@jupiter/core/common/sub/time_events/component/params-source";
 import { DisplayType } from "@jupiter/core/infra/component/use-nested-entities";
 import { TopLevelInfoContext } from "@jupiter/core/infra/top-level-context";
@@ -54,6 +58,8 @@ const CreateFormSchema = z.object({
   startDate: z.string(),
   startTimeInDay: z.string().optional(),
   durationMins: z.string().transform((v) => parseInt(v, 10)),
+  bufferBeforeMins: z.string().optional(),
+  bufferAfterMins: z.string().optional(),
 });
 
 export const handle = {
@@ -115,6 +121,8 @@ export async function action({ request }: ActionFunctionArgs) {
       start_date: startDate,
       start_time_in_day: startTimeInDay ?? "",
       duration_mins: form.durationMins,
+      buffer_before_mins: parseTimeEventBufferMins(form.bufferBeforeMins),
+      buffer_after_mins: parseTimeEventBufferMins(form.bufferAfterMins),
     });
 
     switch (timePlanReason) {
@@ -150,6 +158,8 @@ export default function TimeEventInDayBlockCreateForTodoTask() {
     rightNow.toFormat("HH:mm"),
   );
   const [durationMins, setDurationMins] = useState(60);
+  const [bufferBeforeMins, setBufferBeforeMins] = useState<number | null>(null);
+  const [bufferAfterMins, setBufferAfterMins] = useState<number | null>(null);
 
   useEffect(() => {
     if (query.get("sourceStartDate") && query.get("sourceStartTimeInDay")) {
@@ -294,6 +304,15 @@ export default function TimeEventInDayBlockCreateForTodoTask() {
             <FieldError actionResult={actionData} fieldName="/duration_mins" />
           </FormControl>
         </Stack>
+
+        <TimeEventBuffersEditor
+          inputsEnabled={inputsEnabled}
+          bufferBeforeMins={bufferBeforeMins}
+          bufferAfterMins={bufferAfterMins}
+          onBufferBeforeMinsChange={setBufferBeforeMins}
+          onBufferAfterMinsChange={setBufferAfterMins}
+          actionResult={actionData}
+        />
       </SectionCard>
     </LeafPanel>
   );


### PR DESCRIPTION
An in-day event can now carry a buffer before and a buffer after, each an
optional number of minutes, holding the logistics around the event -
travelling to it, or winding down from it - so that time reads as taken up
without becoming part of the event itself.

* `TimeEventInDayBlock` gains `buffer_before_mins` and `buffer_after_mins`,
  validated between 1 minute and 24 hours when present, with a migration for
  both SQLite and Postgres.
* Every create and update use case carries them through. An external calendar
  re-sync leaves them alone, as does dragging or stretching an event in the
  calendar.
* The calendar draws them as hatched bands hugging the event in its own
  colour, and the schedule views note them under the event's times. An event
  spilling past midnight keeps each buffer on the piece that holds that edge.
* A shared buffers editor sits next to the duration field wherever an in-day
  event is created, edited or shown - the calendar panels, the schedule event
  editor, the time plan panels, and the published pages. It works like the
  duration field but also takes nothing, which is how a buffer says it isn't
  there.

Note that `TimeEventInDayBlockUpdate` and `ScheduleEventInDayUpdate` now
require the two new update actions on the wire: the framework derives
requiredness from type optionality, so an `UpdateAction` field is always
required regardless of any dataclass default.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GMGPmkFB23AfVfPkf7Sg85